### PR TITLE
feat(api): add PnL curve service with SL/TP order integration

### DIFF
--- a/apps/midcurve-api/src/app/api/v1/positions/[positionId]/pnl-curve/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/[positionId]/pnl-curve/route.ts
@@ -1,0 +1,286 @@
+/**
+ * Position PnL Curve Endpoint
+ *
+ * GET /api/v1/positions/:positionId/pnl-curve
+ *
+ * Returns PnL curve data points for a position, optionally including
+ * the effects of automated close orders (stop-loss, take-profit).
+ *
+ * The curve shows position value and PnL across a range of prices:
+ * - positionValue: Raw position value at each price point
+ * - adjustedValue: Value considering order effects (flattens at trigger prices)
+ * - pnl/adjustedPnl: Profit/loss relative to cost basis
+ *
+ * Order Effects:
+ * - Stop-Loss (LOWER trigger): Curve flattens at SL value for prices below trigger
+ * - Take-Profit (UPPER trigger): Curve flattens at TP value for prices above trigger
+ *
+ * Authentication: Required (session only)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withSessionAuth } from '@/middleware/with-session-auth';
+import { createPreflightResponse } from '@/lib/cors';
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  ApiErrorCode,
+  ErrorCodeToHttpStatus,
+  PnLCurvePathParamsSchema,
+  PnLCurveQueryParamsSchema,
+} from '@midcurve/api-shared';
+import type {
+  PnLCurveResponse,
+  PnLCurveResponseData,
+  PnLCurvePointData,
+  PnLCurveOrderData,
+} from '@midcurve/api-shared';
+import { apiLogger, apiLog } from '@/lib/logger';
+import { getPnLCurveService } from '@/lib/services';
+import { prisma } from '@midcurve/database';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * OPTIONS handler for CORS preflight
+ */
+export async function OPTIONS(request: NextRequest) {
+  const origin = request.headers.get('origin');
+  return createPreflightResponse(origin);
+}
+
+/**
+ * GET /api/v1/positions/:positionId/pnl-curve
+ *
+ * Fetch PnL curve data for a position.
+ *
+ * Features:
+ * - Generates curve points across a configurable price range
+ * - Includes automated order effects (stop-loss, take-profit)
+ * - Returns both raw and adjusted values for visualization
+ * - Ensures users can only access curves for their own positions
+ *
+ * Path parameters:
+ * - positionId: Database position ID (CUID)
+ *
+ * Query parameters:
+ * - priceMin: Minimum price for visualization (optional)
+ * - priceMax: Maximum price for visualization (optional)
+ * - numPoints: Number of curve points, 10-500 (default: 150)
+ * - includeOrders: Whether to include order effects (default: true)
+ *
+ * Returns: PnL curve data with position metadata, orders, and curve points
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ positionId: string }> }
+): Promise<Response> {
+  return withSessionAuth(request, async (user, requestId) => {
+    const startTime = Date.now();
+
+    try {
+      // 1. Parse and validate path parameters
+      const resolvedParams = await params;
+      const pathValidation = PnLCurvePathParamsSchema.safeParse(resolvedParams);
+
+      if (!pathValidation.success) {
+        apiLog.validationError(apiLogger, requestId, pathValidation.error.errors);
+
+        const errorResponse = createErrorResponse(
+          ApiErrorCode.VALIDATION_ERROR,
+          'Invalid path parameters',
+          pathValidation.error.errors
+        );
+
+        apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+
+        return NextResponse.json(errorResponse, {
+          status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+        });
+      }
+
+      const { positionId } = pathValidation.data;
+
+      // 2. Parse and validate query parameters
+      const url = new URL(request.url);
+      const queryParams = Object.fromEntries(url.searchParams.entries());
+      const queryValidation = PnLCurveQueryParamsSchema.safeParse(queryParams);
+
+      if (!queryValidation.success) {
+        apiLog.validationError(apiLogger, requestId, queryValidation.error.errors);
+
+        const errorResponse = createErrorResponse(
+          ApiErrorCode.VALIDATION_ERROR,
+          'Invalid query parameters',
+          queryValidation.error.errors
+        );
+
+        apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+
+        return NextResponse.json(errorResponse, {
+          status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+        });
+      }
+
+      const { priceMin, priceMax, numPoints, includeOrders } = queryValidation.data;
+
+      // 3. Verify position exists and belongs to user
+      apiLog.businessOperation(apiLogger, requestId, 'lookup', 'position', positionId, {
+        userId: user.id,
+      });
+
+      const dbPosition = await prisma.position.findUnique({
+        where: { id: positionId },
+        select: { id: true, userId: true, protocol: true },
+      });
+
+      if (!dbPosition) {
+        const errorResponse = createErrorResponse(
+          ApiErrorCode.POSITION_NOT_FOUND,
+          'Position not found',
+          `No position found with ID ${positionId}`
+        );
+
+        apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+
+        return NextResponse.json(errorResponse, {
+          status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+        });
+      }
+
+      // Verify ownership
+      if (dbPosition.userId !== user.id) {
+        const errorResponse = createErrorResponse(
+          ApiErrorCode.FORBIDDEN,
+          'Access denied',
+          'You do not have permission to access this position'
+        );
+
+        apiLog.requestEnd(apiLogger, requestId, 403, Date.now() - startTime);
+
+        return NextResponse.json(errorResponse, {
+          status: ErrorCodeToHttpStatus[ApiErrorCode.FORBIDDEN],
+        });
+      }
+
+      // 4. Generate PnL curve
+      apiLog.businessOperation(apiLogger, requestId, 'generate-pnl-curve', 'position', positionId, {
+        priceMin,
+        priceMax,
+        numPoints,
+        includeOrders,
+      });
+
+      const curveData = await getPnLCurveService().generate({
+        positionId,
+        priceMin: priceMin ? BigInt(priceMin) : undefined,
+        priceMax: priceMax ? BigInt(priceMax) : undefined,
+        numPoints,
+        includeOrders: includeOrders ?? true,
+      });
+
+      apiLog.businessOperation(apiLogger, requestId, 'pnl-curve-generated', 'position', positionId, {
+        pointCount: curveData.curve.length,
+        orderCount: curveData.orders.length,
+      });
+
+      // 5. Serialize bigints to strings for JSON
+      const serializedData: PnLCurveResponseData = {
+        positionId: curveData.positionId,
+        tickLower: curveData.tickLower,
+        tickUpper: curveData.tickUpper,
+        liquidity: curveData.liquidity.toString(),
+        costBasis: curveData.costBasis.toString(),
+        baseToken: curveData.baseToken,
+        quoteToken: curveData.quoteToken,
+        currentPrice: curveData.currentPrice.toString(),
+        currentTick: curveData.currentTick,
+        lowerPrice: curveData.lowerPrice.toString(),
+        upperPrice: curveData.upperPrice.toString(),
+        orders: curveData.orders.map((order): PnLCurveOrderData => ({
+          type: order.type,
+          triggerPrice: order.triggerPrice.toString(),
+          triggerTick: order.triggerTick,
+          status: order.status,
+          valueAtTrigger: order.valueAtTrigger.toString(),
+        })),
+        curve: curveData.curve.map((point): PnLCurvePointData => ({
+          price: point.price.toString(),
+          positionValue: point.positionValue.toString(),
+          adjustedValue: point.adjustedValue.toString(),
+          pnl: point.pnl.toString(),
+          adjustedPnl: point.adjustedPnl.toString(),
+          pnlPercent: point.pnlPercent,
+          adjustedPnlPercent: point.adjustedPnlPercent,
+          phase: point.phase,
+          orderTriggered: point.orderTriggered,
+        })),
+      };
+
+      const response: PnLCurveResponse = {
+        ...createSuccessResponse(serializedData),
+        meta: {
+          timestamp: new Date().toISOString(),
+          pointCount: curveData.curve.length,
+          orderCount: curveData.orders.length,
+          requestId,
+        },
+      };
+
+      apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+
+      return NextResponse.json(response, { status: 200 });
+    } catch (error) {
+      apiLog.methodError(
+        apiLogger,
+        'GET /api/v1/positions/:positionId/pnl-curve',
+        error,
+        { requestId }
+      );
+
+      // Map service errors to API error codes
+      if (error instanceof Error) {
+        // Position not found
+        if (
+          error.message.includes('not found') ||
+          error.message.includes('does not exist')
+        ) {
+          const errorResponse = createErrorResponse(
+            ApiErrorCode.POSITION_NOT_FOUND,
+            'Position not found',
+            error.message
+          );
+          apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+          return NextResponse.json(errorResponse, {
+            status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+          });
+        }
+
+        // Unsupported protocol
+        if (error.message.includes('Unsupported protocol')) {
+          const errorResponse = createErrorResponse(
+            ApiErrorCode.VALIDATION_ERROR,
+            'Unsupported protocol',
+            error.message
+          );
+          apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+          return NextResponse.json(errorResponse, {
+            status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+          });
+        }
+      }
+
+      // Generic error
+      const errorResponse = createErrorResponse(
+        ApiErrorCode.INTERNAL_SERVER_ERROR,
+        'Failed to generate PnL curve',
+        error instanceof Error ? error.message : String(error)
+      );
+      apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+      return NextResponse.json(errorResponse, {
+        status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+      });
+    }
+  });
+}

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3/[chainId]/[nftId]/reload-history/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3/[chainId]/[nftId]/reload-history/route.ts
@@ -187,7 +187,7 @@ export async function POST(
       });
 
       // 6. Serialize bigints to strings for JSON
-      const serializedPosition = serializeBigInt(position) as GetUniswapV3PositionResponse;
+      const serializedPosition = serializeBigInt(position) as unknown as GetUniswapV3PositionResponse;
 
       const response = createSuccessResponse(serializedPosition);
 

--- a/apps/midcurve-api/src/lib/services.ts
+++ b/apps/midcurve-api/src/lib/services.ts
@@ -24,6 +24,7 @@ import {
   CloseOrderService,
   PoolSubscriptionService,
   AutomationLogService,
+  PnLCurveService,
 } from '@midcurve/services';
 
 // Service instances (lazy-initialized)
@@ -43,6 +44,7 @@ let _strategyMetricsService: StrategyMetricsService | null = null;
 let _closeOrderService: CloseOrderService | null = null;
 let _poolSubscriptionService: PoolSubscriptionService | null = null;
 let _automationLogService: AutomationLogService | null = null;
+let _pnlCurveService: PnLCurveService | null = null;
 
 /**
  * Get singleton instance of AuthUserService
@@ -202,4 +204,14 @@ export function getAutomationLogService(): AutomationLogService {
     _automationLogService = new AutomationLogService();
   }
   return _automationLogService;
+}
+
+/**
+ * Get singleton instance of PnLCurveService
+ */
+export function getPnLCurveService(): PnLCurveService {
+  if (!_pnlCurveService) {
+    _pnlCurveService = new PnLCurveService();
+  }
+  return _pnlCurveService;
 }

