### PR TITLE
fix: upgrade Docker base images from node:20-alpine to node:22-alpine

### DIFF
--- a/apps/midcurve-api/Dockerfile
+++ b/apps/midcurve-api/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Install pnpm and build dependencies
@@ -41,21 +41,24 @@ RUN pnpm exec esbuild \
   packages/midcurve-database/prisma/seed-coingecko-tokens.ts \
   --bundle \
   --platform=node \
-  --target=node20 \
+  --target=node22 \
   --format=cjs \
   --out-extension:.js=.cjs \
   --outdir=packages/midcurve-database/prisma \
   --external:../src/generated/prisma/index.js
 
 # Production stage
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3001
 
-# Install required system packages for Prisma
-RUN apk add --no-cache openssl
+# Apply Alpine security patches and install required system packages for Prisma
+RUN apk upgrade --no-cache && apk add --no-cache openssl
+
+# Update npm to patch bundled dependency CVEs (tar, minimatch, glob)
+RUN npm install -g npm@latest
 
 # Install prisma CLI for migrations (pinned to 6.x)
 RUN npm install -g prisma@6.19.0

--- a/apps/midcurve-automation/Dockerfile
+++ b/apps/midcurve-automation/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Install pnpm and build dependencies
@@ -31,15 +31,18 @@ RUN pnpm --filter @midcurve/services build
 RUN pnpm --filter @midcurve/automation build
 
 # Production stage
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3004
 ENV HOSTNAME=0.0.0.0
 
-# Install required system packages (wget for healthcheck)
-RUN apk add --no-cache openssl wget
+# Apply Alpine security patches and install required system packages (wget for healthcheck)
+RUN apk upgrade --no-cache && apk add --no-cache openssl wget
+
+# Update npm to patch bundled dependency CVEs (tar, minimatch, glob)
+RUN npm install -g npm@latest
 
 # Copy standalone build
 COPY --from=builder /app/apps/midcurve-automation/.next/standalone ./

--- a/apps/midcurve-business-logic/Dockerfile
+++ b/apps/midcurve-business-logic/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Install pnpm and build dependencies
@@ -31,10 +31,16 @@ RUN pnpm --filter @midcurve/services build
 RUN pnpm --filter @midcurve/business-logic build
 
 # Production stage
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+
+# Apply Alpine security patches
+RUN apk upgrade --no-cache
+
+# Update npm to patch bundled dependency CVEs (tar, minimatch, glob)
+RUN npm install -g npm@latest
 
 # Copy built application
 COPY --from=builder /app/apps/midcurve-business-logic/dist ./dist

--- a/apps/midcurve-onchain-data/Dockerfile
+++ b/apps/midcurve-onchain-data/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Install pnpm and build dependencies
@@ -31,10 +31,16 @@ RUN pnpm --filter @midcurve/services build
 RUN pnpm --filter @midcurve/onchain-data build
 
 # Production stage
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
+
+# Apply Alpine security patches
+RUN apk upgrade --no-cache
+
+# Update npm to patch bundled dependency CVEs (tar, minimatch, glob)
+RUN npm install -g npm@latest
 
 # Copy built application
 COPY --from=builder /app/apps/midcurve-onchain-data/dist ./dist

--- a/apps/midcurve-signer/Dockerfile
+++ b/apps/midcurve-signer/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Install pnpm and build dependencies
@@ -31,14 +31,17 @@ RUN pnpm --filter @midcurve/services build
 RUN pnpm --filter @midcurve/signer build
 
 # Production stage
-FROM node:20-alpine AS runner
+FROM node:22-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=3003
 
-# Install required system packages
-RUN apk add --no-cache openssl
+# Apply Alpine security patches and install required system packages
+RUN apk upgrade --no-cache && apk add --no-cache openssl
+
+# Update npm to patch bundled dependency CVEs (tar, minimatch, glob)
+RUN npm install -g npm@latest
 
 # Copy standalone build
 COPY --from=builder /app/apps/midcurve-signer/.next/standalone ./

--- a/apps/midcurve-ui/Dockerfile
+++ b/apps/midcurve-ui/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 WORKDIR /app
 
 # Build args for Vite (must be available at build time)


### PR DESCRIPTION
## Summary
- Upgrade all 6 Dockerfiles from `node:20-alpine` to `node:22-alpine` (Node 22 LTS)
- Add `apk upgrade --no-cache` in runner stages for Alpine security patches (zlib, busybox)
- Add `npm install -g npm@latest` in runner stages to patch bundled npm dependency CVEs (tar, minimatch, glob)
- Update esbuild target from `node20` to `node22` in API Dockerfile

Reduces vulnerabilities from **16 (11 HIGH, 2 MEDIUM, 3 LOW)** down to **1 MEDIUM** (unfixed upstream busybox CVE).

Fixes #26

## Test plan
- [x] `docker build -t test-api -f apps/midcurve-api/Dockerfile .` builds successfully
- [x] `docker scout cves test-api` shows only 1 MEDIUM remaining
- [ ] Verify all 6 services start correctly on Railway after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)