### PR TITLE
feat(ui): Add Stop Loss and Take Profit action buttons to position cards

### DIFF
--- a/apps/midcurve-ui/src/components/positions/automation/PnLSimulation.tsx
+++ b/apps/midcurve-ui/src/components/positions/automation/PnLSimulation.tsx
@@ -1,0 +1,208 @@
+/**
+ * PnL Simulation Component
+ *
+ * Reusable component that calculates and displays the expected PnL
+ * for a position at a given trigger price.
+ */
+
+import { useMemo } from 'react';
+import { calculatePositionValue, formatCompactValue } from '@midcurve/shared';
+
+export interface PnLSimulationProps {
+  /**
+   * Position liquidity
+   */
+  liquidity: bigint;
+
+  /**
+   * Position lower tick
+   */
+  tickLower: number;
+
+  /**
+   * Position upper tick
+   */
+  tickUpper: number;
+
+  /**
+   * Current cost basis (in quote token units, as string)
+   */
+  currentCostBasis: string;
+
+  /**
+   * Current unclaimed fees (in quote token units, as string)
+   */
+  unclaimedFees: string;
+
+  /**
+   * Trigger price in sqrtPriceX96 format
+   */
+  triggerSqrtPriceX96: string;
+
+  /**
+   * Current pool price in sqrtPriceX96 format
+   */
+  currentSqrtPriceX96: string;
+
+  /**
+   * Whether token0 is the quote token (affects price direction)
+   */
+  isToken0Quote: boolean;
+
+  /**
+   * Quote token info for formatting
+   */
+  quoteToken: {
+    decimals: number;
+    symbol: string;
+  };
+
+  /**
+   * Optional trigger mode for immediate execution detection
+   * - 'LOWER': Stop-loss (triggers when price falls below)
+   * - 'UPPER': Take-profit (triggers when price rises above)
+   */
+  triggerMode?: 'LOWER' | 'UPPER';
+
+  /**
+   * Optional custom label (defaults to "Expected PnL at trigger:")
+   */
+  label?: string;
+}
+
+export type PnLSimulationResult = {
+  isValid: false;
+} | {
+  isValid: true;
+  value: bigint;
+  isProfit: boolean;
+  displayValue: string;
+  feesDisplay: string;
+}
+
+/**
+ * Hook to calculate PnL simulation
+ * Exported for use in components that need the raw data without UI
+ */
+export function usePnLSimulation({
+  liquidity,
+  tickLower,
+  tickUpper,
+  currentCostBasis,
+  unclaimedFees,
+  triggerSqrtPriceX96,
+  currentSqrtPriceX96,
+  isToken0Quote,
+  quoteToken,
+  triggerMode,
+}: PnLSimulationProps): PnLSimulationResult {
+  return useMemo(() => {
+    // Validation: return invalid if no trigger price or zero liquidity
+    if (!triggerSqrtPriceX96 || triggerSqrtPriceX96 === '0' || liquidity === 0n) {
+      return { isValid: false as const };
+    }
+
+    try {
+      const triggerPrice = BigInt(triggerSqrtPriceX96);
+      const currentPrice = BigInt(currentSqrtPriceX96);
+
+      // Handle immediate execution case
+      // For SL: should trigger when price falls BELOW trigger
+      // For TP: should trigger when price rises ABOVE trigger
+      let effectivePrice = triggerPrice;
+
+      if (triggerMode === 'LOWER') {
+        // Stop-loss triggers when price falls below trigger
+        // If trigger >= current (would execute immediately), use current price
+        // Note: isToken0Quote inverts the relationship
+        const wouldExecuteImmediately = isToken0Quote
+          ? triggerPrice <= currentPrice // inverted: lower sqrt = higher user price
+          : triggerPrice >= currentPrice;
+        if (wouldExecuteImmediately) {
+          effectivePrice = currentPrice;
+        }
+      } else if (triggerMode === 'UPPER') {
+        // Take-profit triggers when price rises above trigger
+        // If trigger <= current (would execute immediately), use current price
+        const wouldExecuteImmediately = isToken0Quote
+          ? triggerPrice >= currentPrice // inverted: higher sqrt = lower user price
+          : triggerPrice <= currentPrice;
+        if (wouldExecuteImmediately) {
+          effectivePrice = currentPrice;
+        }
+      }
+
+      // Calculate position value at effective price
+      const baseIsToken0 = !isToken0Quote;
+      const valueAtTrigger = calculatePositionValue(
+        liquidity,
+        effectivePrice,
+        tickLower,
+        tickUpper,
+        baseIsToken0
+      );
+
+      // Calculate simulated PnL including fees
+      const costBasis = BigInt(currentCostBasis || '0');
+      const fees = BigInt(unclaimedFees || '0');
+      const pnl = valueAtTrigger - costBasis + fees;
+
+      // Format the display value
+      const displayValue = formatCompactValue(pnl < 0n ? -pnl : pnl, quoteToken.decimals);
+
+      return {
+        isValid: true as const,
+        value: pnl,
+        isProfit: pnl >= 0n,
+        displayValue,
+        feesDisplay: formatCompactValue(fees, quoteToken.decimals),
+      };
+    } catch {
+      return { isValid: false as const };
+    }
+  }, [
+    triggerSqrtPriceX96,
+    currentSqrtPriceX96,
+    isToken0Quote,
+    triggerMode,
+    liquidity,
+    tickLower,
+    tickUpper,
+    currentCostBasis,
+    unclaimedFees,
+    quoteToken.decimals,
+  ]);
+}
+
+/**
+ * PnL Simulation display component
+ */
+export function PnLSimulation(props: PnLSimulationProps) {
+  const { quoteToken, label = 'Expected PnL at trigger:' } = props;
+  const simulatedPnL = usePnLSimulation(props);
+
+  return (
+    <div className="p-3 bg-slate-700/30 rounded-lg">
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-slate-400">{label}</span>
+        {simulatedPnL.isValid ? (
+          <span
+            className={`text-sm font-medium ${
+              simulatedPnL.isProfit ? 'text-green-400' : 'text-red-400'
+            }`}
+          >
+            {simulatedPnL.isProfit ? '+' : '-'}
+            {simulatedPnL.displayValue} {quoteToken.symbol}
+          </span>
+        ) : (
+          <span className="text-sm text-slate-500">n/a</span>
+        )}
+      </div>
+      {simulatedPnL.isValid && (
+        <p className="text-xs text-slate-500 mt-1">
+          Includes {simulatedPnL.feesDisplay} {quoteToken.symbol} unclaimed fees
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/midcurve-ui/src/components/positions/automation/StopLossButton.tsx
+++ b/apps/midcurve-ui/src/components/positions/automation/StopLossButton.tsx
@@ -238,10 +238,14 @@ export function StopLossButton({
     );
   }
 
-  // If active order exists, show display button (pink) with cancel X
+  // If active order exists, show display button (pink) - entire button clickable to cancel
   return (
     <>
-      <div className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium border rounded-lg text-pink-300 bg-pink-900/20 border-pink-600/50">
+      <button
+        onClick={handleCancelClick}
+        className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium border rounded-lg text-pink-300 bg-pink-900/20 hover:bg-pink-800/30 border-pink-600/50 transition-colors cursor-pointer"
+        title="Click to cancel order"
+      >
         <span className="flex items-center gap-0.5">
           {buttonLabel!.prefix} @{buttonLabel!.priceDisplay}
           {buttonLabel!.hasSwap && (
@@ -251,14 +255,8 @@ export function StopLossButton({
             </>
           )}
         </span>
-        <button
-          onClick={handleCancelClick}
-          className="ml-1 p-0.5 hover:bg-pink-800/50 rounded transition-colors cursor-pointer"
-          title="Cancel order"
-        >
-          <XIcon className="w-3 h-3" />
-        </button>
-      </div>
+        <XIcon className="w-3 h-3 ml-1" />
+      </button>
 
       {/* Cancel Confirmation Modal */}
       <CancelOrderConfirmModal
@@ -269,6 +267,14 @@ export function StopLossButton({
         contractAddress={contractAddress}
         chainId={chainId}
         onSuccess={() => setShowCancelModal(false)}
+        // Position data for PnL simulation
+        liquidity={BigInt(positionState.liquidity)}
+        tickLower={positionConfig.tickLower}
+        tickUpper={positionConfig.tickUpper}
+        currentCostBasis={position.currentCostBasis}
+        unclaimedFees={position.unClaimedFees}
+        currentSqrtPriceX96={currentSqrtPriceX96}
+        isToken0Quote={isToken0Quote}
       />
     </>
   );

--- a/apps/midcurve-ui/src/components/positions/automation/TakeProfitButton.tsx
+++ b/apps/midcurve-ui/src/components/positions/automation/TakeProfitButton.tsx
@@ -238,10 +238,14 @@ export function TakeProfitButton({
     );
   }
 
-  // If active order exists, show display button (pink) with cancel X
+  // If active order exists, show display button (pink) - entire button clickable to cancel
   return (
     <>
-      <div className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium border rounded-lg text-pink-300 bg-pink-900/20 border-pink-600/50">
+      <button
+        onClick={handleCancelClick}
+        className="flex items-center gap-1 px-3 py-1.5 text-xs font-medium border rounded-lg text-pink-300 bg-pink-900/20 hover:bg-pink-800/30 border-pink-600/50 transition-colors cursor-pointer"
+        title="Click to cancel order"
+      >
         <span className="flex items-center gap-0.5">
           {buttonLabel!.prefix} @{buttonLabel!.priceDisplay}
           {buttonLabel!.hasSwap && (
@@ -251,14 +255,8 @@ export function TakeProfitButton({
             </>
           )}
         </span>
-        <button
-          onClick={handleCancelClick}
-          className="ml-1 p-0.5 hover:bg-pink-800/50 rounded transition-colors cursor-pointer"
-          title="Cancel order"
-        >
-          <XIcon className="w-3 h-3" />
-        </button>
-      </div>
+        <XIcon className="w-3 h-3 ml-1" />
+      </button>
 
       {/* Cancel Confirmation Modal */}
       <CancelOrderConfirmModal
@@ -269,6 +267,14 @@ export function TakeProfitButton({
         contractAddress={contractAddress}
         chainId={chainId}
         onSuccess={() => setShowCancelModal(false)}
+        // Position data for PnL simulation
+        liquidity={BigInt(positionState.liquidity)}
+        tickLower={positionConfig.tickLower}
+        tickUpper={positionConfig.tickUpper}
+        currentCostBasis={position.currentCostBasis}
+        unclaimedFees={position.unClaimedFees}
+        currentSqrtPriceX96={currentSqrtPriceX96}
+        isToken0Quote={isToken0Quote}
       />
     </>
   );


### PR DESCRIPTION
## Summary

- Add Stop Loss (SL) and Take Profit (TP) action buttons to Uniswap V3 position cards
- Create reusable PnL simulation component for order creation and cancellation flows
- Implement cancel order confirmation modal with PnL preview
- Add visual feedback states: executing orders, flashing price labels, dynamic polling

## Features

### Stop Loss / Take Profit Buttons
- **Create mode**: Green "+ Stop Loss" / "+ Take Profit" buttons to create new orders
- **Active mode**: Pink buttons showing trigger price (e.g., "SL @1850.00") - fully clickable to open cancel dialog
- **Executing mode**: Amber spinner state when order is being executed (no cancel option)

### PnL Simulation
- Extracted to reusable `PnLSimulation.tsx` component
- Shows expected PnL at trigger price including unclaimed fees
- Used in both order creation modal and cancel confirmation dialog

### Cancel Order Modal
- Clean UI with order type header (e.g., "Stop-Loss Order")
- Shows trigger price and expected PnL if order triggers
- Red trashcan icon to cancel, green "Keep Order" button

### Other Improvements
- Flashing animation on current price label for visibility
- Arrow icon instead of "=>" text in swap target display
- Dynamic polling that speeds up when orders are executing

## Test plan

- [ ] Create a stop-loss order and verify PnL simulation displays correctly
- [ ] Create a take-profit order and verify PnL simulation displays correctly
- [ ] Click active SL/TP button to open cancel dialog and verify PnL preview
- [ ] Cancel an order and verify success state
- [ ] Verify executing state shows spinner and disables cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)