--- a/apps/midcurve-ui/src/components/positions/pnl-curve-tooltip.tsx
+++ b/apps/midcurve-ui/src/components/positions/pnl-curve-tooltip.tsx
@@ -17,10 +17,6 @@ export function PnLCurveTooltip({
   pnlPercent,
   quoteToken,
 }: PnLCurveTooltipProps) {
-  const isProfitable = pnl > 0;
-  const statusLabel = isProfitable ? "Profit (Fees)" : "Loss (IL)";
-  const statusColor = isProfitable ? "text-green-400" : "text-red-400";
-
   return (
     <div className="bg-slate-800/95 border border-slate-700 rounded-lg p-3 shadow-xl backdrop-blur-sm">
       <p className="text-slate-300 text-sm">
@@ -42,7 +38,6 @@ export function PnLCurveTooltip({
         {pnl.toLocaleString(undefined, { maximumFractionDigits: 2 })}{" "}
         {quoteToken.symbol} ({pnlPercent.toFixed(2)}%)
       </p>
-      <p className={`text-xs ${statusColor}`}>Status: {statusLabel}</p>
     </div>
   );
 }

--- a/apps/midcurve-ui/src/components/positions/protocol/uniswapv3/uniswapv3-overview-tab.tsx
+++ b/apps/midcurve-ui/src/components/positions/protocol/uniswapv3/uniswapv3-overview-tab.tsx
@@ -325,7 +325,7 @@ export function UniswapV3OverviewTab({ position }: UniswapV3OverviewTabProps) {
                   </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-slate-400">PnL Excluding Fees:</span>
+                  <span className="text-slate-400">PnL (Excluding Unclaimed Fees):</span>
                   <span
                     className={`${
                       positionStates.current.pnlExcludingFees > 0n
@@ -431,7 +431,7 @@ export function UniswapV3OverviewTab({ position }: UniswapV3OverviewTabProps) {
                   </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-slate-400">PnL Excluding Fees:</span>
+                  <span className="text-slate-400">PnL (Excluding Unclaimed Fees):</span>
                   <span
                     className={`${
                       positionStates.lowerRange.pnlExcludingFees > 0n
@@ -543,7 +543,7 @@ export function UniswapV3OverviewTab({ position }: UniswapV3OverviewTabProps) {
                   </span>
                 </div>
                 <div className="flex justify-between">
-                  <span className="text-slate-400">PnL Excluding Fees:</span>
+                  <span className="text-slate-400">PnL (Excluding Unclaimed Fees):</span>
                   <span
                     className={`${
                       positionStates.upperRange.pnlExcludingFees > 0n

--- a/apps/midcurve-ui/src/hooks/positions/usePnLCurve.ts
+++ b/apps/midcurve-ui/src/hooks/positions/usePnLCurve.ts
@@ -1,0 +1,137 @@
+/**
+ * React Query Hook for Position PnL Curve
+ *
+ * Fetches PnL curve data for a position, optionally including
+ * the effects of automated close orders (stop-loss, take-profit).
+ *
+ * The curve shows position value and PnL across a range of prices,
+ * with adjusted values when orders are active.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import type {
+  PnLCurveResponse,
+  PnLCurveResponseData,
+} from '@midcurve/api-shared';
+import { apiClient } from '@/lib/api-client';
+
+/**
+ * Options for the PnL curve query
+ */
+export interface UsePnLCurveOptions {
+  /** Minimum price for visualization (bigint as string) */
+  priceMin?: string;
+  /** Maximum price for visualization (bigint as string) */
+  priceMax?: string;
+  /** Number of curve data points (default: 150) */
+  numPoints?: number;
+  /** Whether to include order effects (default: true) */
+  includeOrders?: boolean;
+  /** Whether to enable the query (default: true) */
+  enabled?: boolean;
+}
+
+/**
+ * Fetch PnL curve data for a position
+ *
+ * @param positionId - The database position ID
+ * @param options - Query options including price range and point count
+ * @returns React Query result with PnL curve response
+ *
+ * Response structure:
+ * - data: PnLCurveResponseData - Complete curve data including:
+ *   - Position metadata (ticks, liquidity, costBasis)
+ *   - Token info (base and quote tokens)
+ *   - Current state (price, tick)
+ *   - Price range boundaries
+ *   - Active orders affecting the curve
+ *   - Array of curve points with raw and adjusted values
+ * - meta: { timestamp, pointCount, orderCount, requestId }
+ */
+export function usePnLCurve(
+  positionId: string | undefined,
+  options: UsePnLCurveOptions = {}
+): UseQueryResult<PnLCurveResponse, Error> {
+  const {
+    priceMin,
+    priceMax,
+    numPoints,
+    includeOrders = true,
+    enabled = true,
+  } = options;
+
+  return useQuery<PnLCurveResponse, Error>({
+    queryKey: ['pnl-curve', positionId, priceMin, priceMax, numPoints, includeOrders],
+    queryFn: async () => {
+      if (!positionId) {
+        throw new Error('Position ID is required');
+      }
+
+      // Build query string
+      const params = new URLSearchParams();
+      if (priceMin) params.set('priceMin', priceMin);
+      if (priceMax) params.set('priceMax', priceMax);
+      if (numPoints) params.set('numPoints', numPoints.toString());
+      if (includeOrders !== undefined) params.set('includeOrders', includeOrders.toString());
+
+      const queryString = params.toString();
+      const url = `/api/v1/positions/${positionId}/pnl-curve${queryString ? `?${queryString}` : ''}`;
+
+      const response = await apiClient.get<PnLCurveResponse>(url);
+
+      return response as unknown as PnLCurveResponse;
+    },
+    staleTime: 30 * 1000, // 30 seconds
+    gcTime: 60 * 1000, // 1 minute
+    enabled: enabled && !!positionId,
+  });
+}
+
+/**
+ * Helper to convert curve data to chart-friendly format
+ *
+ * Converts bigint strings to numbers for chart rendering while
+ * preserving the original precision in separate fields.
+ */
+export function convertCurveDataForChart(
+  data: PnLCurveResponseData,
+  quoteDecimals: number
+): {
+  price: number;
+  positionValue: number;
+  adjustedValue: number;
+  pnl: number;
+  adjustedPnl: number;
+  pnlPercent: number;
+  adjustedPnlPercent: number;
+  phase: string;
+  orderTriggered?: string;
+  profitZone: number | null;
+  lossZone: number | null;
+  adjustedProfitZone: number | null;
+  adjustedLossZone: number | null;
+}[] {
+  const divisor = Math.pow(10, quoteDecimals);
+
+  return data.curve.map((point) => {
+    const pnl = Number(BigInt(point.pnl)) / divisor;
+    const adjustedPnl = Number(BigInt(point.adjustedPnl)) / divisor;
+
+    return {
+      price: Number(BigInt(point.price)) / divisor,
+      positionValue: Number(BigInt(point.positionValue)) / divisor,
+      adjustedValue: Number(BigInt(point.adjustedValue)) / divisor,
+      pnl,
+      adjustedPnl,
+      pnlPercent: point.pnlPercent,
+      adjustedPnlPercent: point.adjustedPnlPercent,
+      phase: point.phase,
+      orderTriggered: point.orderTriggered,
+      // For chart area fills
+      profitZone: pnl > 0 ? pnl : null,
+      lossZone: pnl < 0 ? pnl : null,
+      adjustedProfitZone: adjustedPnl > 0 ? adjustedPnl : null,
+      adjustedLossZone: adjustedPnl < 0 ? adjustedPnl : null,
+    };
+  });
+}

--- a/apps/midcurve-ui/src/hooks/positions/usePositionsList.ts
+++ b/apps/midcurve-ui/src/hooks/positions/usePositionsList.ts
@@ -40,6 +40,11 @@ export function usePositionsList(
         searchParams.set('offset', params.offset.toString());
       }
 
+      // Include PnL curve data by default for mini curve visualization
+      // Can be overridden by explicitly passing includePnLCurve: false
+      const includePnLCurve = params?.includePnLCurve ?? true;
+      searchParams.set('includePnLCurve', includePnLCurve.toString());
+
       const url = `/api/v1/positions/list${
         searchParams.toString() ? `?${searchParams}` : ''
       }`;

--- a/packages/midcurve-api-shared/src/types/positions/common/index.ts
+++ b/packages/midcurve-api-shared/src/types/positions/common/index.ts
@@ -8,3 +8,4 @@
 export * from './list.js';
 export * from './ledger.js';
 export * from './apr.js';
+export * from './pnl-curve.js';

--- a/packages/midcurve-api-shared/src/types/positions/common/list.ts
+++ b/packages/midcurve-api-shared/src/types/positions/common/list.ts
@@ -8,6 +8,7 @@
 import type { BigIntToString, PaginatedResponse } from '../../common/index.js';
 import type { AnyPosition } from '@midcurve/shared';
 import type { AprPeriodData } from './apr.js';
+import type { PnLCurveResponseData } from './pnl-curve.js';
 import { z } from 'zod';
 import { PaginationParamsSchema } from '../../common/pagination.js';
 
@@ -75,6 +76,13 @@ export interface ListPositionsParams {
    * @default 0
    */
   offset?: number;
+
+  /**
+   * Include PnL curve data in response
+   * When true, generates PnL curve with order effects for each position
+   * @default false (opt-in since curve generation is expensive)
+   */
+  includePnLCurve?: boolean;
 }
 
 /**
@@ -94,6 +102,13 @@ export type ListPositionData = BigIntToString<AnyPosition> & {
    * Optional - may be undefined for positions without historical data
    */
   aprPeriods?: AprPeriodData[];
+
+  /**
+   * PnL curve data with order effects (SL/TP)
+   * Included when `includePnLCurve=true` in request
+   * Contains curve points with adjusted values considering automation orders
+   */
+  pnlCurve?: PnLCurveResponseData;
 };
 
 /**
@@ -169,6 +184,12 @@ export const ListPositionsQuerySchema = PaginationParamsSchema.extend({
     .default('desc')
     .transform((val) => val as 'asc' | 'desc')
     .pipe(SortDirectionSchema),
+
+  includePnLCurve: z
+    .string()
+    .optional()
+    .default('false')
+    .transform((val) => val === 'true'),
 });
 
 /**

--- a/packages/midcurve-api-shared/src/types/positions/common/pnl-curve.ts
+++ b/packages/midcurve-api-shared/src/types/positions/common/pnl-curve.ts
@@ -1,0 +1,229 @@
+/**
+ * Position PnL Curve Types
+ *
+ * Types for the GET /api/v1/positions/:positionId/pnl-curve endpoint
+ *
+ * Returns PnL curve data points with optional order effects (stop-loss, take-profit)
+ */
+
+import type { ApiResponse } from '../../common/api-response.js';
+import { z } from 'zod';
+
+// =============================================================================
+// Core Types
+// =============================================================================
+
+/**
+ * Order type for display purposes
+ */
+export type PnLCurveOrderType = 'stop-loss' | 'take-profit';
+
+/**
+ * Order status for PnL curve display
+ */
+export type PnLCurveOrderStatus = 'active' | 'pending' | 'executed' | 'cancelled' | 'expired';
+
+/**
+ * Position phase at a price point
+ */
+export type PnLCurvePositionPhase = 'below' | 'in-range' | 'above';
+
+/**
+ * Serialized order info for API response
+ */
+export interface PnLCurveOrderData {
+  /** Order type for display */
+  type: PnLCurveOrderType;
+  /** Trigger price in quote token units (bigint as string) */
+  triggerPrice: string;
+  /** Trigger tick (Uniswap V3 tick at trigger price) */
+  triggerTick: number;
+  /** Order status */
+  status: PnLCurveOrderStatus;
+  /** Position value at trigger price (bigint as string) */
+  valueAtTrigger: string;
+}
+
+/**
+ * Serialized curve point for API response
+ */
+export interface PnLCurvePointData {
+  /** Price in quote token units (bigint as string) */
+  price: string;
+  /** Position value before order effects (bigint as string) */
+  positionValue: string;
+  /** Adjusted value after order effects (bigint as string) */
+  adjustedValue: string;
+  /** PnL before order effects (bigint as string) */
+  pnl: string;
+  /** Adjusted PnL after order effects (bigint as string) */
+  adjustedPnl: string;
+  /** PnL percentage before order effects */
+  pnlPercent: number;
+  /** Adjusted PnL percentage after order effects */
+  adjustedPnlPercent: number;
+  /** Position phase at this price */
+  phase: PnLCurvePositionPhase;
+  /** Which order (if any) triggers at this price point */
+  orderTriggered?: PnLCurveOrderType;
+}
+
+/**
+ * Token info for PnL curve response
+ */
+export interface PnLCurveTokenData {
+  /** Token symbol */
+  symbol: string;
+  /** Token decimals */
+  decimals: number;
+  /** Token address (checksummed) */
+  address: string;
+}
+
+/**
+ * Complete PnL curve data for API response
+ */
+export interface PnLCurveResponseData {
+  // Position metadata
+  /** Position ID */
+  positionId: string;
+  /** Lower tick boundary */
+  tickLower: number;
+  /** Upper tick boundary */
+  tickUpper: number;
+  /** Position liquidity (bigint as string) */
+  liquidity: string;
+  /** Cost basis for PnL calculation (bigint as string) */
+  costBasis: string;
+
+  // Token info
+  /** Base token information */
+  baseToken: PnLCurveTokenData;
+  /** Quote token information */
+  quoteToken: PnLCurveTokenData;
+
+  // Current state
+  /** Current price in quote token units (bigint as string) */
+  currentPrice: string;
+  /** Current tick */
+  currentTick: number;
+
+  // Price range boundaries
+  /** Lower price boundary (bigint as string) */
+  lowerPrice: string;
+  /** Upper price boundary (bigint as string) */
+  upperPrice: string;
+
+  // Orders
+  /** Active orders affecting the curve */
+  orders: PnLCurveOrderData[];
+
+  // Curve data points
+  /** Array of curve points */
+  curve: PnLCurvePointData[];
+}
+
+// =============================================================================
+// Request Types
+// =============================================================================
+
+/**
+ * Path parameters for PnL curve endpoint
+ */
+export interface PnLCurvePathParams {
+  positionId: string;
+}
+
+/**
+ * Query parameters for PnL curve endpoint
+ */
+export interface PnLCurveQueryParams {
+  /** Minimum price for visualization (bigint as string, optional) */
+  priceMin?: string;
+  /** Maximum price for visualization (bigint as string, optional) */
+  priceMax?: string;
+  /** Number of curve data points (default: 150) */
+  numPoints?: number;
+  /** Whether to include order effects (default: true) */
+  includeOrders?: boolean;
+}
+
+// =============================================================================
+// Response Types
+// =============================================================================
+
+/**
+ * Response type for PnL curve endpoint
+ */
+export interface PnLCurveResponse extends ApiResponse<PnLCurveResponseData> {
+  meta?: {
+    timestamp: string;
+    pointCount: number;
+    orderCount: number;
+    requestId?: string;
+  };
+}
+
+// =============================================================================
+// Zod Schemas
+// =============================================================================
+
+/**
+ * Path parameter validation schema
+ */
+export const PnLCurvePathParamsSchema = z.object({
+  /**
+   * Position ID (CUID)
+   */
+  positionId: z
+    .string()
+    .min(1, 'Position ID is required'),
+});
+
+/**
+ * Query parameter validation schema
+ */
+export const PnLCurveQueryParamsSchema = z.object({
+  /**
+   * Minimum price for visualization (bigint as string)
+   * Optional - defaults to -50% from position range
+   */
+  priceMin: z
+    .string()
+    .regex(/^\d+$/, 'priceMin must be a valid positive integer')
+    .optional(),
+
+  /**
+   * Maximum price for visualization (bigint as string)
+   * Optional - defaults to +50% from position range
+   */
+  priceMax: z
+    .string()
+    .regex(/^\d+$/, 'priceMax must be a valid positive integer')
+    .optional(),
+
+  /**
+   * Number of curve data points
+   * Default: 150, Min: 10, Max: 500
+   */
+  numPoints: z
+    .string()
+    .regex(/^\d+$/, 'numPoints must be a valid number')
+    .transform((val) => parseInt(val, 10))
+    .pipe(z.number().int().min(10).max(500))
+    .optional(),
+
+  /**
+   * Whether to include order effects
+   * Default: true
+   */
+  includeOrders: z
+    .string()
+    .transform((val) => val === 'true')
+    .optional(),
+});
+
+/**
+ * Parsed query parameters type
+ */
+export type ParsedPnLCurveQueryParams = z.infer<typeof PnLCurveQueryParamsSchema>;

--- a/packages/midcurve-api-shared/src/types/positions/uniswapv3/get.ts
+++ b/packages/midcurve-api-shared/src/types/positions/uniswapv3/get.ts
@@ -7,6 +7,7 @@
 
 import type { UniswapV3Position } from '@midcurve/shared';
 import type { BigIntToString } from '../../common/index.js';
+import type { PnLCurveResponseData } from '../common/pnl-curve.js';
 import { z } from 'zod';
 
 /**
@@ -24,8 +25,12 @@ export interface GetUniswapV3PositionParams {
  *
  * Returns the complete position data with all bigint fields converted to strings for JSON serialization.
  * The position state is refreshed from on-chain data before being returned.
+ * Includes PnL curve data with order effects (SL/TP) for visualization.
  */
-export type GetUniswapV3PositionResponse = BigIntToString<UniswapV3Position>;
+export type GetUniswapV3PositionResponse = BigIntToString<UniswapV3Position> & {
+  /** PnL curve data with order effects for visualization */
+  pnlCurve?: PnLCurveResponseData;
+};
 
 // =============================================================================
 // Zod Schemas

--- a/packages/midcurve-services/src/index.ts
+++ b/packages/midcurve-services/src/index.ts
@@ -46,6 +46,7 @@ export * from './services/strategy-ledger/index.js';
 export * from './services/strategy-metrics/index.js';
 export * from './services/strategy-position-metrics/index.js';
 export * from './services/automation/index.js';
+export * from './services/pnl-curve/index.js';
 
 // Export service types
 export * from './services/types/auth/index.js';

--- a/packages/midcurve-services/src/services/pnl-curve/index.ts
+++ b/packages/midcurve-services/src/services/pnl-curve/index.ts
@@ -1,0 +1,20 @@
+/**
+ * PnL Curve Service
+ *
+ * Service for generating PnL curves for concentrated liquidity positions
+ * with support for automated close orders (stop-loss, take-profit).
+ */
+
+export { PnLCurveService } from './pnl-curve-service.js';
+export type { PnLCurveServiceDependencies } from './pnl-curve-service.js';
+
+export type {
+  OrderType,
+  OrderStatus,
+  PnLCurveOrder,
+  PnLCurvePoint,
+  PnLCurveTokenInfo,
+  PnLCurveData,
+  GeneratePnLCurveInput,
+  PositionDataForCurve,
+} from './types.js';

--- a/packages/midcurve-services/src/services/pnl-curve/pnl-curve-service.ts
+++ b/packages/midcurve-services/src/services/pnl-curve/pnl-curve-service.ts
@@ -1,0 +1,537 @@
+/**
+ * PnL Curve Service
+ *
+ * Generates PnL curves for Uniswap V3 positions with support for
+ * automated close orders (stop-loss, take-profit).
+ *
+ * The service:
+ * 1. Fetches position data including pool, tokens, and orders
+ * 2. Generates the base PnL curve using position parameters
+ * 3. Applies order effects to create adjusted values
+ */
+
+import type { PrismaClient } from '@midcurve/database';
+import { prisma as defaultPrisma } from '@midcurve/database';
+import type { Logger } from 'pino';
+import { createServiceLogger, log } from '../../logging/index.js';
+import {
+  generatePnLCurve,
+  tickToPrice,
+  getTickSpacing,
+  calculatePositionValue,
+  type UniswapV3PositionConfig,
+  type UniswapV3PositionState,
+  type UniswapV3PoolState,
+  type Erc20TokenConfig,
+  type TriggerMode,
+} from '@midcurve/shared';
+import { TickMath } from '@uniswap/v3-sdk';
+import JSBI from 'jsbi';
+import type {
+  PnLCurveData,
+  PnLCurvePoint,
+  PnLCurveOrder,
+  GeneratePnLCurveInput,
+  PositionDataForCurve,
+  OrderType,
+  OrderStatus,
+} from './types.js';
+
+/**
+ * Service dependencies
+ */
+export interface PnLCurveServiceDependencies {
+  prisma?: PrismaClient;
+}
+
+/**
+ * PnL Curve Service
+ *
+ * Generates PnL curves for concentrated liquidity positions.
+ */
+export class PnLCurveService {
+  protected readonly prisma: PrismaClient;
+  protected readonly logger: Logger;
+
+  constructor(dependencies: PnLCurveServiceDependencies = {}) {
+    this.prisma = dependencies.prisma ?? defaultPrisma;
+    this.logger = createServiceLogger('pnl-curve');
+  }
+
+  /**
+   * Generate PnL curve data for a position
+   *
+   * @param input - Generation parameters
+   * @returns Complete PnL curve data with order effects
+   */
+  async generate(input: GeneratePnLCurveInput): Promise<PnLCurveData> {
+    log.methodEntry(this.logger, 'generate', { positionId: input.positionId });
+
+    try {
+      // 1. Fetch position with all related data
+      const position = await this.fetchPositionData(input.positionId);
+
+      if (!position) {
+        throw new Error(`Position not found: ${input.positionId}`);
+      }
+
+      if (position.protocol !== 'uniswapv3') {
+        throw new Error(`Unsupported protocol: ${position.protocol}. Only 'uniswapv3' is supported.`);
+      }
+
+      // 2. Parse position and pool data
+      const positionConfig = position.config as unknown as UniswapV3PositionConfig;
+      const positionState = position.state as unknown as UniswapV3PositionState;
+      const poolState = position.pool.state as unknown as UniswapV3PoolState;
+
+      // 3. Determine base and quote tokens
+      const { baseToken, quoteToken } = this.resolveTokenRoles(
+        position.pool.token0,
+        position.pool.token1,
+        position.isToken0Quote
+      );
+
+      // 4. Calculate current price and tick
+      const currentTick = poolState.currentTick;
+      const currentPrice = tickToPrice(
+        currentTick,
+        baseToken.config.address,
+        quoteToken.config.address,
+        baseToken.decimals
+      );
+
+      // 5. Calculate position range prices
+      const { lowerPrice, upperPrice } = this.calculateRangePrices(
+        positionConfig.tickLower,
+        positionConfig.tickUpper,
+        baseToken,
+        quoteToken,
+        position.isToken0Quote
+      );
+
+      // 6. Determine visualization price range
+      const { priceMin, priceMax } = this.determinePriceRange(
+        input.priceMin,
+        input.priceMax,
+        lowerPrice,
+        upperPrice
+      );
+
+      // 7. Process orders
+      const orders = this.processOrders(
+        position.automationOrders,
+        baseToken,
+        quoteToken,
+        positionConfig,
+        positionState
+      );
+
+      // 8. Generate base curve
+      const numPoints = input.numPoints ?? 150;
+      const tickSpacing = getTickSpacing(position.pool.feeBps);
+      const costBasis = BigInt(position.currentCostBasis);
+
+      const baseCurve = generatePnLCurve(
+        positionState.liquidity,
+        positionConfig.tickLower,
+        positionConfig.tickUpper,
+        costBasis,
+        baseToken.config.address,
+        quoteToken.config.address,
+        baseToken.decimals,
+        tickSpacing,
+        { min: priceMin, max: priceMax },
+        numPoints
+      );
+
+      // 9. Apply order effects if requested
+      const includeOrders = input.includeOrders ?? true;
+      const curveWithOrderEffects = includeOrders
+        ? this.applyOrderEffects(baseCurve, orders, costBasis)
+        : baseCurve.map((point) => ({
+            ...point,
+            adjustedValue: point.positionValue,
+            adjustedPnl: point.pnl,
+            adjustedPnlPercent: point.pnlPercent,
+          }));
+
+      // 10. Build response
+      const result: PnLCurveData = {
+        positionId: position.id,
+        tickLower: positionConfig.tickLower,
+        tickUpper: positionConfig.tickUpper,
+        liquidity: positionState.liquidity,
+        costBasis,
+        baseToken: {
+          symbol: baseToken.symbol,
+          decimals: baseToken.decimals,
+          address: baseToken.config.address,
+        },
+        quoteToken: {
+          symbol: quoteToken.symbol,
+          decimals: quoteToken.decimals,
+          address: quoteToken.config.address,
+        },
+        currentPrice,
+        currentTick,
+        lowerPrice,
+        upperPrice,
+        orders,
+        curve: curveWithOrderEffects,
+      };
+
+      log.methodExit(this.logger, 'generate', {
+        positionId: input.positionId,
+        pointCount: result.curve.length,
+        orderCount: result.orders.length,
+      });
+
+      return result;
+    } catch (error) {
+      log.methodError(this.logger, 'generate', error as Error, {
+        positionId: input.positionId,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * Fetch position data with related entities
+   */
+  private async fetchPositionData(positionId: string): Promise<PositionDataForCurve | null> {
+    const position = await this.prisma.position.findUnique({
+      where: { id: positionId },
+      include: {
+        pool: {
+          include: {
+            token0: true,
+            token1: true,
+          },
+        },
+        automationOrders: {
+          where: {
+            status: { in: ['active', 'pending', 'registering'] },
+          },
+        },
+      },
+    });
+
+    if (!position) {
+      return null;
+    }
+
+    return {
+      id: position.id,
+      protocol: position.protocol,
+      isToken0Quote: position.isToken0Quote,
+      currentCostBasis: position.currentCostBasis,
+      pool: {
+        id: position.pool.id,
+        protocol: position.pool.protocol,
+        feeBps: position.pool.feeBps,
+        token0: {
+          id: position.pool.token0.id,
+          symbol: position.pool.token0.symbol,
+          decimals: position.pool.token0.decimals,
+          config: position.pool.token0.config,
+        },
+        token1: {
+          id: position.pool.token1.id,
+          symbol: position.pool.token1.symbol,
+          decimals: position.pool.token1.decimals,
+          config: position.pool.token1.config,
+        },
+        config: position.pool.config,
+        state: position.pool.state,
+      },
+      config: position.config,
+      state: position.state,
+      automationOrders: position.automationOrders.map((order) => ({
+        id: order.id,
+        closeOrderType: order.closeOrderType,
+        status: order.status,
+        config: order.config,
+        state: order.state,
+      })),
+    };
+  }
+
+  /**
+   * Resolve base and quote tokens based on user preference
+   */
+  private resolveTokenRoles(
+    token0: { id: string; symbol: string; decimals: number; config: unknown },
+    token1: { id: string; symbol: string; decimals: number; config: unknown },
+    isToken0Quote: boolean
+  ): {
+    baseToken: { symbol: string; decimals: number; config: Erc20TokenConfig };
+    quoteToken: { symbol: string; decimals: number; config: Erc20TokenConfig };
+  } {
+    const token0Config = token0.config as Erc20TokenConfig;
+    const token1Config = token1.config as Erc20TokenConfig;
+
+    if (isToken0Quote) {
+      return {
+        baseToken: { symbol: token1.symbol, decimals: token1.decimals, config: token1Config },
+        quoteToken: { symbol: token0.symbol, decimals: token0.decimals, config: token0Config },
+      };
+    } else {
+      return {
+        baseToken: { symbol: token0.symbol, decimals: token0.decimals, config: token0Config },
+        quoteToken: { symbol: token1.symbol, decimals: token1.decimals, config: token1Config },
+      };
+    }
+  }
+
+  /**
+   * Calculate price boundaries for position range
+   */
+  private calculateRangePrices(
+    tickLower: number,
+    tickUpper: number,
+    baseToken: { symbol: string; decimals: number; config: Erc20TokenConfig },
+    quoteToken: { symbol: string; decimals: number; config: Erc20TokenConfig },
+    isToken0Quote: boolean
+  ): { lowerPrice: bigint; upperPrice: bigint } {
+    const priceAtTickLower = tickToPrice(
+      tickLower,
+      baseToken.config.address,
+      quoteToken.config.address,
+      baseToken.decimals
+    );
+
+    const priceAtTickUpper = tickToPrice(
+      tickUpper,
+      baseToken.config.address,
+      quoteToken.config.address,
+      baseToken.decimals
+    );
+
+    // When quote is token0, tick-to-price relationship is inverted
+    if (isToken0Quote) {
+      return {
+        lowerPrice: priceAtTickUpper,
+        upperPrice: priceAtTickLower,
+      };
+    }
+
+    return {
+      lowerPrice: priceAtTickLower,
+      upperPrice: priceAtTickUpper,
+    };
+  }
+
+  /**
+   * Determine the price range for visualization
+   */
+  private determinePriceRange(
+    inputMin: bigint | undefined,
+    inputMax: bigint | undefined,
+    lowerPrice: bigint,
+    upperPrice: bigint
+  ): { priceMin: bigint; priceMax: bigint } {
+    // Default: ±50% from position range
+    const rangeWidth = upperPrice - lowerPrice;
+    const buffer = rangeWidth / 2n;
+
+    const priceMin = inputMin ?? (lowerPrice - buffer > 0n ? lowerPrice - buffer : 1n);
+    const priceMax = inputMax ?? upperPrice + buffer;
+
+    return { priceMin, priceMax };
+  }
+
+  /**
+   * Validate sqrtPriceX96 is within valid Uniswap V3 range
+   * MIN_SQRT_RATIO = 4295128739
+   * MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342
+   */
+  private isValidSqrtPriceX96(sqrtPriceX96: bigint): boolean {
+    const MIN_SQRT_RATIO = 4295128739n;
+    const MAX_SQRT_RATIO = 1461446703485210103287273052203988822378723970342n;
+    return sqrtPriceX96 >= MIN_SQRT_RATIO && sqrtPriceX96 <= MAX_SQRT_RATIO;
+  }
+
+  /**
+   * Process automation orders into curve-friendly format
+   */
+  private processOrders(
+    orders: { id: string; closeOrderType: string; status: string; config: unknown; state: unknown }[],
+    baseToken: { symbol: string; decimals: number; config: Erc20TokenConfig },
+    quoteToken: { symbol: string; decimals: number; config: Erc20TokenConfig },
+    positionConfig: UniswapV3PositionConfig,
+    positionState: UniswapV3PositionState
+  ): PnLCurveOrder[] {
+    const result: PnLCurveOrder[] = [];
+
+    for (const order of orders) {
+      if (order.closeOrderType !== 'uniswapv3') {
+        continue;
+      }
+
+      const config = order.config as {
+        triggerMode: TriggerMode;
+        sqrtPriceX96Lower: string;
+        sqrtPriceX96Upper: string;
+      };
+
+      const status = this.mapOrderStatus(order.status);
+      const baseIsToken0 = BigInt(baseToken.config.address) < BigInt(quoteToken.config.address);
+
+      // Process LOWER trigger (stop-loss)
+      if (config.triggerMode === 'LOWER' || config.triggerMode === 'BOTH') {
+        const sqrtPriceX96Lower = BigInt(config.sqrtPriceX96Lower || '0');
+
+        // Only process if sqrtPriceX96 is valid (not a sentinel value)
+        if (this.isValidSqrtPriceX96(sqrtPriceX96Lower)) {
+          // Convert BigInt to JSBI for Uniswap SDK compatibility
+          const sqrtRatioJSBI = JSBI.BigInt(sqrtPriceX96Lower.toString());
+          const triggerTick = TickMath.getTickAtSqrtRatio(sqrtRatioJSBI);
+
+          const triggerPrice = tickToPrice(
+            triggerTick,
+            baseToken.config.address,
+            quoteToken.config.address,
+            baseToken.decimals
+          );
+
+          const valueAtTrigger = calculatePositionValue(
+            positionState.liquidity,
+            sqrtPriceX96Lower,
+            positionConfig.tickLower,
+            positionConfig.tickUpper,
+            baseIsToken0
+          );
+
+          result.push({
+            type: 'stop-loss',
+            triggerPrice,
+            triggerTick,
+            status,
+            valueAtTrigger,
+          });
+        } else {
+          this.logger.debug(
+            { orderId: order.id, sqrtPriceX96Lower: sqrtPriceX96Lower.toString() },
+            'Skipping LOWER trigger: invalid sqrtPriceX96 (sentinel value)'
+          );
+          // NOTE: No continue! Let code flow to UPPER block for 'BOTH' mode
+        }
+      }
+
+      // Process UPPER trigger (take-profit)
+      if (config.triggerMode === 'UPPER' || config.triggerMode === 'BOTH') {
+        const sqrtPriceX96Upper = BigInt(config.sqrtPriceX96Upper || '0');
+
+        // Only process if sqrtPriceX96 is valid (not a sentinel value)
+        if (this.isValidSqrtPriceX96(sqrtPriceX96Upper)) {
+          // Convert BigInt to JSBI for Uniswap SDK compatibility
+          const sqrtRatioJSBI = JSBI.BigInt(sqrtPriceX96Upper.toString());
+          const triggerTick = TickMath.getTickAtSqrtRatio(sqrtRatioJSBI);
+
+          const triggerPrice = tickToPrice(
+            triggerTick,
+            baseToken.config.address,
+            quoteToken.config.address,
+            baseToken.decimals
+          );
+
+          const valueAtTrigger = calculatePositionValue(
+            positionState.liquidity,
+            sqrtPriceX96Upper,
+            positionConfig.tickLower,
+            positionConfig.tickUpper,
+            baseIsToken0
+          );
+
+          result.push({
+            type: 'take-profit',
+            triggerPrice,
+            triggerTick,
+            status,
+            valueAtTrigger,
+          });
+        } else {
+          this.logger.debug(
+            { orderId: order.id, sqrtPriceX96Upper: sqrtPriceX96Upper.toString() },
+            'Skipping UPPER trigger: invalid sqrtPriceX96 (sentinel value)'
+          );
+          // NOTE: No continue!
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /**
+   * Map database order status to curve-friendly status
+   */
+  private mapOrderStatus(status: string): OrderStatus {
+    switch (status) {
+      case 'active':
+        return 'active';
+      case 'pending':
+      case 'registering':
+        return 'pending';
+      case 'executed':
+      case 'triggering':
+        return 'executed';
+      case 'cancelled':
+        return 'cancelled';
+      case 'expired':
+        return 'expired';
+      default:
+        return 'pending';
+    }
+  }
+
+  /**
+   * Apply order effects to the PnL curve
+   *
+   * For stop-loss orders: curve becomes flat at trigger value for all prices below trigger
+   * For take-profit orders: curve becomes flat at trigger value for all prices above trigger
+   */
+  private applyOrderEffects(
+    baseCurve: { price: bigint; positionValue: bigint; pnl: bigint; pnlPercent: number; phase: string }[],
+    orders: PnLCurveOrder[],
+    costBasis: bigint
+  ): PnLCurvePoint[] {
+    // Find active SL and TP orders
+    const stopLoss = orders.find((o) => o.type === 'stop-loss' && o.status === 'active');
+    const takeProfit = orders.find((o) => o.type === 'take-profit' && o.status === 'active');
+
+    return baseCurve.map((point) => {
+      let adjustedValue = point.positionValue;
+      let orderTriggered: OrderType | undefined;
+
+      // Apply stop-loss effect (price below SL trigger)
+      if (stopLoss && point.price <= stopLoss.triggerPrice) {
+        adjustedValue = stopLoss.valueAtTrigger;
+        orderTriggered = 'stop-loss';
+      }
+
+      // Apply take-profit effect (price above TP trigger)
+      if (takeProfit && point.price >= takeProfit.triggerPrice) {
+        adjustedValue = takeProfit.valueAtTrigger;
+        orderTriggered = 'take-profit';
+      }
+
+      const adjustedPnl = adjustedValue - costBasis;
+      const adjustedPnlPercent = costBasis > 0n
+        ? Number((adjustedPnl * 10000n) / costBasis) / 100
+        : 0;
+
+      return {
+        price: point.price,
+        positionValue: point.positionValue,
+        adjustedValue,
+        pnl: point.pnl,
+        adjustedPnl,
+        pnlPercent: point.pnlPercent,
+        adjustedPnlPercent,
+        phase: point.phase as 'below' | 'in-range' | 'above',
+        orderTriggered,
+      };
+    });
+  }
+}

--- a/packages/midcurve-services/src/services/pnl-curve/types.ts
+++ b/packages/midcurve-services/src/services/pnl-curve/types.ts
@@ -1,0 +1,173 @@
+/**
+ * PnL Curve Service Types
+ *
+ * Types for PnL curve calculation with order integration.
+ * Supports automated close orders (stop-loss, take-profit) that modify
+ * the curve shape by "locking in" values at trigger prices.
+ */
+
+import type { PositionPhase } from '@midcurve/shared';
+
+/**
+ * Order type for display purposes
+ *
+ * Maps from TriggerMode to user-friendly terminology:
+ * - LOWER trigger = stop-loss (price falling)
+ * - UPPER trigger = take-profit (price rising)
+ */
+export type OrderType = 'stop-loss' | 'take-profit';
+
+/**
+ * Order status for PnL curve display
+ */
+export type OrderStatus = 'active' | 'pending' | 'executed' | 'cancelled' | 'expired';
+
+/**
+ * Simplified order info for PnL curve response
+ */
+export interface PnLCurveOrder {
+  /** Order type for display */
+  type: OrderType;
+  /** Trigger price in quote token units (with decimals) */
+  triggerPrice: bigint;
+  /** Trigger tick (Uniswap V3 tick at trigger price) */
+  triggerTick: number;
+  /** Order status */
+  status: OrderStatus;
+  /** Position value at trigger price (quote token units) */
+  valueAtTrigger: bigint;
+}
+
+/**
+ * Single point on the PnL curve
+ */
+export interface PnLCurvePoint {
+  /** Price in quote token units (with decimals) */
+  price: bigint;
+  /** Position value before order effects (quote token units) */
+  positionValue: bigint;
+  /** Adjusted value after order effects (quote token units) */
+  adjustedValue: bigint;
+  /** PnL before order effects (quote token units) */
+  pnl: bigint;
+  /** Adjusted PnL after order effects (quote token units) */
+  adjustedPnl: bigint;
+  /** PnL percentage before order effects */
+  pnlPercent: number;
+  /** Adjusted PnL percentage after order effects */
+  adjustedPnlPercent: number;
+  /** Position phase at this price */
+  phase: PositionPhase;
+  /** Which order (if any) triggers at this price point */
+  orderTriggered?: OrderType;
+}
+
+/**
+ * Token info for PnL curve response
+ */
+export interface PnLCurveTokenInfo {
+  /** Token symbol */
+  symbol: string;
+  /** Token decimals */
+  decimals: number;
+  /** Token address (checksummed) */
+  address: string;
+}
+
+/**
+ * Complete PnL curve data
+ */
+export interface PnLCurveData {
+  // Position metadata
+  /** Position ID */
+  positionId: string;
+  /** Lower tick boundary */
+  tickLower: number;
+  /** Upper tick boundary */
+  tickUpper: number;
+  /** Position liquidity */
+  liquidity: bigint;
+  /** Cost basis for PnL calculation */
+  costBasis: bigint;
+
+  // Token info
+  /** Base token information */
+  baseToken: PnLCurveTokenInfo;
+  /** Quote token information */
+  quoteToken: PnLCurveTokenInfo;
+
+  // Current state
+  /** Current price in quote token units */
+  currentPrice: bigint;
+  /** Current tick */
+  currentTick: number;
+
+  // Price range boundaries
+  /** Lower price boundary (quote token units) */
+  lowerPrice: bigint;
+  /** Upper price boundary (quote token units) */
+  upperPrice: bigint;
+
+  // Orders
+  /** Active orders affecting the curve */
+  orders: PnLCurveOrder[];
+
+  // Curve data points
+  /** Array of curve points */
+  curve: PnLCurvePoint[];
+}
+
+/**
+ * Input parameters for PnL curve generation
+ */
+export interface GeneratePnLCurveInput {
+  /** Position ID to generate curve for */
+  positionId: string;
+  /** Minimum price for visualization (optional, defaults to -50% from range) */
+  priceMin?: bigint;
+  /** Maximum price for visualization (optional, defaults to +50% from range) */
+  priceMax?: bigint;
+  /** Number of curve data points (default: 150) */
+  numPoints?: number;
+  /** Whether to include order effects (default: true) */
+  includeOrders?: boolean;
+}
+
+/**
+ * Position data required for curve generation
+ * (fetched from database)
+ */
+export interface PositionDataForCurve {
+  id: string;
+  protocol: string;
+  isToken0Quote: boolean;
+  currentCostBasis: string;
+  pool: {
+    id: string;
+    protocol: string;
+    feeBps: number;
+    token0: {
+      id: string;
+      symbol: string;
+      decimals: number;
+      config: unknown;
+    };
+    token1: {
+      id: string;
+      symbol: string;
+      decimals: number;
+      config: unknown;
+    };
+    config: unknown;
+    state: unknown;
+  };
+  config: unknown;
+  state: unknown;
+  automationOrders: {
+    id: string;
+    closeOrderType: string;
+    status: string;
+    config: unknown;
+    state: unknown;
+  }[];
+}


### PR DESCRIPTION
## Summary

- Add PnL curve service in `@midcurve/services` that generates position PnL curves with stop-loss/take-profit order effects
- Embed PnL curve data in position list endpoint (`includePnLCurve` query param) and detail endpoint (always included)
- Update mini PnL curve component to use server-generated curve data instead of client-side calculation
- Update position simulator to display adjusted PnL values that account for SL/TP order effects
- Fix label accuracy: changed "PnL Excluding Fees" to "PnL (Excluding Unclaimed Fees)"

## Changes

### New Files
- `packages/midcurve-services/src/services/pnl-curve/` - PnL curve generation service with order integration
- `packages/midcurve-api-shared/src/types/positions/common/pnl-curve.ts` - PnL curve response types
- `apps/midcurve-api/src/app/api/v1/positions/[positionId]/pnl-curve/route.ts` - Standalone endpoint (kept for future use)
- `apps/midcurve-ui/src/hooks/positions/usePnLCurve.ts` - React Query hook (may not be needed with embedded approach)

### Modified Files
- Position list endpoint: Added `includePnLCurve` query parameter
- Position detail endpoint: Always includes `pnlCurve` data
- Mini PnL curve component: Uses embedded data instead of local calculation
- Position simulator: Shows adjusted PnL from curve data (accounts for SL/TP flattening)
- Overview tab & simulator: Updated labels to "PnL (Excluding Unclaimed Fees)"

## Test plan

- [ ] Verify mini PnL curves render correctly on position list page
- [ ] Verify curves persist after position detail refresh (no more disappearing curves)
- [ ] Test position simulator shows adjusted PnL when sliding price
- [ ] Verify curve flattens beyond SL/TP trigger prices for positions with orders
- [ ] Confirm tooltip displays correct values on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)