### PR TITLE
fix: promote base/quote roles to first-class API parameters (#45)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -14,6 +14,15 @@
         "--browser-url=http://127.0.0.1:9222",
         "--no-usage-statistics"
       ]
+    },
+    "midcurve": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["apps/midcurve-mcp-server/dist/index.js"],
+      "env": {
+        "MIDCURVE_API_KEY": "${MIDCURVE_DEV_API_KEY}",
+        "MIDCURVE_API_URL": "http://localhost:3001"
+      }
     }
   }
 }

--- a/apps/midcurve-api/src/app/api/v1/pools/favorites/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/pools/favorites/route.ts
@@ -88,7 +88,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         });
       }
 
-      const { protocol, chainId, poolAddress } = validation.data;
+      const { protocol, chainId, poolAddress, isToken0Quote } = validation.data;
 
       // 2. Delegate to protocol-specific service
       apiLog.businessOperation(
@@ -97,7 +97,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         'addFavorite',
         'FavoritePool',
         `${protocol}/${chainId}/${poolAddress}`,
-        { protocol, chainId, poolAddress }
+        { protocol, chainId, poolAddress, isToken0Quote }
       );
 
       let result;
@@ -110,6 +110,7 @@ export async function POST(request: NextRequest): Promise<Response> {
               userId: user.id,
               chainId,
               poolAddress,
+              ...(typeof isToken0Quote === 'boolean' && { isToken0Quote }),
             });
           } catch (error) {
             if (error instanceof Error) {
@@ -221,6 +222,9 @@ export async function POST(request: NextRequest): Promise<Response> {
         poolAddress: result.pool.address,
         pool: serializedPool as unknown as FavoritePoolItem['pool'],
         metrics: metricsBlock,
+        ...(typeof result.isToken0Quote === 'boolean' && {
+          userProvidedInfo: { isToken0Quote: result.isToken0Quote },
+        }),
       };
 
       const responseData: AddFavoritePoolData = {
@@ -368,6 +372,9 @@ export async function GET(request: NextRequest): Promise<Response> {
           poolAddress: fav.pool.address,
           pool: serializedPool as unknown as FavoritePoolItem['pool'],
           metrics: buildPoolMetricsBlock(subgraphInput, sigma),
+          ...(typeof fav.isToken0Quote === 'boolean' && {
+            userProvidedInfo: { isToken0Quote: fav.isToken0Quote },
+          }),
         });
       }
 

--- a/apps/midcurve-api/src/app/api/v1/pools/uniswapv3/[chainId]/[address]/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/pools/uniswapv3/[chainId]/[address]/route.ts
@@ -48,6 +48,9 @@ export async function OPTIONS(request: NextRequest): Promise<Response> {
  * Query params:
  * - metrics (optional): Include subgraph metrics (TVL, volume, fees). Defaults to false.
  * - fees (optional): Include fee data for APR calculations (24h volumes, token prices). Defaults to false.
+ * - isToken0Quote (optional): If provided, response includes
+ *   `userProvidedInfo: { isToken0Quote }` (pure echo — metrics/feeData are
+ *   not reoriented).
  */
 export async function GET(
   request: NextRequest,
@@ -102,7 +105,7 @@ export async function GET(
         });
       }
 
-      const { metrics, fees } = queryResult.data;
+      const { metrics, fees, isToken0Quote } = queryResult.data;
 
       // 3. Discover pool (creates if new, refreshes if existing)
       // This ensures we always return fresh on-chain state
@@ -240,6 +243,9 @@ export async function GET(
         pool: serializedPool as unknown as UniswapV3Pool,
         ...(metricsData && { metrics: metricsData }),
         ...(feeData && { feeData }),
+        ...(typeof isToken0Quote === 'boolean' && {
+          userProvidedInfo: { isToken0Quote },
+        }),
       };
 
       const response = createSuccessResponse(responseData, {

--- a/apps/midcurve-api/src/app/api/v1/pools/uniswapv3/search/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/pools/uniswapv3/search/route.ts
@@ -34,12 +34,15 @@ export async function OPTIONS(request: NextRequest): Promise<Response> {
  * Returns pools sorted by TVL with 7-day APR calculation.
  *
  * Request body:
- * - tokenSetA (required): Array of token addresses or symbols
- * - tokenSetB (required): Array of token addresses or symbols
+ * - base (required): Array of token addresses or exact CoinGecko symbols
+ * - quote (required): Array of token addresses or exact CoinGecko symbols
  * - chainIds (required): Array of chain IDs to search
  * - sortBy (optional): Field to sort by (tvlUSD, volume24hUSD, fees24hUSD, volume7dAvgUSD, fees7dAvgUSD, apr7d)
  * - sortDirection (optional): Sort direction (asc, desc)
  * - limit (optional): Maximum results to return (1-100, default: 20)
+ *
+ * Each result is annotated with `userProvidedInfo.isToken0Quote`, derived
+ * per pool by checking which side appears in the request's `quote` array.
  */
 export async function POST(request: NextRequest): Promise<Response> {
   return withAuth(request, async (user, requestId) => {
@@ -82,17 +85,17 @@ export async function POST(request: NextRequest): Promise<Response> {
         });
       }
 
-      const { tokenSetA, tokenSetB, chainIds, sortBy, sortDirection, limit } = validation.data;
+      const { base, quote, chainIds, sortBy, sortDirection, limit } = validation.data;
 
       apiLog.businessOperation(
         apiLogger,
         requestId,
         'searching',
         'uniswapv3-pools',
-        `${chainIds.join(',')}-${tokenSetA.length}x${tokenSetB.length}`,
+        `${chainIds.join(',')}-${base.length}x${quote.length}`,
         {
-          tokenSetA,
-          tokenSetB,
+          base,
+          quote,
           chainIds,
           sortBy,
           limit,
@@ -101,8 +104,8 @@ export async function POST(request: NextRequest): Promise<Response> {
 
       // Search pools via service
       const results = await getUniswapV3PoolSearchService().searchPools({
-        tokenSetA,
-        tokenSetB,
+        base,
+        quote,
         chainIds,
         sortBy,
         sortDirection,

--- a/apps/midcurve-mcp-server/src/api-client.ts
+++ b/apps/midcurve-mcp-server/src/api-client.ts
@@ -57,6 +57,40 @@ export class ApiClient {
     return body as T;
   }
 
+  /**
+   * POST an endpoint that returns the standard `{ success, data, meta }` envelope.
+   * Returns the unwrapped `data` field.
+   */
+  async post<T>(path: string, payload: unknown): Promise<T> {
+    const url = this.buildUrl(path);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.config.apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new ApiError(
+        `API returned non-JSON response (HTTP ${response.status})`,
+        response.status,
+        'INVALID_RESPONSE'
+      );
+    }
+    if (!response.ok) {
+      this.throwApiError(body, response.status);
+    }
+    if (!isObject(body) || body.success !== true) {
+      this.throwApiError(body, response.status);
+    }
+    return (body as unknown as ApiResponse<T>).data;
+  }
+
   private async fetchBody(path: string, query?: Record<string, unknown>): Promise<unknown> {
     const url = this.buildUrl(path, query);
     const response = await fetch(url, {

--- a/apps/midcurve-mcp-server/src/formatters.test.ts
+++ b/apps/midcurve-mcp-server/src/formatters.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatPool } from './formatters.js';
+import { formatPool, formatPoolSearchResult } from './formatters.js';
 
 /**
  * Fixture shapes mirror the API's `serializeUniswapV3Pool` output (see
@@ -203,6 +203,106 @@ describe('formatPool', () => {
     const detail = { ...basePool(), metrics: metrics as NonNullable<PoolDetail['metrics']> };
     const out = formatPool(detail);
     const m = out.metrics as Record<string, unknown>;
+    expect(m.sigmaFilter).toBeNull();
+  });
+
+  it('omits userProvidedInfo when not supplied (issue #45)', () => {
+    const out = formatPool(basePool());
+    expect('userProvidedInfo' in out).toBe(false);
+  });
+
+  it('echoes userProvidedInfo when supplied (issue #45)', () => {
+    const out = formatPool({ ...basePool(), userProvidedInfo: { isToken0Quote: true } });
+    expect(out.userProvidedInfo).toEqual({ isToken0Quote: true });
+
+    const out2 = formatPool({ ...basePool(), userProvidedInfo: { isToken0Quote: false } });
+    expect(out2.userProvidedInfo).toEqual({ isToken0Quote: false });
+  });
+});
+
+// =============================================================================
+// formatPoolSearchResult (issue #45)
+// =============================================================================
+
+type SearchResult = Parameters<typeof formatPoolSearchResult>[0];
+
+function baseSearchResult(): SearchResult {
+  return {
+    poolAddress: '0xd0b53D9277642d899DF5C87A3966A349A798F224',
+    chainId: 8453,
+    chainName: 'Base',
+    feeTier: 500,
+    token0: {
+      address: '0x4200000000000000000000000000000000000006',
+      symbol: 'WETH',
+      decimals: 18,
+    },
+    token1: {
+      address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      symbol: 'USDC',
+      decimals: 6,
+    },
+    metrics: {
+      tvlUSD: '12500000.5',
+      volume24hUSD: '50000000',
+      fees24hUSD: '25000',
+      fees7dUSD: '175000',
+      volume7dAvgUSD: '50000000',
+      fees7dAvgUSD: '25000',
+      apr7d: 25.12,
+      feeApr24h: 0.2512,
+      feeApr7dAvg: 0.2512,
+      feeAprPrimary: 0.2512,
+      feeAprSource: '7d_avg',
+    },
+  };
+}
+
+describe('formatPoolSearchResult', () => {
+  it('formats the canonical fields and dual-emits USD money', () => {
+    const out = formatPoolSearchResult(baseSearchResult());
+    expect(out.pair).toBe('WETH/USDC');
+    expect(out.feeTier).toBe('0.05%');
+    const m = out.metrics as Record<string, unknown>;
+    expect(m.tvlRaw).toBe('12500000.5');
+    expect(typeof m.tvl).toBe('string');
+    expect(m.apr7d).toBe('25.12%');
+    expect(m.feeApr7dAvg).toBe('25.12%');
+  });
+
+  it('defaults isFavorite to false when omitted, echoes when present', () => {
+    const out = formatPoolSearchResult(baseSearchResult());
+    expect(out.isFavorite).toBe(false);
+
+    const out2 = formatPoolSearchResult({ ...baseSearchResult(), isFavorite: true });
+    expect(out2.isFavorite).toBe(true);
+  });
+
+  it('omits userProvidedInfo when not supplied', () => {
+    const out = formatPoolSearchResult(baseSearchResult());
+    expect('userProvidedInfo' in out).toBe(false);
+  });
+
+  it('echoes userProvidedInfo when supplied (orientation pivot)', () => {
+    // token0 is in the user's quote set
+    const out = formatPoolSearchResult({
+      ...baseSearchResult(),
+      userProvidedInfo: { isToken0Quote: true },
+    });
+    expect(out.userProvidedInfo).toEqual({ isToken0Quote: true });
+
+    // token0 is NOT in the user's quote set
+    const out2 = formatPoolSearchResult({
+      ...baseSearchResult(),
+      userProvidedInfo: { isToken0Quote: false },
+    });
+    expect(out2.userProvidedInfo).toEqual({ isToken0Quote: false });
+  });
+
+  it('handles missing volatility / sigmaFilter blocks (search results may omit them)', () => {
+    const out = formatPoolSearchResult(baseSearchResult());
+    const m = out.metrics as Record<string, unknown>;
+    expect(m.volatility).toBeNull();
     expect(m.sigmaFilter).toBeNull();
   });
 });

--- a/apps/midcurve-mcp-server/src/formatters.ts
+++ b/apps/midcurve-mcp-server/src/formatters.ts
@@ -402,6 +402,12 @@ interface PoolDetailRaw {
     sigmaFilter?: SigmaFilterBlockRaw;
   };
   feeData?: Record<string, unknown>;
+  /**
+   * Optional echo of the request's `isToken0Quote` query param (PRD-issue-#45).
+   * When present, surfaced unchanged on the formatted output so consumers can
+   * pivot to base/quote orientation. Pool itself remains role-agnostic.
+   */
+  userProvidedInfo?: { isToken0Quote: boolean };
 }
 
 /**
@@ -488,7 +494,7 @@ function formatSigmaFilter(s: SigmaFilterBlockRaw): Record<string, unknown> {
  * §3.1 ("Embedded pool summary vs standalone pool detail").
  */
 export function formatPool(detail: PoolDetailRaw): Record<string, unknown> {
-  const { pool, metrics, feeData } = detail;
+  const { pool, metrics, feeData, userProvidedInfo } = detail;
   const token0 = {
     address: pool.token0.config.address,
     symbol: pool.token0.symbol,
@@ -549,7 +555,94 @@ export function formatPool(detail: PoolDetailRaw): Record<string, unknown> {
         }
       : null,
     feeData: feeData ?? null,
+    ...(userProvidedInfo && { userProvidedInfo }),
     state: pool.state,
+  };
+}
+
+// =============================================================================
+// Pool Search Result (POST /api/v1/pools/uniswapv3/search)
+// =============================================================================
+
+interface PoolSearchTokenInfoRaw {
+  address: string;
+  symbol: string;
+  decimals: number;
+}
+
+interface PoolSearchResultRaw {
+  poolAddress: string;
+  chainId: number;
+  chainName: string;
+  feeTier: number;
+  token0: PoolSearchTokenInfoRaw;
+  token1: PoolSearchTokenInfoRaw;
+  metrics: {
+    tvlUSD: string;
+    volume24hUSD: string;
+    fees24hUSD: string;
+    fees7dUSD: string;
+    volume7dAvgUSD: string;
+    fees7dAvgUSD: string;
+    apr7d: number | null;
+    feeApr24h?: number | null;
+    feeApr7dAvg?: number | null;
+    feeAprPrimary?: number | null;
+    feeAprSource?: '24h' | '7d_avg' | 'unavailable';
+    volatility?: VolatilityBlockRaw;
+    sigmaFilter?: SigmaFilterBlockRaw;
+  };
+  isFavorite?: boolean;
+  userProvidedInfo?: { isToken0Quote: boolean };
+}
+
+/**
+ * Format a single pool search result for MCP output. Mirrors `formatPool`'s
+ * shape (canonical token0/token1, dual-emitted USD fields, humanized
+ * percentages, σ-filter / volatility blocks) and adds search-specific fields
+ * (`isFavorite`, `userProvidedInfo`).
+ */
+export function formatPoolSearchResult(
+  result: PoolSearchResultRaw
+): Record<string, unknown> {
+  const fmtUsd = (raw: string | undefined): string | null =>
+    raw ? formatUSDValue(raw) : null;
+  const m = result.metrics;
+  return {
+    chainId: result.chainId,
+    chainName: result.chainName,
+    poolAddress: result.poolAddress,
+    pair: `${result.token0.symbol}/${result.token1.symbol}`,
+    feeBps: result.feeTier,
+    feeTier: `${(result.feeTier / 10_000).toFixed(2)}%`,
+    token0: result.token0,
+    token1: result.token1,
+    metrics: {
+      tvl: fmtUsd(m.tvlUSD),
+      tvlRaw: m.tvlUSD,
+      volume24h: fmtUsd(m.volume24hUSD),
+      volume24hRaw: m.volume24hUSD,
+      fees24h: fmtUsd(m.fees24hUSD),
+      fees24hRaw: m.fees24hUSD,
+      fees7d: fmtUsd(m.fees7dUSD),
+      fees7dRaw: m.fees7dUSD,
+      volume7dAvg: fmtUsd(m.volume7dAvgUSD),
+      volume7dAvgRaw: m.volume7dAvgUSD,
+      fees7dAvg: fmtUsd(m.fees7dAvgUSD),
+      fees7dAvgRaw: m.fees7dAvgUSD,
+      apr7d:
+        m.apr7d !== null && m.apr7d !== undefined
+          ? formatPercentage(m.apr7d, 2)
+          : null,
+      feeApr24h: fmtRate(m.feeApr24h ?? null, 2),
+      feeApr7dAvg: fmtRate(m.feeApr7dAvg ?? null, 2),
+      feeAprPrimary: fmtRate(m.feeAprPrimary ?? null, 2),
+      feeAprSource: m.feeAprSource ?? 'unavailable',
+      volatility: m.volatility ? formatVolatility(m.volatility) : null,
+      sigmaFilter: m.sigmaFilter ? formatSigmaFilter(m.sigmaFilter) : null,
+    },
+    isFavorite: result.isFavorite ?? false,
+    ...(result.userProvidedInfo && { userProvidedInfo: result.userProvidedInfo }),
   };
 }
 

--- a/apps/midcurve-mcp-server/src/index.ts
+++ b/apps/midcurve-mcp-server/src/index.ts
@@ -30,6 +30,7 @@ import { buildConvertPriceAndTickTool } from './tools/convert-price-and-tick.js'
 import { buildGetPnlTool } from './tools/get-pnl.js';
 import { buildListCloseOrdersTool } from './tools/list-close-orders.js';
 import { buildGetPoolTool } from './tools/get-pool.js';
+import { buildSearchPoolsTool } from './tools/search-pools.js';
 import { buildListNotificationsTool } from './tools/list-notifications.js';
 
 async function main(): Promise<void> {
@@ -101,9 +102,10 @@ async function main(): Promise<void> {
   register(buildGetPnlTool(client));
   register(buildListCloseOrdersTool(client));
   register(buildGetPoolTool(client));
+  register(buildSearchPoolsTool(client));
   register(buildListNotificationsTool(client));
 
-  log.info({ count: 16 }, 'tools registered');
+  log.info({ count: 17 }, 'tools registered');
 
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/apps/midcurve-mcp-server/src/tools/get-pool.ts
+++ b/apps/midcurve-mcp-server/src/tools/get-pool.ts
@@ -20,6 +20,15 @@ const inputSchema = {
     .optional()
     .default(false)
     .describe('Include fee data for APR calculations.'),
+  isToken0Quote: z
+    .boolean()
+    .optional()
+    .describe(
+      'Optional base/quote orientation echoed back via `userProvidedInfo.isToken0Quote`. ' +
+        'When supplied, the response includes `userProvidedInfo: { isToken0Quote }`; when omitted, ' +
+        'no orientation is attached and the canonical pool-native token0/token1 ordering applies. ' +
+        'Pure echo — metrics/feeData are not reoriented.'
+    ),
 };
 
 export function buildGetPoolTool(client: ApiClient) {
@@ -61,9 +70,16 @@ export function buildGetPoolTool(client: ApiClient) {
       inputSchema,
     },
     handler: async (args: { [K in keyof typeof inputSchema]: z.infer<(typeof inputSchema)[K]> }) => {
+      const query: Record<string, unknown> = {
+        metrics: args.metrics,
+        fees: args.fees,
+      };
+      if (typeof args.isToken0Quote === 'boolean') {
+        query.isToken0Quote = args.isToken0Quote;
+      }
       const pool = await client.get<Parameters<typeof formatPool>[0]>(
         `/api/v1/pools/uniswapv3/${args.chainId}/${args.address}`,
-        { metrics: args.metrics, fees: args.fees }
+        query
       );
 
       return {

--- a/apps/midcurve-mcp-server/src/tools/search-pools.ts
+++ b/apps/midcurve-mcp-server/src/tools/search-pools.ts
@@ -1,0 +1,97 @@
+import { z } from 'zod';
+import type { ApiClient } from '../api-client.js';
+import { formatPoolSearchResult } from '../formatters.js';
+
+const inputSchema = {
+  base: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(10)
+    .describe(
+      'Base side of the pair. Accepts exact token symbols (case-insensitive — must match a ' +
+        'CoinGecko symbol exactly) or EIP-55 addresses. Fuzzy/prefix resolution is the ' +
+        "consumer's responsibility — passing 'eth' will not match WETH/stETH/rETH."
+    ),
+  quote: z
+    .array(z.string().min(1))
+    .min(1)
+    .max(10)
+    .describe(
+      "Quote side of the pair. Same input contract as `base`. Determines each result's " +
+        '`userProvidedInfo.isToken0Quote` (set to true when the pool\'s token0 resolves ' +
+        'to a member of this set on that chain).'
+    ),
+  chainIds: z
+    .array(z.number().int().positive())
+    .min(1)
+    .max(5)
+    .describe('EVM chain IDs to search. Supported: 1 (Ethereum), 42161 (Arbitrum), 8453 (Base), 10 (Optimism), 137 (Polygon).'),
+  sortBy: z
+    .enum(['tvlUSD', 'volume24hUSD', 'fees24hUSD', 'volume7dAvgUSD', 'fees7dAvgUSD', 'apr7d'])
+    .optional()
+    .describe('Field to sort results by. Defaults to tvlUSD on the server.'),
+  sortDirection: z
+    .enum(['asc', 'desc'])
+    .optional()
+    .describe('Sort direction. Defaults to desc on the server.'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(100)
+    .optional()
+    .describe('Maximum results to return (1-100, default 20).'),
+};
+
+export function buildSearchPoolsTool(client: ApiClient) {
+  return {
+    name: 'search_pools',
+    config: {
+      title: 'Search Uniswap V3 pools by base/quote token sets',
+      description:
+        'Search the cartesian product `base × quote` across one or more chains and return ' +
+        'matching pools sorted by the chosen metric. Each result is annotated with ' +
+        '`userProvidedInfo.isToken0Quote` (derived from the request\'s quote-side input — ' +
+        'true if the pool\'s `token0` is a member of `quote` on that chain) so consumers ' +
+        'can render pairs in user-intended orientation regardless of pool-native token order.\n\n' +
+        '**Input contract (important):** `base` and `quote` accept *exact* token symbols ' +
+        '(case-insensitive — must match a CoinGecko symbol exactly) or EIP-55 addresses. ' +
+        'Fuzzy/prefix resolution is the consumer\'s responsibility. Passing `"eth"` will ' +
+        'not match `WETH`/`stETH`/`rETH`.\n\n' +
+        '**Validation:** the trivial case `|base| = |quote| = 1 ∧ base[0] === quote[0]` is ' +
+        'rejected as 400. Richer queries like `base=["WETH","stETH"], quote=["WETH","stETH"]` ' +
+        'are valid (per-chain self-exclusion handles `(b, q)` pairs with `b === q`).\n\n' +
+        '**Output:** each item carries the same `metrics` block shape as `get_pool` ' +
+        '(dual-emitted USD fields, humanized fee-APR percentages, optional `volatility` ' +
+        'and `sigmaFilter` σ-filter blocks per PRD-pool-sigma-filter), plus `isFavorite` ' +
+        'and `userProvidedInfo`. The pool itself is in canonical pool ordering ' +
+        '(`token0`/`token1`); use `userProvidedInfo.isToken0Quote` to pivot to the ' +
+        'user-intended base/quote orientation.',
+      inputSchema,
+    },
+    handler: async (args: { [K in keyof typeof inputSchema]: z.infer<(typeof inputSchema)[K]> }) => {
+      const payload: Record<string, unknown> = {
+        base: args.base,
+        quote: args.quote,
+        chainIds: args.chainIds,
+      };
+      if (args.sortBy) payload.sortBy = args.sortBy;
+      if (args.sortDirection) payload.sortDirection = args.sortDirection;
+      if (typeof args.limit === 'number') payload.limit = args.limit;
+
+      const results = await client.post<Parameters<typeof formatPoolSearchResult>[0][]>(
+        '/api/v1/pools/uniswapv3/search',
+        payload
+      );
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(results.map(formatPoolSearchResult), null, 2),
+          },
+        ],
+      };
+    },
+  };
+}

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/context/CreatePositionWizardContext.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/context/CreatePositionWizardContext.tsx
@@ -232,13 +232,20 @@ function wizardReducer(
     case 'SET_POOL_TAB':
       return { ...state, poolSelectionTab: action.tab };
 
-    case 'SELECT_POOL':
-      // Default: token0 is base, token1 is quote (user can swap later)
+    case 'SELECT_POOL': {
+      // Honor user-provided base/quote orientation when present
+      // (search-tab and favorites-tab results carry it). For results
+      // without orientation (Direct Address tab), fall back to the
+      // pool-native default: token0 = base, token1 = quote. The Flip
+      // button still works either way.
+      const isToken0Quote = action.pool.userProvidedInfo?.isToken0Quote;
+      const baseToken = isToken0Quote === true ? action.pool.token1 : action.pool.token0;
+      const quoteToken = isToken0Quote === true ? action.pool.token0 : action.pool.token1;
       return {
         ...state,
         selectedPool: action.pool,
-        baseToken: action.pool.token0,
-        quoteToken: action.pool.token1,
+        baseToken,
+        quoteToken,
         // Reset tick range (will be set when current tick is fetched)
         tickLower: 0,
         tickUpper: 0,
@@ -263,6 +270,7 @@ function wizardReducer(
         totalQuoteValue: '0',
         liquidity: '0',
       };
+    }
 
     case 'CLEAR_POOL':
       return {

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTable.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTable.tsx
@@ -203,7 +203,16 @@ export function PoolTable({
                   <td className="py-3">
                     <div className="flex flex-col">
                       <span className="font-medium">
-                        {pool.token0.symbol} / {pool.token1.symbol}
+                        {(() => {
+                          // Render in user-intended base/quote orientation when
+                          // the result carries userProvidedInfo (search / favorites).
+                          // Direct-Address results have no orientation → fall back
+                          // to pool-native token0/token1 ordering.
+                          const isToken0Quote = pool.userProvidedInfo?.isToken0Quote;
+                          const baseSymbol = isToken0Quote === true ? pool.token1.symbol : pool.token0.symbol;
+                          const quoteSymbol = isToken0Quote === true ? pool.token0.symbol : pool.token1.symbol;
+                          return `${baseSymbol} / ${quoteSymbol}`;
+                        })()}
                       </span>
                       <span className="text-sm text-slate-400">
                         {pool.chainName} • {formatFeeTier(pool.feeTier)}

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/steps/PoolSelectionStep.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/steps/PoolSelectionStep.tsx
@@ -60,19 +60,19 @@ export function PoolSelectionStep() {
   const discoverPool = useDiscoverPool();
 
   // Token set state - arrays of selected tokens
-  const [tokenSetA, setTokenSetA] = useState<TokenSearchResult[]>([]);
-  const [tokenSetB, setTokenSetB] = useState<TokenSearchResult[]>([]);
+  const [baseTokens, setBaseTokens] = useState<TokenSearchResult[]>([]);
+  const [quoteTokens, setQuoteTokens] = useState<TokenSearchResult[]>([]);
   const [directAddress, setDirectAddress] = useState('');
   const [selectedChainIds, setSelectedChainIds] = useState<number[]>([1, 42161, 8453]); // Ethereum, Arbitrum, Base
 
   // Pool search hook
   const { pools, isLoading } = usePoolSearch({
-    tokenSetA: tokenSetA.map((t) => t.symbol),
-    tokenSetB: tokenSetB.map((t) => t.symbol),
+    base: baseTokens.map((t) => t.symbol),
+    quote: quoteTokens.map((t) => t.symbol),
     chainIds: selectedChainIds,
     sortBy: 'tvlUSD',
     limit: 50,
-    enabled: state.poolSelectionTab === 'search' && tokenSetA.length > 0 && tokenSetB.length > 0,
+    enabled: state.poolSelectionTab === 'search' && baseTokens.length > 0 && quoteTokens.length > 0,
   });
 
   // Toggle favorite mutation
@@ -105,7 +105,9 @@ export function PoolSelectionStep() {
     enabled: state.poolSelectionTab === 'direct' && isValidEthereumAddress(debouncedAddress),
   });
 
-  // Transform FavoritePoolItem to PoolSearchResultItem for PoolTable
+  // Transform FavoritePoolItem to PoolSearchResultItem for PoolTable.
+  // Forward stored userProvidedInfo so downstream consumers (the wizard
+  // SELECT_POOL reducer, the favorite-toggle handler) can read the orientation.
   const transformFavoriteToSearchResult = useCallback(
     (favorite: FavoritePoolItem): PoolSearchResultItem => {
       const chainMeta = getChainMetadataByChainId(favorite.chainId);
@@ -126,6 +128,9 @@ export function PoolSelectionStep() {
         },
         metrics: favorite.metrics,
         isFavorite: true,
+        ...(favorite.userProvidedInfo && {
+          userProvidedInfo: favorite.userProvidedInfo,
+        }),
       };
     },
     []
@@ -139,25 +144,25 @@ export function PoolSelectionStep() {
 
   // Token selection handlers
   const handleTokenASelect = useCallback((token: TokenSearchResult) => {
-    setTokenSetA((prev) => {
+    setBaseTokens((prev) => {
       if (prev.some((t) => t.symbol === token.symbol)) return prev;
       return [...prev, token];
     });
   }, []);
 
   const handleTokenARemove = useCallback((token: TokenSearchResult) => {
-    setTokenSetA((prev) => prev.filter((t) => t.symbol !== token.symbol));
+    setBaseTokens((prev) => prev.filter((t) => t.symbol !== token.symbol));
   }, []);
 
   const handleTokenBSelect = useCallback((token: TokenSearchResult) => {
-    setTokenSetB((prev) => {
+    setQuoteTokens((prev) => {
       if (prev.some((t) => t.symbol === token.symbol)) return prev;
       return [...prev, token];
     });
   }, []);
 
   const handleTokenBRemove = useCallback((token: TokenSearchResult) => {
-    setTokenSetB((prev) => prev.filter((t) => t.symbol !== token.symbol));
+    setQuoteTokens((prev) => prev.filter((t) => t.symbol !== token.symbol));
   }, []);
 
   // Chain toggle handler
@@ -169,7 +174,20 @@ export function PoolSelectionStep() {
     );
   }, []);
 
-  // Handle favorite toggle
+  // Handle favorite toggle.
+  //
+  // Forward `pool.userProvidedInfo?.isToken0Quote` on the add path so the
+  // favorite is persisted with the active base/quote orientation:
+  //   - Search-tab results carry the user's currently-selected orientation
+  //     (derived server-side from the search request's `quote` array) →
+  //     forwarded unchanged.
+  //   - Favorites-tab results carry the previously-stored orientation →
+  //     re-favoriting from this tab is a no-op for role.
+  //   - Direct-Address results have no orientation — forwarded as undefined
+  //     (legacy-equivalent storage).
+  //
+  // On the remove path, the role is irrelevant — toggleFavorite.mutate
+  // ignores `isToken0Quote` when `isFavorite === true`.
   const handleToggleFavorite = useCallback(
     (pool: PoolSearchResultItem) => {
       toggleFavorite.mutate({
@@ -177,6 +195,9 @@ export function PoolSelectionStep() {
         chainId: pool.chainId,
         poolAddress: pool.poolAddress,
         isFavorite: pool.isFavorite ?? false,
+        ...(pool.userProvidedInfo && {
+          isToken0Quote: pool.userProvidedInfo.isToken0Quote,
+        }),
       });
     },
     [toggleFavorite]
@@ -200,6 +221,9 @@ export function PoolSelectionStep() {
         const result = await discoverPool.mutateAsync({
           chainId: pool.chainId,
           address: pool.poolAddress,
+          ...(pool.userProvidedInfo && {
+            isToken0Quote: pool.userProvidedInfo.isToken0Quote,
+          }),
         });
         // Deserialize JSON to class instance for proper method access
         const poolInstance = UniswapV3Pool.fromJSON(result.pool as unknown as PoolJSON);
@@ -282,24 +306,24 @@ export function PoolSelectionStep() {
         <div className="space-y-4">
           <TokenSetSearchInput
             label="Base Token"
-            selectedTokens={tokenSetA}
+            selectedTokens={baseTokens}
             onTokenSelect={handleTokenASelect}
             onTokenRemove={handleTokenARemove}
             chainIds={selectedChainIds}
             placeholder="Search..."
             maxTokens={4}
-            excludeTokens={tokenSetB}
+            excludeTokens={quoteTokens}
           />
 
           <TokenSetSearchInput
             label="Quote Token"
-            selectedTokens={tokenSetB}
+            selectedTokens={quoteTokens}
             onTokenSelect={handleTokenBSelect}
             onTokenRemove={handleTokenBRemove}
             chainIds={selectedChainIds}
             placeholder="Search..."
             maxTokens={4}
-            excludeTokens={tokenSetA}
+            excludeTokens={baseTokens}
           />
 
           <div className="flex items-center gap-4">

--- a/apps/midcurve-ui/src/hooks/pools/useDiscoverPool.ts
+++ b/apps/midcurve-ui/src/hooks/pools/useDiscoverPool.ts
@@ -4,6 +4,9 @@
  * React Query mutation hook for discovering/persisting a pool by address.
  * Calls the backend which fetches on-chain data and persists to database.
  *
+ * Optionally accepts `isToken0Quote` to round-trip the user's intended
+ * base/quote orientation back via `userProvidedInfo` on the response.
+ *
  * Usage:
  * ```tsx
  * const { mutateAsync: discoverPool, isPending } = useDiscoverPool();
@@ -13,8 +16,10 @@
  *     const result = await discoverPool({
  *       chainId: pool.chainId,
  *       address: pool.poolAddress,
+ *       isToken0Quote: pool.userProvidedInfo?.isToken0Quote,
  *     });
  *     // result.pool is the fully populated UniswapV3Pool
+ *     // result.userProvidedInfo echoes the requested orientation (when supplied)
  *   } catch (error) {
  *     // Handle error
  *   }
@@ -24,7 +29,7 @@
 
 import { useMutation } from '@tanstack/react-query';
 import type { UniswapV3Pool } from '@midcurve/shared';
-import type { GetUniswapV3PoolData } from '@midcurve/api-shared';
+import type { GetUniswapV3PoolData, PoolUserProvidedInfo } from '@midcurve/api-shared';
 import { apiClient } from '@/lib/api-client';
 
 export interface DiscoverPoolParams {
@@ -37,6 +42,12 @@ export interface DiscoverPoolParams {
    * Pool contract address
    */
   address: string;
+
+  /**
+   * Optional base/quote orientation to round-trip via `userProvidedInfo`
+   * on the response. Pure echo — server does not reorient metrics/feeData.
+   */
+  isToken0Quote?: boolean;
 }
 
 export interface DiscoverPoolResult {
@@ -44,6 +55,12 @@ export interface DiscoverPoolResult {
    * The discovered pool data with fresh on-chain state
    */
   pool: UniswapV3Pool;
+
+  /**
+   * Echoed base/quote orientation when `isToken0Quote` was supplied in the
+   * request. Undefined when the caller did not pass an orientation.
+   */
+  userProvidedInfo?: PoolUserProvidedInfo;
 }
 
 /**
@@ -56,12 +73,21 @@ export interface DiscoverPoolResult {
  */
 export function useDiscoverPool() {
   return useMutation({
-    mutationFn: async ({ chainId, address }: DiscoverPoolParams): Promise<DiscoverPoolResult> => {
-      const response = await apiClient.get<GetUniswapV3PoolData>(
-        `/api/v1/pools/uniswapv3/${chainId}/${address}`
-      );
+    mutationFn: async ({
+      chainId,
+      address,
+      isToken0Quote,
+    }: DiscoverPoolParams): Promise<DiscoverPoolResult> => {
+      const url =
+        typeof isToken0Quote === 'boolean'
+          ? `/api/v1/pools/uniswapv3/${chainId}/${address}?isToken0Quote=${isToken0Quote}`
+          : `/api/v1/pools/uniswapv3/${chainId}/${address}`;
+      const response = await apiClient.get<GetUniswapV3PoolData>(url);
       return {
         pool: response.data.pool,
+        ...(response.data.userProvidedInfo && {
+          userProvidedInfo: response.data.userProvidedInfo,
+        }),
       };
     },
   });

--- a/apps/midcurve-ui/src/hooks/pools/usePoolFavorites.ts
+++ b/apps/midcurve-ui/src/hooks/pools/usePoolFavorites.ts
@@ -86,12 +86,16 @@ export function usePoolFavorites({
 // ============================================================================
 
 /**
- * Input for adding a pool to favorites
+ * Input for adding a pool to favorites.
+ *
+ * `isToken0Quote` (optional) pins a base/quote orientation to the favorite —
+ * surfaces on subsequent reads via `FavoritePoolItem.userProvidedInfo`.
  */
 export interface AddFavoriteInput {
   protocol: string;
   chainId: number;
   poolAddress: string;
+  isToken0Quote?: boolean;
 }
 
 /**
@@ -104,7 +108,14 @@ export function useAddPoolFavorite() {
     mutationFn: async (input: AddFavoriteInput) => {
       const response = await apiClient.post<AddFavoritePoolData>(
         '/api/v1/pools/favorites',
-        input
+        {
+          protocol: input.protocol,
+          chainId: input.chainId,
+          poolAddress: input.poolAddress,
+          ...(typeof input.isToken0Quote === 'boolean' && {
+            isToken0Quote: input.isToken0Quote,
+          }),
+        }
       );
       return response.data;
     },
@@ -173,13 +184,18 @@ export function useRemovePoolFavorite() {
 // ============================================================================
 
 /**
- * Input for toggling a pool's favorite status
+ * Input for toggling a pool's favorite status.
+ *
+ * On the add path, `isToken0Quote` (optional) pins the base/quote orientation
+ * for the favorite — typically forwarded from the active search result's
+ * `userProvidedInfo.isToken0Quote`. Ignored on the remove path.
  */
 export interface ToggleFavoriteInput {
   protocol: string;
   chainId: number;
   poolAddress: string;
   isFavorite: boolean;
+  isToken0Quote?: boolean;
 }
 
 /**
@@ -206,13 +222,17 @@ export function useTogglePoolFavorite() {
         );
         return { action: 'removed' as const, data: response.data };
       } else {
-        // Not favorited, so add
+        // Not favorited, so add — forward isToken0Quote if the caller has
+        // an active orientation (search-tab path); omit otherwise.
         const response = await apiClient.post<AddFavoritePoolData>(
           '/api/v1/pools/favorites',
           {
             protocol: input.protocol,
             chainId: input.chainId,
             poolAddress: input.poolAddress,
+            ...(typeof input.isToken0Quote === 'boolean' && {
+              isToken0Quote: input.isToken0Quote,
+            }),
           }
         );
         return { action: 'added' as const, data: response.data };

--- a/apps/midcurve-ui/src/hooks/pools/usePoolSearch.ts
+++ b/apps/midcurve-ui/src/hooks/pools/usePoolSearch.ts
@@ -1,14 +1,15 @@
 /**
  * usePoolSearch Hook
  *
- * React Query hook for searching Uniswap V3 pools by token sets.
- * Returns pools with favorite status for authenticated users.
+ * React Query hook for searching Uniswap V3 pools by base/quote token sets.
+ * Returns pools annotated with `userProvidedInfo.isToken0Quote` (derived
+ * from the quote-side input) and `isFavorite` for authenticated users.
  *
  * Usage:
  * ```tsx
  * const { pools, isLoading, error } = usePoolSearch({
- *   tokenSetA: ['WETH', 'stETH'],
- *   tokenSetB: ['USDC', 'USDT'],
+ *   base: ['WETH', 'stETH'],
+ *   quote: ['USDC', 'USDT'],
  *   chainIds: [1, 42161],
  *   sortBy: 'apr7d',
  *   limit: 20,
@@ -22,20 +23,25 @@ import { apiClient } from '@/lib/api-client';
 import { queryKeys } from '@/lib/query-keys';
 
 /**
- * Search parameters for pool search
+ * Search parameters for pool search.
+ *
+ * `base`/`quote` accept exact token symbols (case-insensitive — must match a
+ * CoinGecko symbol exactly) or EIP-55 addresses. Fuzzy/prefix resolution is
+ * the consumer's responsibility (the token picker upstream handles it).
  */
 export interface PoolSearchParams {
   /**
-   * First set of tokens (addresses or symbols)
+   * Base side of the pair.
    * @example ["WETH", "stETH"]
    */
-  tokenSetA: string[];
+  base: string[];
 
   /**
-   * Second set of tokens (addresses or symbols)
+   * Quote side of the pair. Determines `userProvidedInfo.isToken0Quote`
+   * on each result.
    * @example ["USDC", "USDT"]
    */
-  tokenSetB: string[];
+  quote: string[];
 
   /**
    * Chain IDs to search on
@@ -110,16 +116,17 @@ export interface UsePoolSearchReturn {
  *
  * Features:
  * - Multi-chain search
- * - Symbol or address input
+ * - Symbol or address input (exact match — see PoolSearchParams)
  * - Favorite status enrichment
+ * - Per-result `userProvidedInfo.isToken0Quote` orientation
  * - Sorting by various metrics
  *
  * @param props - Search parameters
  * @returns Pool search results and query state
  */
 export function usePoolSearch({
-  tokenSetA,
-  tokenSetB,
+  base,
+  quote,
   chainIds,
   sortBy = 'tvlUSD',
   sortDirection = 'desc',
@@ -127,12 +134,12 @@ export function usePoolSearch({
   enabled = true,
 }: UsePoolSearchProps): UsePoolSearchReturn {
   // Only enable query when both token sets have at least one token
-  const hasValidInput = tokenSetA.length > 0 && tokenSetB.length > 0 && chainIds.length > 0;
+  const hasValidInput = base.length > 0 && quote.length > 0 && chainIds.length > 0;
 
   const query = useQuery({
     queryKey: queryKeys.pools.uniswapv3.search({
-      tokenSetA,
-      tokenSetB,
+      base,
+      quote,
       chainIds,
       sortBy,
       limit,
@@ -141,8 +148,8 @@ export function usePoolSearch({
       const response = await apiClient.post<PoolSearchResponse['data']>(
         '/api/v1/pools/uniswapv3/search',
         {
-          tokenSetA,
-          tokenSetB,
+          base,
+          quote,
           chainIds,
           sortBy,
           sortDirection,

--- a/apps/midcurve-ui/src/lib/query-keys.ts
+++ b/apps/midcurve-ui/src/lib/query-keys.ts
@@ -148,11 +148,11 @@ export const queryKeys = {
       detail: (chainId: number, address: string) =>
         [...queryKeys.pools.uniswapv3.details(), chainId, address] as const,
 
-      // Search (token sets + chain IDs → list of pools)
+      // Search (base/quote token sets + chain IDs → list of pools)
       searches: () => [...queryKeys.pools.uniswapv3.all, 'search'] as const,
       search: (params: {
-        tokenSetA: string[];
-        tokenSetB: string[];
+        base: string[];
+        quote: string[];
         chainIds: number[];
         sortBy?: string;
         limit?: number;

--- a/packages/midcurve-api-shared/package.json
+++ b/packages/midcurve-api-shared/package.json
@@ -54,6 +54,8 @@
     "dev": "tsup src/index.ts --format esm,cjs --dts --out-dir dist --watch",
     "clean": "rm -rf dist",
     "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run",
     "yalc:link": "yalc link @midcurve/shared && npm install",
     "yalc:update": "yalc update @midcurve/shared",
     "yalc:unlink": "yalc remove @midcurve/shared && npm install",

--- a/packages/midcurve-api-shared/src/types/pools/favorite-pools.ts
+++ b/packages/midcurve-api-shared/src/types/pools/favorite-pools.ts
@@ -12,6 +12,7 @@ import type { UniswapV3Pool } from '@midcurve/shared';
 import type { ApiResponse } from '../common/index.js';
 import type { BigIntToString } from '../common/serialization.js';
 import type { PoolMetricsBlock } from './pool-metrics-shared.js';
+import type { PoolUserProvidedInfo } from './pool-search.js';
 
 // ============================================================================
 // REQUEST TYPES
@@ -44,6 +45,15 @@ export interface AddFavoritePoolRequest {
    * @example "0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"
    */
   poolAddress: string;
+
+  /**
+   * Optional base/quote orientation to persist with the favorite.
+   *
+   * If provided, the favorite is stored with this orientation and returned
+   * via `FavoritePoolItem.userProvidedInfo` on subsequent reads. If omitted,
+   * the favorite is stored without orientation (matching legacy entries).
+   */
+  isToken0Quote?: boolean;
 }
 
 /**
@@ -139,6 +149,14 @@ export interface FavoritePoolItem {
    * verdict. See `PoolMetricsBlock` for the full schema.
    */
   metrics: PoolMetricsBlock;
+
+  /**
+   * Stored base/quote orientation for this favorite, if the user pinned one
+   * when favoriting (or has been re-favorited from a search result that
+   * carried orientation). Legacy entries that pre-date this field surface
+   * with `userProvidedInfo` undefined.
+   */
+  userProvidedInfo?: PoolUserProvidedInfo;
 }
 
 /**
@@ -258,6 +276,8 @@ export const AddFavoritePoolRequestSchema = z.object({
     .string()
     .min(1, 'Pool address is required')
     .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid pool address format'),
+
+  isToken0Quote: z.boolean().optional(),
 });
 
 /**
@@ -423,6 +443,15 @@ export interface GenericAddFavoritePoolRequest {
    * @example "0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"
    */
   poolAddress: string;
+
+  /**
+   * Optional base/quote orientation to persist with the favorite.
+   *
+   * If provided, the favorite is stored with this orientation and returned
+   * via `FavoritePoolItem.userProvidedInfo` on subsequent reads. If omitted,
+   * the favorite is stored without orientation (matching legacy entries).
+   */
+  isToken0Quote?: boolean;
 }
 
 /**
@@ -454,6 +483,8 @@ export const GenericAddFavoritePoolRequestSchema = z.object({
     .string()
     .min(1, 'Pool address is required')
     .regex(/^0x[a-fA-F0-9]{40}$/, 'Invalid pool address format'),
+
+  isToken0Quote: z.boolean().optional(),
 });
 
 /**

--- a/packages/midcurve-api-shared/src/types/pools/pool-search.test.ts
+++ b/packages/midcurve-api-shared/src/types/pools/pool-search.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { PoolSearchRequestSchema } from './pool-search.js';
+
+/**
+ * Pool search request validation — issue #45 same-token rejection.
+ *
+ * The schema rejects ONLY the trivial verbatim case:
+ * `|base| = |quote| = 1 ∧ base[0] === quote[0]` (after EIP-55 normalization
+ * for addresses, case-insensitive compare for symbols). Richer queries like
+ * `base=["WETH","stETH"], quote=["WETH","stETH"]` pass — per-chain
+ * self-exclusion in the service handles the cartesian product.
+ */
+describe('PoolSearchRequestSchema — trivial-case same-token rejection', () => {
+  const baseValid = {
+    chainIds: [1],
+    sortBy: 'tvlUSD' as const,
+    sortDirection: 'desc' as const,
+    limit: 20,
+  };
+
+  it('accepts a normal query', () => {
+    const r = PoolSearchRequestSchema.safeParse({
+      ...baseValid,
+      base: ['WETH'],
+      quote: ['USDC'],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects |base|=|quote|=1 with identical symbol', () => {
+    const r = PoolSearchRequestSchema.safeParse({
+      ...baseValid,
+      base: ['WETH'],
+      quote: ['WETH'],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects |base|=|quote|=1 with case-different symbol (case-insensitive compare)', () => {
+    const r = PoolSearchRequestSchema.safeParse({
+      ...baseValid,
+      base: ['WETH'],
+      quote: ['weth'],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects |base|=|quote|=1 with same address in different cases (EIP-55 normalize)', () => {
+    const lower = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const checksummed = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+    const r = PoolSearchRequestSchema.safeParse({
+      ...baseValid,
+      base: [lower],
+      quote: [checksummed],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts the WETH/stETH-on-both-sides shape (cartesian product yields valid pairs)', () => {
+    const r = PoolSearchRequestSchema.safeParse({
+      ...baseValid,
+      base: ['WETH', 'stETH'],
+      quote: ['WETH', 'stETH'],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts |base|=2, |quote|=1 even when the single quote is in base', () => {
+    const r = PoolSearchRequestSchema.safeParse({
+      ...baseValid,
+      base: ['WETH', 'stETH'],
+      quote: ['WETH'],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects empty base or quote arrays (min(1))', () => {
+    expect(
+      PoolSearchRequestSchema.safeParse({ ...baseValid, base: [], quote: ['USDC'] }).success
+    ).toBe(false);
+    expect(
+      PoolSearchRequestSchema.safeParse({ ...baseValid, base: ['WETH'], quote: [] }).success
+    ).toBe(false);
+  });
+
+  it('preserves defaults for sortBy / sortDirection / limit when omitted', () => {
+    const r = PoolSearchRequestSchema.safeParse({
+      base: ['WETH'],
+      quote: ['USDC'],
+      chainIds: [1],
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.sortBy).toBe('tvlUSD');
+      expect(r.data.sortDirection).toBe('desc');
+      expect(r.data.limit).toBe(20);
+    }
+  });
+});

--- a/packages/midcurve-api-shared/src/types/pools/pool-search.ts
+++ b/packages/midcurve-api-shared/src/types/pools/pool-search.ts
@@ -2,10 +2,11 @@
  * Pool Search Endpoint Types
  *
  * Types for the POST /api/v1/pools/uniswapv3/search endpoint.
- * Allows searching for pools by token sets across multiple chains.
+ * Allows searching for pools by base/quote token sets across multiple chains.
  */
 
 import { z } from 'zod';
+import { isValidAddress, normalizeAddress } from '@midcurve/shared';
 import type { ApiResponse } from '../common/index.js';
 import type { PoolMetricsBlock } from './pool-metrics-shared.js';
 
@@ -16,29 +17,39 @@ import type { PoolMetricsBlock } from './pool-metrics-shared.js';
 /**
  * POST /api/v1/pools/uniswapv3/search - Request body
  *
- * Search for pools matching token sets across multiple chains.
+ * Search for pools matching base × quote token sets across multiple chains.
+ *
+ * Each pool result is annotated with `userProvidedInfo.isToken0Quote`,
+ * derived per result by checking which of the pool's token0/token1 appears
+ * in the `quote` array.
+ *
+ * **Symbol/address contract**: `base` and `quote` accept exact token symbols
+ * (case-insensitive — must match a CoinGecko symbol exactly) or EIP-55
+ * addresses. Fuzzy / prefix resolution is the consumer's responsibility —
+ * passing `"eth"` will not match `WETH`/`stETH`/`rETH`.
  */
 export interface PoolSearchRequest {
   /**
-   * First set of tokens (addresses or symbols)
+   * Base side of the pair.
    *
-   * Can be:
-   * - Token addresses (e.g., "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
-   * - Token symbols (e.g., "WETH", "stETH")
+   * Accepts exact token symbols (case-insensitive — must match a CoinGecko
+   * symbol exactly) or EIP-55 addresses. Fuzzy / prefix resolution is the
+   * consumer's responsibility.
    *
    * @example ["WETH", "stETH"]
    * @example ["0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"]
    */
-  tokenSetA: string[];
+  base: string[];
 
   /**
-   * Second set of tokens (addresses or symbols)
+   * Quote side of the pair.
    *
-   * Same format as tokenSetA.
+   * Same format as `base`. The cartesian product `base × quote` is searched
+   * (with same-token-on-both-sides pairs excluded per chain).
    *
    * @example ["USDC", "USDT", "DAI"]
    */
-  tokenSetB: string[];
+  quote: string[];
 
   /**
    * Chain IDs to search on
@@ -100,6 +111,23 @@ export interface PoolSearchTokenInfo {
 }
 
 /**
+ * User-provided role annotation echoed onto a pool result.
+ *
+ * Carries the user's intended base/quote orientation derived from the
+ * search request (or echoed from the pool detail endpoint). Pool itself
+ * remains role-agnostic — this is purely query-side metadata.
+ */
+export interface PoolUserProvidedInfo {
+  /**
+   * Whether the pool's `token0` is the quote side from the user's perspective.
+   *
+   * `true` → token0 = quote, token1 = base
+   * `false` → token0 = base, token1 = quote
+   */
+  isToken0Quote: boolean;
+}
+
+/**
  * Single pool search result
  */
 export interface PoolSearchResultItem {
@@ -130,6 +158,14 @@ export interface PoolSearchResultItem {
    * undefined/missing when not authenticated.
    */
   isFavorite?: boolean;
+
+  /**
+   * User-provided role annotation derived from the search request's
+   * `quote` array. Indicates which of `token0`/`token1` the user intends
+   * as the quote side, allowing consumers to render pairs in user-intended
+   * orientation regardless of pool-native token order.
+   */
+  userProvidedInfo?: PoolUserProvidedInfo;
 }
 
 /**
@@ -168,54 +204,83 @@ export interface PoolSearchResponse extends ApiResponse<PoolSearchData> {
 const SUPPORTED_CHAIN_IDS = [1, 42161, 8453, 10, 137] as const;
 
 /**
- * POST /api/v1/pools/uniswapv3/search - Request validation
+ * Canonicalize a `base` / `quote` entry for verbatim equality comparison.
+ * - Addresses: EIP-55 normalized.
+ * - Symbols: uppercased (case-insensitive compare).
  */
-export const PoolSearchRequestSchema = z.object({
-  tokenSetA: z
-    .array(z.string().min(1, 'Token cannot be empty'))
-    .min(1, 'tokenSetA must have at least one token')
-    .max(10, 'tokenSetA cannot have more than 10 tokens'),
+function canonicalizeTokenInput(input: string): string {
+  if (isValidAddress(input)) {
+    return normalizeAddress(input);
+  }
+  return input.toUpperCase();
+}
 
-  tokenSetB: z
-    .array(z.string().min(1, 'Token cannot be empty'))
-    .min(1, 'tokenSetB must have at least one token')
-    .max(10, 'tokenSetB cannot have more than 10 tokens'),
+/**
+ * POST /api/v1/pools/uniswapv3/search - Request validation
+ *
+ * Trivial-case rejection: rejects only `|base| = |quote| = 1 ∧ base[0] === quote[0]`
+ * (after EIP-55 normalize for addresses, case-insensitive compare for symbols).
+ * Richer queries like `base=["WETH","stETH"], quote=["WETH","stETH"]` pass and
+ * are handled at the service layer with per-chain self-exclusion.
+ */
+export const PoolSearchRequestSchema = z
+  .object({
+    base: z
+      .array(z.string().min(1, 'Token cannot be empty'))
+      .min(1, 'base must have at least one token')
+      .max(10, 'base cannot have more than 10 tokens'),
 
-  chainIds: z
-    .array(
-      z
-        .number()
-        .int('Chain ID must be an integer')
-        .refine(
-          (id) => SUPPORTED_CHAIN_IDS.includes(id as (typeof SUPPORTED_CHAIN_IDS)[number]),
-          (id) => ({ message: `Chain ID ${id} is not supported. Supported: ${SUPPORTED_CHAIN_IDS.join(', ')}` })
-        )
-    )
-    .min(1, 'At least one chain ID is required')
-    .max(5, 'Cannot search more than 5 chains at once'),
+    quote: z
+      .array(z.string().min(1, 'Token cannot be empty'))
+      .min(1, 'quote must have at least one token')
+      .max(10, 'quote cannot have more than 10 tokens'),
 
-  sortBy: z
-    .enum([
-      'tvlUSD',
-      'volume24hUSD',
-      'fees24hUSD',
-      'volume7dAvgUSD',
-      'fees7dAvgUSD',
-      'apr7d',
-    ])
-    .optional()
-    .default('tvlUSD'),
+    chainIds: z
+      .array(
+        z
+          .number()
+          .int('Chain ID must be an integer')
+          .refine(
+            (id) => SUPPORTED_CHAIN_IDS.includes(id as (typeof SUPPORTED_CHAIN_IDS)[number]),
+            (id) => ({ message: `Chain ID ${id} is not supported. Supported: ${SUPPORTED_CHAIN_IDS.join(', ')}` })
+          )
+      )
+      .min(1, 'At least one chain ID is required')
+      .max(5, 'Cannot search more than 5 chains at once'),
 
-  sortDirection: z.enum(['asc', 'desc']).optional().default('desc'),
+    sortBy: z
+      .enum([
+        'tvlUSD',
+        'volume24hUSD',
+        'fees24hUSD',
+        'volume7dAvgUSD',
+        'fees7dAvgUSD',
+        'apr7d',
+      ])
+      .optional()
+      .default('tvlUSD'),
 
-  limit: z
-    .number()
-    .int('Limit must be an integer')
-    .min(1, 'Limit must be at least 1')
-    .max(100, 'Limit cannot exceed 100')
-    .optional()
-    .default(20),
-});
+    sortDirection: z.enum(['asc', 'desc']).optional().default('desc'),
+
+    limit: z
+      .number()
+      .int('Limit must be an integer')
+      .min(1, 'Limit must be at least 1')
+      .max(100, 'Limit cannot exceed 100')
+      .optional()
+      .default(20),
+  })
+  .refine(
+    (data) => {
+      if (data.base.length !== 1 || data.quote.length !== 1) return true;
+      return canonicalizeTokenInput(data.base[0]!) !== canonicalizeTokenInput(data.quote[0]!);
+    },
+    {
+      message:
+        'base and quote cannot be the same single token. Provide at least one differing token to express the desired pair.',
+      path: ['quote'],
+    }
+  );
 
 /**
  * Inferred type from schema (for runtime validation)

--- a/packages/midcurve-api-shared/src/types/pools/uniswapv3.ts
+++ b/packages/midcurve-api-shared/src/types/pools/uniswapv3.ts
@@ -8,7 +8,7 @@
 import { z } from 'zod';
 import type { UniswapV3Pool } from '@midcurve/shared';
 import type { ApiResponse } from '../common/index.js';
-import type { PoolSearchResultItem } from './pool-search.js';
+import type { PoolSearchResultItem, PoolUserProvidedInfo } from './pool-search.js';
 import type { PoolMetricsBlock } from './pool-metrics-shared.js';
 
 /**
@@ -45,6 +45,19 @@ export interface GetUniswapV3PoolQuery {
    * @example true
    */
   fees?: boolean;
+
+  /**
+   * Optional base/quote orientation echoed back via
+   * `userProvidedInfo.isToken0Quote` on the response.
+   *
+   * When `true`/`false`, the response includes
+   * `userProvidedInfo: { isToken0Quote }`. When omitted, the field is not
+   * included and the response uses pool-native token0/token1 ordering.
+   *
+   * Pure echo — metrics/feeData are not reoriented based on this flag.
+   * @example true
+   */
+  isToken0Quote?: boolean;
 }
 
 /**
@@ -112,6 +125,13 @@ export interface GetUniswapV3PoolData {
      */
     calculatedAt: string;
   };
+
+  /**
+   * User-provided role annotation echoed from the `isToken0Quote` query
+   * parameter. Only present when the request supplied that param. Pool
+   * itself remains role-agnostic — this is purely query-side metadata.
+   */
+  userProvidedInfo?: PoolUserProvidedInfo;
 }
 
 /**
@@ -157,6 +177,12 @@ export const GetUniswapV3PoolQuerySchema = z.object({
     .default('false')
     .transform((val) => val === 'true')
     .pipe(z.boolean()),
+
+  isToken0Quote: z
+    .string()
+    .optional()
+    .transform((val) => (val === undefined ? undefined : val === 'true'))
+    .pipe(z.boolean().optional()),
 });
 
 // ============================================================================

--- a/packages/midcurve-services/src/services/favorite-pool/favorite-pool-service.ts
+++ b/packages/midcurve-services/src/services/favorite-pool/favorite-pool-service.ts
@@ -46,6 +46,11 @@ export interface FavoritePoolResult {
   poolId: string;
   /** The full pool object */
   pool: UniswapV3Pool;
+  /**
+   * Stored base/quote orientation for this favorite. Undefined for legacy
+   * entries or favorites added without a role context.
+   */
+  isToken0Quote?: boolean;
 }
 
 /**
@@ -142,8 +147,13 @@ export class FavoritePoolService {
    * If the pool is already favorited, moves it to the front (most recent).
    */
   async addFavorite(input: AddFavoritePoolInput): Promise<FavoritePoolResult> {
-    const { userId, chainId, poolAddress } = input;
-    log.methodEntry(this.logger, 'addFavorite', { userId, chainId, poolAddress });
+    const { userId, chainId, poolAddress, isToken0Quote } = input;
+    log.methodEntry(this.logger, 'addFavorite', {
+      userId,
+      chainId,
+      poolAddress,
+      isToken0Quote,
+    });
 
     // 1. Discover the pool (this triggers token discovery as well)
     this.logger.debug(
@@ -161,27 +171,35 @@ export class FavoritePoolService {
       'Pool discovered successfully'
     );
 
-    // 2. Store pool hash in user settings
+    // 2. Store pool hash + optional orientation in user settings
     const poolHash = this.poolService.createHash({
       chainId,
       address: poolAddress,
     });
 
-    await this.userSettingsService.addFavoritePoolHash(userId, poolHash);
+    await this.userSettingsService.addFavoritePoolEntry(
+      userId,
+      poolHash,
+      isToken0Quote
+    );
 
     this.logger.info(
-      { userId, poolHash, poolId: pool.id },
+      { userId, poolHash, poolId: pool.id, isToken0Quote },
       'Pool added to favorites'
     );
 
     log.methodExit(this.logger, 'addFavorite', { poolHash });
 
-    return {
+    const result: FavoritePoolResult = {
       poolHash,
       userId,
       poolId: pool.id,
       pool,
     };
+    if (typeof isToken0Quote === 'boolean') {
+      result.isToken0Quote = isToken0Quote;
+    }
+    return result;
   }
 
   // ============================================================================
@@ -203,7 +221,7 @@ export class FavoritePoolService {
       address: poolAddress,
     });
 
-    await this.userSettingsService.removeFavoritePoolHash(userId, poolHash);
+    await this.userSettingsService.removeFavoritePoolEntry(userId, poolHash);
 
     this.logger.info(
       { userId, poolHash },
@@ -227,13 +245,13 @@ export class FavoritePoolService {
     const { userId, limit = 50, offset = 0 } = input;
     log.methodEntry(this.logger, 'listFavorites', { userId, limit, offset });
 
-    // 1. Get favorite pool hashes from settings
-    const allHashes = await this.userSettingsService.getFavoritePoolHashes(userId);
+    // 1. Get favorite pool entries from settings (lazy-normalized from storage)
+    const allEntries = await this.userSettingsService.getFavoritePoolEntries(userId);
 
     // 2. Apply pagination
-    const paginatedHashes = allHashes.slice(offset, offset + limit);
+    const paginatedEntries = allEntries.slice(offset, offset + limit);
 
-    if (paginatedHashes.length === 0) {
+    if (paginatedEntries.length === 0) {
       log.methodExit(this.logger, 'listFavorites', { count: 0 });
       return [];
     }
@@ -242,10 +260,10 @@ export class FavoritePoolService {
     // Hash format: "uniswapv3/{chainId}/{poolAddress}"
     const results: FavoritePoolResult[] = [];
 
-    for (const hash of paginatedHashes) {
-      const parts = hash.split('/');
+    for (const entry of paginatedEntries) {
+      const parts = entry.hash.split('/');
       if (parts.length !== 3 || parts[0] !== 'uniswapv3') {
-        this.logger.debug({ poolHash: hash }, 'Invalid pool hash format, skipping');
+        this.logger.debug({ poolHash: entry.hash }, 'Invalid pool hash format, skipping');
         continue;
       }
 
@@ -254,16 +272,20 @@ export class FavoritePoolService {
 
       const pool = await this.poolService.discover({ chainId, poolAddress });
       if (!pool) {
-        this.logger.debug({ poolHash: hash }, 'Pool discovery returned null, skipping');
+        this.logger.debug({ poolHash: entry.hash }, 'Pool discovery returned null, skipping');
         continue;
       }
 
-      results.push({
-        poolHash: hash,
+      const result: FavoritePoolResult = {
+        poolHash: entry.hash,
         userId,
         poolId: pool.id,
         pool,
-      });
+      };
+      if (typeof entry.isToken0Quote === 'boolean') {
+        result.isToken0Quote = entry.isToken0Quote;
+      }
+      results.push(result);
     }
 
     // 5. Enrich with metrics from subgraph
@@ -374,9 +396,8 @@ export class FavoritePoolService {
     }
 
     // Get all favorite hashes as a Set for O(1) lookups
-    const favoriteHashes = new Set(
-      await this.userSettingsService.getFavoritePoolHashes(userId)
-    );
+    const entries = await this.userSettingsService.getFavoritePoolEntries(userId);
+    const favoriteHashes = new Set(entries.map((e) => e.hash));
 
     const result = new Set<string>();
     for (const pool of pools) {
@@ -408,8 +429,8 @@ export class FavoritePoolService {
   async countFavorites(userId: string): Promise<number> {
     log.methodEntry(this.logger, 'countFavorites', { userId });
 
-    const hashes = await this.userSettingsService.getFavoritePoolHashes(userId);
-    const count = hashes.length;
+    const entries = await this.userSettingsService.getFavoritePoolEntries(userId);
+    const count = entries.length;
 
     log.methodExit(this.logger, 'countFavorites', { userId, count });
     return count;

--- a/packages/midcurve-services/src/services/pool-search/uniswapv3-pool-search-service.test.ts
+++ b/packages/midcurve-services/src/services/pool-search/uniswapv3-pool-search-service.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PrismaClient } from '@midcurve/database';
+import { UniswapV3PoolSearchService } from './uniswapv3-pool-search-service.js';
+import type { UniswapV3SubgraphClient, PoolSearchSubgraphResult } from '../../clients/subgraph/uniswapv3/index.js';
+import type { CoingeckoTokenService } from '../coingecko-token/index.js';
+import type { EvmConfig } from '../../config/evm.js';
+import { PoolSigmaFilterService } from '../volatility/index.js';
+
+/**
+ * Service-layer tests for UniswapV3PoolSearchService — issue #45.
+ *
+ * The schema-level tests in @midcurve/api-shared cover request validation;
+ * the UserSettings tests cover storage compat. These tests pin the
+ * service-layer logic that's unique to the issue:
+ *
+ *  1. Per-chain orientation derivation — when the same symbol resolves to
+ *     different on-chain addresses across chains (USDC@Mainnet vs USDC@Base,
+ *     where USDC sorts as token0 on Mainnet but token1 on Base), each
+ *     result must carry the correct per-chain `isToken0Quote`. This
+ *     exercises the `Map<chainId, Set<address>>` introduced for the
+ *     refinement.
+ *
+ *  2. Self-exclusion at the service layer — calling `searchPools` with a
+ *     trivial same-token pair (e.g. base=["WETH"], quote=["WETH"]) must
+ *     return [] gracefully without invoking the subgraph. The schema layer
+ *     already rejects this as 400, but the service must remain robust to
+ *     direct callers that bypass schema validation.
+ */
+
+// -----------------------------------------------------------------------------
+// Fixtures (real EIP-55 addresses on Mainnet and Base)
+// -----------------------------------------------------------------------------
+
+const MAINNET = 1;
+const BASE = 8453;
+
+const USDC_MAINNET = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'; // sorts < WETH
+const WETH_MAINNET = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const USDC_BASE = '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+const WETH_BASE = '0x4200000000000000000000000000000000000006'; // sorts < USDC
+
+function makeSubgraphPool(
+  chainId: number,
+  poolAddress: string,
+  token0: { address: string; symbol: string; decimals: number },
+  token1: { address: string; symbol: string; decimals: number },
+): PoolSearchSubgraphResult {
+  return {
+    poolAddress,
+    chainId,
+    feeTier: 500,
+    token0: { address: token0.address.toLowerCase(), symbol: token0.symbol, decimals: token0.decimals },
+    token1: { address: token1.address.toLowerCase(), symbol: token1.symbol, decimals: token1.decimals },
+    tvlUSD: '1000000',
+    volume24hUSD: '0',
+    fees24hUSD: '0',
+    fees7dUSD: '0',
+    volume7dAvgUSD: '0',
+    fees7dAvgUSD: '0',
+    apr7d: 0,
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Test setup
+// -----------------------------------------------------------------------------
+
+interface Mocks {
+  searchByTextAndChains: ReturnType<typeof vi.fn>;
+  validateSubgraphFactory: ReturnType<typeof vi.fn>;
+  searchPoolsByTokenSets: ReturnType<typeof vi.fn>;
+  enrichPools: ReturnType<typeof vi.fn>;
+  getChainConfig: ReturnType<typeof vi.fn>;
+}
+
+function buildService(mocks: Mocks): UniswapV3PoolSearchService {
+  return new UniswapV3PoolSearchService({
+    prisma: {} as unknown as PrismaClient,
+    subgraphClient: {
+      validateSubgraphFactory: mocks.validateSubgraphFactory,
+      searchPoolsByTokenSets: mocks.searchPoolsByTokenSets,
+    } as unknown as UniswapV3SubgraphClient,
+    coingeckoTokenService: {
+      searchByTextAndChains: mocks.searchByTextAndChains,
+    } as unknown as CoingeckoTokenService,
+    evmConfig: {
+      getChainConfig: mocks.getChainConfig,
+    } as unknown as EvmConfig,
+    poolSigmaFilterService: {
+      enrichPools: mocks.enrichPools,
+    } as unknown as PoolSigmaFilterService,
+  });
+}
+
+describe('UniswapV3PoolSearchService.searchPools — issue #45', () => {
+  let mocks: Mocks;
+
+  beforeEach(() => {
+    mocks = {
+      // Default: 'WETH' and 'USDC' resolve to per-chain addresses; everything
+      // else is unknown (empty result). Tests can override per-test.
+      searchByTextAndChains: vi.fn(async (text: string, _chainIds: number[]) => {
+        if (text.toUpperCase() === 'WETH') {
+          return [
+            {
+              symbol: 'WETH',
+              name: 'Wrapped Ether',
+              coingeckoId: 'weth',
+              addresses: [
+                { chainId: MAINNET, address: WETH_MAINNET },
+                { chainId: BASE, address: WETH_BASE },
+              ],
+            },
+          ];
+        }
+        if (text.toUpperCase() === 'USDC') {
+          return [
+            {
+              symbol: 'USDC',
+              name: 'USD Coin',
+              coingeckoId: 'usd-coin',
+              addresses: [
+                { chainId: MAINNET, address: USDC_MAINNET },
+                { chainId: BASE, address: USDC_BASE },
+              ],
+            },
+          ];
+        }
+        return [];
+      }),
+      validateSubgraphFactory: vi.fn(async () => true),
+      searchPoolsByTokenSets: vi.fn(async (chainId: number) => {
+        if (chainId === MAINNET) {
+          // Mainnet: USDC sorts lower than WETH → USDC = token0
+          return [makeSubgraphPool(
+            MAINNET,
+            '0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640',
+            { address: USDC_MAINNET, symbol: 'USDC', decimals: 6 },
+            { address: WETH_MAINNET, symbol: 'WETH', decimals: 18 },
+          )];
+        }
+        if (chainId === BASE) {
+          // Base: WETH (canonical wrapped-native at 0x4200…0006) sorts lower
+          // than USDC → WETH = token0
+          return [makeSubgraphPool(
+            BASE,
+            '0xd0b53D9277642d899DF5C87A3966A349A798F224',
+            { address: WETH_BASE, symbol: 'WETH', decimals: 18 },
+            { address: USDC_BASE, symbol: 'USDC', decimals: 6 },
+          )];
+        }
+        return [];
+      }),
+      enrichPools: vi.fn(async () => new Map()),
+      getChainConfig: vi.fn((chainId: number) => ({
+        name: chainId === MAINNET ? 'Ethereum' : chainId === BASE ? 'Base' : `Chain ${chainId}`,
+      })),
+    };
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 1: per-chain orientation derivation
+  // ---------------------------------------------------------------------------
+
+  describe('per-chain isToken0Quote derivation', () => {
+    it('derives orientation per-chain when same symbol resolves to different addresses across chains', async () => {
+      const service = buildService(mocks);
+
+      const results = await service.searchPools({
+        base: ['WETH'],
+        quote: ['USDC'],
+        chainIds: [MAINNET, BASE],
+      });
+
+      expect(results).toHaveLength(2);
+
+      const mainnet = results.find((r) => r.chainId === MAINNET);
+      const base = results.find((r) => r.chainId === BASE);
+
+      // Mainnet pool: token0 = USDC ∈ quote → isToken0Quote = true
+      expect(mainnet?.token0.address.toLowerCase()).toBe(USDC_MAINNET.toLowerCase());
+      expect(mainnet?.userProvidedInfo).toEqual({ isToken0Quote: true });
+
+      // Base pool: token0 = WETH ∈ base (NOT in quote) → isToken0Quote = false
+      expect(base?.token0.address.toLowerCase()).toBe(WETH_BASE.toLowerCase());
+      expect(base?.userProvidedInfo).toEqual({ isToken0Quote: false });
+    });
+
+    it('derives orientation correctly when role is reversed (USDC base, WETH quote)', async () => {
+      const service = buildService(mocks);
+
+      const results = await service.searchPools({
+        base: ['USDC'],
+        quote: ['WETH'],
+        chainIds: [MAINNET, BASE],
+      });
+
+      expect(results).toHaveLength(2);
+
+      const mainnet = results.find((r) => r.chainId === MAINNET);
+      const base = results.find((r) => r.chainId === BASE);
+
+      // Mainnet: token0 = USDC ∈ base (NOT quote) → isToken0Quote = false
+      expect(mainnet?.userProvidedInfo).toEqual({ isToken0Quote: false });
+
+      // Base: token0 = WETH ∈ quote → isToken0Quote = true
+      expect(base?.userProvidedInfo).toEqual({ isToken0Quote: true });
+    });
+
+    it('passes the correct address sets to the subgraph per chain (not globally pooled)', async () => {
+      const service = buildService(mocks);
+
+      await service.searchPools({
+        base: ['WETH'],
+        quote: ['USDC'],
+        chainIds: [MAINNET, BASE],
+      });
+
+      // searchPoolsByTokenSets(chainId, base, quote) — addresses are
+      // lowercased and per-chain. Mainnet must see Mainnet addresses only,
+      // Base must see Base addresses only.
+      expect(mocks.searchPoolsByTokenSets).toHaveBeenCalledTimes(2);
+
+      const mainnetCall = mocks.searchPoolsByTokenSets.mock.calls.find(
+        (call) => call[0] === MAINNET,
+      );
+      const baseCall = mocks.searchPoolsByTokenSets.mock.calls.find(
+        (call) => call[0] === BASE,
+      );
+
+      expect(mainnetCall?.[1]).toEqual([WETH_MAINNET.toLowerCase()]);
+      expect(mainnetCall?.[2]).toEqual([USDC_MAINNET.toLowerCase()]);
+      expect(baseCall?.[1]).toEqual([WETH_BASE.toLowerCase()]);
+      expect(baseCall?.[2]).toEqual([USDC_BASE.toLowerCase()]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 2: self-exclusion at the service layer
+  // ---------------------------------------------------------------------------
+
+  describe('per-chain self-exclusion (base ∩ quote)', () => {
+    it('returns [] without invoking the subgraph when base=quote=[same symbol] (schema bypass)', async () => {
+      const service = buildService(mocks);
+
+      const results = await service.searchPools({
+        base: ['WETH'],
+        quote: ['WETH'],
+        chainIds: [MAINNET],
+      });
+
+      expect(results).toEqual([]);
+      // Self-exclusion runs before the subgraph call — no chain has a valid
+      // (b, q) pair with b !== q, so we never reach searchPoolsByTokenSets.
+      expect(mocks.searchPoolsByTokenSets).not.toHaveBeenCalled();
+      expect(mocks.validateSubgraphFactory).not.toHaveBeenCalled();
+    });
+
+    it('keeps richer queries valid when base ⊃ quote partially', async () => {
+      // base=["WETH","stETH"], quote=["WETH","stETH"] is a legitimate
+      // "all WETH/stETH pools either orientation" query — the per-chain
+      // (WETH, stETH) and (stETH, WETH) pairs survive self-exclusion.
+      mocks.searchByTextAndChains.mockImplementation(async (text: string) => {
+        if (text.toUpperCase() === 'WETH') {
+          return [{
+            symbol: 'WETH',
+            name: 'Wrapped Ether',
+            coingeckoId: 'weth',
+            addresses: [{ chainId: MAINNET, address: WETH_MAINNET }],
+          }];
+        }
+        if (text.toUpperCase() === 'STETH') {
+          return [{
+            symbol: 'stETH',
+            name: 'Lido Staked Ether',
+            coingeckoId: 'staked-ether',
+            addresses: [{ chainId: MAINNET, address: '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84' }],
+          }];
+        }
+        return [];
+      });
+
+      // Service returns whatever the subgraph returns; we just need to
+      // confirm the subgraph was called (i.e., self-exclusion did NOT
+      // short-circuit the chain).
+      mocks.searchPoolsByTokenSets.mockResolvedValue([]);
+
+      const service = buildService(mocks);
+      const results = await service.searchPools({
+        base: ['WETH', 'stETH'],
+        quote: ['WETH', 'stETH'],
+        chainIds: [MAINNET],
+      });
+
+      expect(results).toEqual([]);
+      expect(mocks.searchPoolsByTokenSets).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/midcurve-services/src/services/pool-search/uniswapv3-pool-search-service.ts
+++ b/packages/midcurve-services/src/services/pool-search/uniswapv3-pool-search-service.ts
@@ -15,8 +15,8 @@
  * ```typescript
  * const service = new UniswapV3PoolSearchService();
  * const results = await service.searchPools({
- *   tokenSetA: ['WETH', 'stETH'],
- *   tokenSetB: ['USDC', 'USDT'],
+ *   base: ['WETH', 'stETH'],
+ *   quote: ['USDC', 'USDT'],
  *   chainIds: [1, 42161],
  *   sortBy: 'apr7d',
  *   limit: 20,
@@ -43,6 +43,9 @@ import type { UniswapV3PoolSearchInput, ResolvedTokenAddress } from '../types/po
  * Same shape as `PoolSearchResultItem` from `@midcurve/api-shared` (minus the
  * route-only `isFavorite` flag) — metrics are nested under a single
  * `PoolMetricsBlock` containing TVL/volume/fees alongside σ-filter verdict.
+ *
+ * `userProvidedInfo.isToken0Quote` is derived per pool by checking whether
+ * `token0` resolves to a member of the `quote` set on that chain.
  */
 export interface PoolSearchResult {
   /** Pool contract address (EIP-55 checksummed). */
@@ -59,6 +62,12 @@ export interface PoolSearchResult {
   token1: PoolSearchSubgraphResult['token1'];
   /** Pool metrics — TVL, volume, fees, fee-APR, volatility, σ-filter verdict. */
   metrics: PoolMetricsBlock;
+  /**
+   * User-provided base/quote orientation derived from the request's `quote`
+   * array. Indicates which of `token0`/`token1` the user intends as the
+   * quote side.
+   */
+  userProvidedInfo: { isToken0Quote: boolean };
 }
 
 /**
@@ -107,8 +116,8 @@ export class UniswapV3PoolSearchService {
    */
   async searchPools(input: UniswapV3PoolSearchInput): Promise<PoolSearchResult[]> {
     log.methodEntry(this.logger, 'searchPools', {
-      tokenSetA: input.tokenSetA,
-      tokenSetB: input.tokenSetB,
+      base: input.base,
+      quote: input.quote,
       chainIds: input.chainIds,
       sortBy: input.sortBy,
       limit: input.limit,
@@ -119,8 +128,8 @@ export class UniswapV3PoolSearchService {
     const limit = Math.min(input.limit ?? 20, 100);
 
     // Validate inputs
-    if (input.tokenSetA.length === 0 || input.tokenSetB.length === 0) {
-      this.logger.warn('Empty token set provided, returning empty results');
+    if (input.base.length === 0 || input.quote.length === 0) {
+      this.logger.warn('Empty base/quote set provided, returning empty results');
       log.methodExit(this.logger, 'searchPools', { reason: 'empty_input' });
       return [];
     }
@@ -132,25 +141,56 @@ export class UniswapV3PoolSearchService {
     }
 
     // Step 1: Resolve token symbols to addresses for each chain
-    const resolvedTokensA = await this.resolveTokens(input.tokenSetA, input.chainIds);
-    const resolvedTokensB = await this.resolveTokens(input.tokenSetB, input.chainIds);
+    const resolvedBase = await this.resolveTokens(input.base, input.chainIds);
+    const resolvedQuote = await this.resolveTokens(input.quote, input.chainIds);
 
     this.logger.debug(
       {
-        resolvedTokensA: resolvedTokensA.length,
-        resolvedTokensB: resolvedTokensB.length,
+        resolvedBase: resolvedBase.length,
+        resolvedQuote: resolvedQuote.length,
       },
       'Tokens resolved'
     );
 
-    // Group resolved tokens by chain
-    const tokensByChain = this.groupTokensByChain(resolvedTokensA, resolvedTokensB);
+    // Group resolved tokens by chain — keep base/quote separate so we can
+    // (a) build the per-chain quote set used for `userProvidedInfo` derivation
+    // and (b) apply per-chain self-exclusion in the cartesian product.
+    const tokensByChain = this.groupTokensByChain(resolvedBase, resolvedQuote);
 
-    // Step 2: Query each chain in parallel
+    // Build the per-chain quote-address set (lowercased — same canonical form
+    // the subgraph uses) so result-side `isToken0Quote` derivation is a
+    // simple O(1) membership check per pool.
+    const quoteAddressesByChain = new Map<number, Set<string>>();
+    for (const [chainId, sets] of tokensByChain) {
+      quoteAddressesByChain.set(chainId, new Set(sets.quote));
+    }
+
+    // Step 2: Query each chain in parallel.
+    //
+    // The Uniswap subgraph search expects two address sets and matches pools
+    // where `(token0, token1)` is one element from each in either order
+    // (cartesian product). We pass the union of base + quote per chain
+    // because the subgraph filter is set-based, then perform per-chain
+    // self-exclusion before issuing the query: if a chain ends up with no
+    // valid `(b, q)` pair (b ≠ q), skip the chain — consistent with how
+    // unresolved symbols already cause a chain to be skipped.
     const chainQueries = input.chainIds.map(async (chainId) => {
       const chainTokens = tokensByChain.get(chainId);
-      if (!chainTokens || chainTokens.setA.length === 0 || chainTokens.setB.length === 0) {
+      if (!chainTokens || chainTokens.base.length === 0 || chainTokens.quote.length === 0) {
         this.logger.debug({ chainId }, 'No tokens for chain, skipping');
+        return [];
+      }
+
+      // Per-chain self-exclusion: ensure at least one (b, q) with b !== q.
+      // Lowercased compare matches the subgraph's canonical form.
+      const hasValidPair = chainTokens.base.some((b) =>
+        chainTokens.quote.some((q) => q !== b)
+      );
+      if (!hasValidPair) {
+        this.logger.debug(
+          { chainId },
+          'No valid (base, quote) pair after self-exclusion, skipping'
+        );
         return [];
       }
 
@@ -165,10 +205,17 @@ export class UniswapV3PoolSearchService {
       }
 
       try {
-        return await this.subgraphClient.searchPoolsByTokenSets(
+        const subgraphResults = await this.subgraphClient.searchPoolsByTokenSets(
           chainId,
-          chainTokens.setA,
-          chainTokens.setB
+          chainTokens.base,
+          chainTokens.quote
+        );
+        // Defensive: filter pools where token0 === token1 (impossible on
+        // Uniswap V3 by construction, but the search method's set-based
+        // semantics could in principle echo a same-token pair if the same
+        // address appears on both sides). Compare lowercased.
+        return subgraphResults.filter(
+          (p) => p.token0.address.toLowerCase() !== p.token1.address.toLowerCase()
         );
       } catch (error) {
         this.logger.error(
@@ -235,9 +282,12 @@ export class UniswapV3PoolSearchService {
       }
     }
 
-    const uniquePools: PoolSearchResult[] = uniquePending.map(({ subgraph, chainName }) =>
-      this.assembleResult(subgraph, chainName, sigmaResults),
-    );
+    const uniquePools: PoolSearchResult[] = uniquePending.map(({ subgraph, chainName }) => {
+      const quoteSet = quoteAddressesByChain.get(subgraph.chainId);
+      const isToken0Quote =
+        quoteSet?.has(subgraph.token0.address.toLowerCase()) ?? false;
+      return this.assembleResult(subgraph, chainName, sigmaResults, isToken0Quote);
+    });
 
     // Step 6: Sort
     const sortedPools = this.sortPools(uniquePools, sortBy, sortDirection);
@@ -268,6 +318,7 @@ export class UniswapV3PoolSearchService {
     subgraph: PoolSearchSubgraphResult,
     chainName: string,
     sigmaResults: ReadonlyMap<string, PoolSigmaResult>,
+    isToken0Quote: boolean,
   ): PoolSearchResult {
     const poolHash = `uniswapv3/${subgraph.chainId}/${subgraph.poolAddress}`;
     const sigma = sigmaResults.get(poolHash);
@@ -328,6 +379,7 @@ export class UniswapV3PoolSearchService {
       token0: subgraph.token0,
       token1: subgraph.token1,
       metrics,
+      userProvidedInfo: { isToken0Quote },
     };
   }
 
@@ -405,37 +457,38 @@ export class UniswapV3PoolSearchService {
   }
 
   /**
-   * Group resolved tokens by chain ID
+   * Group resolved base/quote tokens by chain ID.
+   *
+   * Addresses are lowercased — that's the canonical form the subgraph uses
+   * and the form used by the per-chain quote-set membership check.
    */
   private groupTokensByChain(
-    tokensA: ResolvedTokenAddress[],
-    tokensB: ResolvedTokenAddress[]
-  ): Map<number, { setA: string[]; setB: string[] }> {
-    const result = new Map<number, { setA: string[]; setB: string[] }>();
+    base: ResolvedTokenAddress[],
+    quote: ResolvedTokenAddress[]
+  ): Map<number, { base: string[]; quote: string[] }> {
+    const result = new Map<number, { base: string[]; quote: string[] }>();
 
-    // Group setA by chain
-    for (const token of tokensA) {
+    for (const token of base) {
       let entry = result.get(token.chainId);
       if (!entry) {
-        entry = { setA: [], setB: [] };
+        entry = { base: [], quote: [] };
         result.set(token.chainId, entry);
       }
-      // Add lowercase address (subgraph uses lowercase)
-      if (!entry.setA.includes(token.address.toLowerCase())) {
-        entry.setA.push(token.address.toLowerCase());
+      const lower = token.address.toLowerCase();
+      if (!entry.base.includes(lower)) {
+        entry.base.push(lower);
       }
     }
 
-    // Group setB by chain
-    for (const token of tokensB) {
+    for (const token of quote) {
       let entry = result.get(token.chainId);
       if (!entry) {
-        entry = { setA: [], setB: [] };
+        entry = { base: [], quote: [] };
         result.set(token.chainId, entry);
       }
-      // Add lowercase address (subgraph uses lowercase)
-      if (!entry.setB.includes(token.address.toLowerCase())) {
-        entry.setB.push(token.address.toLowerCase());
+      const lower = token.address.toLowerCase();
+      if (!entry.quote.includes(lower)) {
+        entry.quote.push(lower);
       }
     }
 

--- a/packages/midcurve-services/src/services/types/favorite-pool/favorite-pool-input.ts
+++ b/packages/midcurve-services/src/services/types/favorite-pool/favorite-pool-input.ts
@@ -19,6 +19,13 @@ export interface AddFavoritePoolInput {
 
   /** Pool contract address (will be validated and normalized) */
   poolAddress: string;
+
+  /**
+   * Optional base/quote orientation to persist with the favorite.
+   * When provided, surfaces on subsequent reads via
+   * `FavoritePoolItem.userProvidedInfo.isToken0Quote`.
+   */
+  isToken0Quote?: boolean;
 }
 
 /**

--- a/packages/midcurve-services/src/services/types/pool-search/pool-search-input.ts
+++ b/packages/midcurve-services/src/services/types/pool-search/pool-search-input.ts
@@ -6,20 +6,18 @@
  */
 
 /**
- * Pool search input for finding pools by token sets
+ * Pool search input for finding pools by base/quote token sets
  *
- * Searches for pools where:
- * - token0 is in tokenSetA AND token1 is in tokenSetB, OR
- * - token0 is in tokenSetB AND token1 is in tokenSetA
- *
- * This allows finding all pools between two groups of tokens.
+ * Searches the cartesian product `base × quote` per chain (with same-token
+ * pairs excluded). Each result is annotated with `userProvidedInfo.isToken0Quote`
+ * derived per pool by checking which side appears in `quote`.
  *
  * @example
  * ```typescript
  * const input: UniswapV3PoolSearchInput = {
- *   tokenSetA: ['WETH', 'stETH'],    // Base tokens
- *   tokenSetB: ['USDC', 'USDT'],     // Quote tokens
- *   chainIds: [1, 42161],            // Search on Ethereum and Arbitrum
+ *   base: ['WETH', 'stETH'],
+ *   quote: ['USDC', 'USDT'],
+ *   chainIds: [1, 42161],
  *   sortBy: 'tvlUSD',
  *   limit: 20,
  * };
@@ -27,26 +25,30 @@
  */
 export interface UniswapV3PoolSearchInput {
   /**
-   * First set of tokens (addresses or symbols)
+   * Base side of the pair (addresses or exact CoinGecko symbols).
    *
    * Can be:
    * - Token addresses (any case, will be normalized)
-   * - Token symbols (will be resolved via CoingeckoTokenService)
+   * - Token symbols — must match a CoinGecko symbol exactly
+   *   (case-insensitive). Fuzzy / prefix matching is the consumer's
+   *   responsibility.
    *
    * @example ['0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2', '0xae7ab96520de3a18e5e111b5eaab095312d7fe84']
    * @example ['WETH', 'stETH']
    */
-  tokenSetA: string[];
+  base: string[];
 
   /**
-   * Second set of tokens (addresses or symbols)
+   * Quote side of the pair (addresses or exact CoinGecko symbols).
    *
-   * Same format as tokenSetA.
+   * Same format as `base`. Determines `userProvidedInfo.isToken0Quote` on
+   * each result — if a pool's `token0` resolves to a member of this set
+   * (per chain), `isToken0Quote = true`.
    *
    * @example ['0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48', '0xdAC17F958D2ee523a2206206994597C13D831ec7']
    * @example ['USDC', 'USDT']
    */
-  tokenSetB: string[];
+  quote: string[];
 
   /**
    * Chain IDs to search on

--- a/packages/midcurve-services/src/services/user-settings/user-settings-service.test.ts
+++ b/packages/midcurve-services/src/services/user-settings/user-settings-service.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UserSettingsService } from './user-settings-service.js';
+import type { PrismaClient } from '@midcurve/database';
+import type { FavoritePoolEntry } from '@midcurve/shared';
+
+/**
+ * UserSettingsService — lazy backwards-compatibility for `favoritePoolHashes`.
+ *
+ * Pre-issue-#45 entries were stored as plain strings (pool hashes only).
+ * Reads must accept both shapes (`string` and `{ hash, isToken0Quote? }`)
+ * and normalize to `FavoritePoolEntry[]`. Writes always emit the object form.
+ */
+
+describe('UserSettingsService — favoritePoolHashes lazy compat', () => {
+  const findUnique = vi.fn();
+  const upsert = vi.fn();
+  const mockPrisma = {
+    userSettings: { findUnique, upsert },
+  } as unknown as PrismaClient;
+
+  let service: UserSettingsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new UserSettingsService({ prisma: mockPrisma });
+  });
+
+  function row(favoritePoolHashes: unknown): { settings: unknown } {
+    return {
+      settings: {
+        favoritePoolHashes,
+        costBasisMethod: 'fifo',
+      },
+    };
+  }
+
+  describe('getByUserId / getFavoritePoolEntries — read normalization', () => {
+    it('returns DEFAULT_USER_SETTINGS when no row exists', async () => {
+      findUnique.mockResolvedValue(null);
+      const settings = await service.getByUserId('u1');
+      expect(settings.favoritePoolHashes).toEqual([]);
+      expect(settings.costBasisMethod).toBe('fifo');
+    });
+
+    it('normalizes legacy string entries to FavoritePoolEntry shape', async () => {
+      findUnique.mockResolvedValue(
+        row(['uniswapv3/1/0xAbC', 'uniswapv3/42161/0xDeF'])
+      );
+      const entries = await service.getFavoritePoolEntries('u1');
+      expect(entries).toEqual<FavoritePoolEntry[]>([
+        { hash: 'uniswapv3/1/0xAbC' },
+        { hash: 'uniswapv3/42161/0xDeF' },
+      ]);
+    });
+
+    it('preserves isToken0Quote on object-shape entries', async () => {
+      findUnique.mockResolvedValue(
+        row([
+          { hash: 'uniswapv3/1/0xAbC', isToken0Quote: true },
+          { hash: 'uniswapv3/42161/0xDeF', isToken0Quote: false },
+          { hash: 'uniswapv3/8453/0x111' },
+        ])
+      );
+      const entries = await service.getFavoritePoolEntries('u1');
+      expect(entries).toEqual<FavoritePoolEntry[]>([
+        { hash: 'uniswapv3/1/0xAbC', isToken0Quote: true },
+        { hash: 'uniswapv3/42161/0xDeF', isToken0Quote: false },
+        { hash: 'uniswapv3/8453/0x111' },
+      ]);
+    });
+
+    it('handles a mixed array (legacy strings + new objects) round-tripped from one user', async () => {
+      findUnique.mockResolvedValue(
+        row([
+          'uniswapv3/1/0xAbC',
+          { hash: 'uniswapv3/42161/0xDeF', isToken0Quote: true },
+        ])
+      );
+      const entries = await service.getFavoritePoolEntries('u1');
+      expect(entries).toEqual<FavoritePoolEntry[]>([
+        { hash: 'uniswapv3/1/0xAbC' },
+        { hash: 'uniswapv3/42161/0xDeF', isToken0Quote: true },
+      ]);
+    });
+
+    it('drops malformed entries silently (null, numbers, missing hash)', async () => {
+      findUnique.mockResolvedValue(
+        row([
+          'uniswapv3/1/0xAbC',
+          null,
+          42,
+          { isToken0Quote: true }, // no hash
+          { hash: 123 }, // hash not a string
+          { hash: 'uniswapv3/8453/0x111', isToken0Quote: 'truthy' }, // wrong type → drop the bool but keep entry
+        ])
+      );
+      const entries = await service.getFavoritePoolEntries('u1');
+      expect(entries).toEqual<FavoritePoolEntry[]>([
+        { hash: 'uniswapv3/1/0xAbC' },
+        { hash: 'uniswapv3/8453/0x111' },
+      ]);
+    });
+
+    it('returns [] when favoritePoolHashes is missing or not an array', async () => {
+      findUnique.mockResolvedValue({ settings: { costBasisMethod: 'fifo' } });
+      let entries = await service.getFavoritePoolEntries('u1');
+      expect(entries).toEqual([]);
+
+      findUnique.mockResolvedValue(row('not-an-array'));
+      entries = await service.getFavoritePoolEntries('u1');
+      expect(entries).toEqual([]);
+    });
+  });
+
+  describe('addFavoritePoolEntry — always writes object shape', () => {
+    it('appends as { hash, isToken0Quote } when orientation supplied', async () => {
+      findUnique.mockResolvedValue(row([]));
+      upsert.mockImplementation(async ({ create }: { create: { settings: unknown } }) => ({
+        settings: create.settings,
+      }));
+
+      const result = await service.addFavoritePoolEntry(
+        'u1',
+        'uniswapv3/1/0xAbC',
+        true
+      );
+
+      expect(result.favoritePoolHashes).toEqual<FavoritePoolEntry[]>([
+        { hash: 'uniswapv3/1/0xAbC', isToken0Quote: true },
+      ]);
+      // Verify the actual JSON shape persisted to Prisma carries the object form.
+      const upsertArgs = upsert.mock.calls[0][0];
+      const persisted = upsertArgs.create.settings as {
+        favoritePoolHashes: unknown[];
+      };
+      expect(persisted.favoritePoolHashes[0]).toEqual({
+        hash: 'uniswapv3/1/0xAbC',
+        isToken0Quote: true,
+      });
+    });
+
+    it('appends as { hash } only when orientation is undefined', async () => {
+      findUnique.mockResolvedValue(row([]));
+      upsert.mockImplementation(async ({ create }: { create: { settings: unknown } }) => ({
+        settings: create.settings,
+      }));
+
+      const result = await service.addFavoritePoolEntry('u1', 'uniswapv3/1/0xAbC');
+      expect(result.favoritePoolHashes).toEqual<FavoritePoolEntry[]>([
+        { hash: 'uniswapv3/1/0xAbC' },
+      ]);
+    });
+
+    it('upgrades a legacy string entry to the object shape on re-add (orientation provided)', async () => {
+      // Existing storage has a legacy string for the same hash.
+      findUnique.mockResolvedValue(row(['uniswapv3/1/0xAbC']));
+      upsert.mockImplementation(async ({ update }: { update: { settings: unknown } }) => ({
+        settings: update.settings,
+      }));
+
+      const result = await service.addFavoritePoolEntry(
+        'u1',
+        'uniswapv3/1/0xAbC',
+        false
+      );
+
+      // Prepended (most-recent-first) AND deduped.
+      expect(result.favoritePoolHashes).toEqual<FavoritePoolEntry[]>([
+        { hash: 'uniswapv3/1/0xAbC', isToken0Quote: false },
+      ]);
+    });
+
+    it('moves existing entry to the front when re-added (idempotent)', async () => {
+      findUnique.mockResolvedValue(
+        row([
+          { hash: 'uniswapv3/1/0xAAA' },
+          { hash: 'uniswapv3/1/0xBBB', isToken0Quote: true },
+          { hash: 'uniswapv3/1/0xCCC' },
+        ])
+      );
+      upsert.mockImplementation(async ({ update }: { update: { settings: unknown } }) => ({
+        settings: update.settings,
+      }));
+
+      const result = await service.addFavoritePoolEntry(
+        'u1',
+        'uniswapv3/1/0xCCC',
+        true
+      );
+
+      expect(result.favoritePoolHashes.map((e) => e.hash)).toEqual([
+        'uniswapv3/1/0xCCC',
+        'uniswapv3/1/0xAAA',
+        'uniswapv3/1/0xBBB',
+      ]);
+      // Re-added entry now carries the new orientation.
+      expect(result.favoritePoolHashes[0]).toEqual({
+        hash: 'uniswapv3/1/0xCCC',
+        isToken0Quote: true,
+      });
+    });
+  });
+
+  describe('removeFavoritePoolEntry — filters by hash, ignores orientation', () => {
+    it('removes the entry whose hash matches', async () => {
+      findUnique.mockResolvedValue(
+        row([
+          { hash: 'uniswapv3/1/0xAAA', isToken0Quote: true },
+          { hash: 'uniswapv3/1/0xBBB' },
+        ])
+      );
+      upsert.mockImplementation(async ({ update }: { update: { settings: unknown } }) => ({
+        settings: update.settings,
+      }));
+
+      const result = await service.removeFavoritePoolEntry('u1', 'uniswapv3/1/0xAAA');
+      expect(result.favoritePoolHashes).toEqual<FavoritePoolEntry[]>([
+        { hash: 'uniswapv3/1/0xBBB' },
+      ]);
+    });
+
+    it('removes a legacy string entry by its hash', async () => {
+      findUnique.mockResolvedValue(
+        row(['uniswapv3/1/0xAAA', 'uniswapv3/1/0xBBB'])
+      );
+      upsert.mockImplementation(async ({ update }: { update: { settings: unknown } }) => ({
+        settings: update.settings,
+      }));
+
+      const result = await service.removeFavoritePoolEntry('u1', 'uniswapv3/1/0xAAA');
+      expect(result.favoritePoolHashes).toEqual<FavoritePoolEntry[]>([
+        { hash: 'uniswapv3/1/0xBBB' },
+      ]);
+    });
+
+    it('is idempotent (no-op when hash not present)', async () => {
+      findUnique.mockResolvedValue(row([{ hash: 'uniswapv3/1/0xAAA' }]));
+      upsert.mockImplementation(async ({ update }: { update: { settings: unknown } }) => ({
+        settings: update.settings,
+      }));
+
+      const result = await service.removeFavoritePoolEntry(
+        'u1',
+        'uniswapv3/1/0xZZZ'
+      );
+      expect(result.favoritePoolHashes).toEqual<FavoritePoolEntry[]>([
+        { hash: 'uniswapv3/1/0xAAA' },
+      ]);
+    });
+  });
+
+  describe('isFavoritePoolHash', () => {
+    it('returns true when the hash is present (object form)', async () => {
+      findUnique.mockResolvedValue(
+        row([{ hash: 'uniswapv3/1/0xAAA', isToken0Quote: true }])
+      );
+      const isFav = await service.isFavoritePoolHash('u1', 'uniswapv3/1/0xAAA');
+      expect(isFav).toBe(true);
+    });
+
+    it('returns true when the hash is present (legacy string form)', async () => {
+      findUnique.mockResolvedValue(row(['uniswapv3/1/0xAAA']));
+      const isFav = await service.isFavoritePoolHash('u1', 'uniswapv3/1/0xAAA');
+      expect(isFav).toBe(true);
+    });
+
+    it('returns false when the hash is absent', async () => {
+      findUnique.mockResolvedValue(row([{ hash: 'uniswapv3/1/0xAAA' }]));
+      const isFav = await service.isFavoritePoolHash('u1', 'uniswapv3/1/0xZZZ');
+      expect(isFav).toBe(false);
+    });
+  });
+});

--- a/packages/midcurve-services/src/services/user-settings/user-settings-service.ts
+++ b/packages/midcurve-services/src/services/user-settings/user-settings-service.ts
@@ -7,16 +7,20 @@
  * Methods:
  * - getByUserId: Get settings for a user (returns defaults if no row exists)
  * - upsert: Create or replace entire settings JSON
- * - addFavoritePoolHash: Prepend a pool hash to favorites (idempotent)
- * - removeFavoritePoolHash: Remove a pool hash from favorites (idempotent)
- * - getFavoritePoolHashes: Get the user's favorite pool hashes
+ * - addFavoritePoolEntry: Prepend a favorite pool entry (idempotent, optionally pinning isToken0Quote)
+ * - removeFavoritePoolEntry: Remove a favorite by pool hash (idempotent)
+ * - getFavoritePoolEntries: Get the user's favorite pool entries
  * - isFavoritePoolHash: Check if a pool hash is in the user's favorites
+ *
+ * Storage compatibility: legacy installations stored `favoritePoolHashes`
+ * as `string[]`. Reads normalize legacy entries to `FavoritePoolEntry`
+ * on the fly; writes always emit the object shape.
  */
 
 import { prisma as prismaClient, PrismaClient } from '@midcurve/database';
 import type { Prisma } from '@midcurve/database';
 import { DEFAULT_USER_SETTINGS } from '@midcurve/shared';
-import type { UserSettingsData } from '@midcurve/shared';
+import type { FavoritePoolEntry, UserSettingsData } from '@midcurve/shared';
 import { createServiceLogger, log } from '../../logging/index.js';
 import type { ServiceLogger } from '../../logging/index.js';
 
@@ -32,10 +36,42 @@ export interface UserSettingsServiceDependencies {
 }
 
 /**
+ * Normalize a single stored entry into `FavoritePoolEntry`.
+ *
+ * Accepts either the legacy `string` shape or the new object shape.
+ */
+function normalizeEntry(raw: unknown): FavoritePoolEntry | null {
+  if (typeof raw === 'string') {
+    return { hash: raw };
+  }
+  if (raw && typeof raw === 'object' && 'hash' in raw && typeof (raw as { hash: unknown }).hash === 'string') {
+    const obj = raw as { hash: string; isToken0Quote?: unknown };
+    if (typeof obj.isToken0Quote === 'boolean') {
+      return { hash: obj.hash, isToken0Quote: obj.isToken0Quote };
+    }
+    return { hash: obj.hash };
+  }
+  return null;
+}
+
+/**
+ * Normalize the raw `favoritePoolHashes` JSON value into `FavoritePoolEntry[]`.
+ * Drops malformed entries silently — they have no place in the typed runtime.
+ */
+function normalizeEntries(raw: unknown): FavoritePoolEntry[] {
+  if (!Array.isArray(raw)) return [];
+  const result: FavoritePoolEntry[] = [];
+  for (const item of raw) {
+    const entry = normalizeEntry(item);
+    if (entry) result.push(entry);
+  }
+  return result;
+}
+
+/**
  * User Settings Service
  *
  * Manages per-user settings stored as a single JSON structure.
- * Follows the WebhookConfigService 1:1 pattern.
  */
 export class UserSettingsService {
   private readonly prisma: PrismaClient;
@@ -51,7 +87,10 @@ export class UserSettingsService {
   // ============================================================================
 
   /**
-   * Gets settings for a user
+   * Gets settings for a user.
+   *
+   * Normalizes the stored `favoritePoolHashes` JSON (which may be a legacy
+   * `string[]`) into `FavoritePoolEntry[]` before returning.
    *
    * @returns The user's settings, or DEFAULT_USER_SETTINGS if no row exists
    */
@@ -67,12 +106,19 @@ export class UserSettingsService {
       return { ...DEFAULT_USER_SETTINGS };
     }
 
+    const raw = row.settings as unknown as Record<string, unknown>;
+    const settings: UserSettingsData = {
+      ...DEFAULT_USER_SETTINGS,
+      ...(raw as Partial<UserSettingsData>),
+      favoritePoolHashes: normalizeEntries(raw.favoritePoolHashes),
+    };
+
     log.methodExit(this.logger, 'getByUserId', { found: true });
-    return row.settings as unknown as UserSettingsData;
+    return settings;
   }
 
   /**
-   * Creates or replaces the entire settings JSON for a user
+   * Creates or replaces the entire settings JSON for a user.
    */
   async upsert(
     userId: string,
@@ -93,84 +139,98 @@ export class UserSettingsService {
       },
     });
 
+    const raw = result.settings as unknown as Record<string, unknown>;
+    const normalized: UserSettingsData = {
+      ...DEFAULT_USER_SETTINGS,
+      ...(raw as Partial<UserSettingsData>),
+      favoritePoolHashes: normalizeEntries(raw.favoritePoolHashes),
+    };
+
     log.methodExit(this.logger, 'upsert', { userId });
-    return result.settings as unknown as UserSettingsData;
+    return normalized;
   }
 
   // ============================================================================
-  // FAVORITE POOL HASH OPERATIONS
+  // FAVORITE POOL ENTRY OPERATIONS
   // ============================================================================
 
   /**
-   * Prepends a pool hash to the user's favorites (idempotent)
+   * Prepends a favorite pool entry to the user's favorites (idempotent).
    *
-   * If the hash already exists, it is moved to the front.
+   * If an entry with the same `hash` already exists, it is removed first and
+   * the new entry — including the (possibly updated) `isToken0Quote` — is
+   * prepended. Always writes the new object shape, regardless of whether the
+   * caller provided an orientation.
    */
-  async addFavoritePoolHash(
+  async addFavoritePoolEntry(
     userId: string,
-    poolHash: string
+    hash: string,
+    isToken0Quote?: boolean
   ): Promise<UserSettingsData> {
-    log.methodEntry(this.logger, 'addFavoritePoolHash', { userId, poolHash });
+    log.methodEntry(this.logger, 'addFavoritePoolEntry', {
+      userId,
+      hash,
+      isToken0Quote,
+    });
 
     const current = await this.getByUserId(userId);
-
-    // Remove if already present (will re-prepend)
-    const filtered = current.favoritePoolHashes.filter((h) => h !== poolHash);
+    const filtered = current.favoritePoolHashes.filter((e) => e.hash !== hash);
+    const newEntry: FavoritePoolEntry =
+      typeof isToken0Quote === 'boolean'
+        ? { hash, isToken0Quote }
+        : { hash };
     const updated: UserSettingsData = {
       ...current,
-      favoritePoolHashes: [poolHash, ...filtered],
+      favoritePoolHashes: [newEntry, ...filtered],
     };
 
     const result = await this.upsert(userId, updated);
-    log.methodExit(this.logger, 'addFavoritePoolHash', {
+    log.methodExit(this.logger, 'addFavoritePoolEntry', {
       totalFavorites: result.favoritePoolHashes.length,
     });
     return result;
   }
 
   /**
-   * Removes a pool hash from the user's favorites (idempotent)
+   * Removes a favorite pool entry by hash (idempotent).
    */
-  async removeFavoritePoolHash(
+  async removeFavoritePoolEntry(
     userId: string,
-    poolHash: string
+    hash: string
   ): Promise<UserSettingsData> {
-    log.methodEntry(this.logger, 'removeFavoritePoolHash', {
-      userId,
-      poolHash,
-    });
+    log.methodEntry(this.logger, 'removeFavoritePoolEntry', { userId, hash });
 
     const current = await this.getByUserId(userId);
     const updated: UserSettingsData = {
       ...current,
       favoritePoolHashes: current.favoritePoolHashes.filter(
-        (h) => h !== poolHash
+        (e) => e.hash !== hash
       ),
     };
 
     const result = await this.upsert(userId, updated);
-    log.methodExit(this.logger, 'removeFavoritePoolHash', {
+    log.methodExit(this.logger, 'removeFavoritePoolEntry', {
       totalFavorites: result.favoritePoolHashes.length,
     });
     return result;
   }
 
   /**
-   * Returns the user's favorite pool hashes
+   * Returns the user's favorite pool entries (lazy-normalized from storage).
    */
-  async getFavoritePoolHashes(userId: string): Promise<string[]> {
+  async getFavoritePoolEntries(userId: string): Promise<FavoritePoolEntry[]> {
     const settings = await this.getByUserId(userId);
     return settings.favoritePoolHashes;
   }
 
   /**
-   * Checks if a pool hash is in the user's favorites
+   * Checks if a pool hash is in the user's favorites.
    */
   async isFavoritePoolHash(
     userId: string,
     poolHash: string
   ): Promise<boolean> {
-    const hashes = await this.getFavoritePoolHashes(userId);
-    return hashes.includes(poolHash);
+    const entries = await this.getFavoritePoolEntries(userId);
+    return entries.some((e) => e.hash === poolHash);
   }
 }

--- a/packages/midcurve-shared/src/types/index.ts
+++ b/packages/midcurve-shared/src/types/index.ts
@@ -5,7 +5,7 @@
 
 // User types
 export type { User } from './user.js';
-export type { UserSettingsData, CostBasisMethod } from './user-settings.js';
+export type { UserSettingsData, CostBasisMethod, FavoritePoolEntry } from './user-settings.js';
 export { DEFAULT_USER_SETTINGS } from './user-settings.js';
 
 // ============================================================================

--- a/packages/midcurve-shared/src/types/user-settings.ts
+++ b/packages/midcurve-shared/src/types/user-settings.ts
@@ -6,13 +6,6 @@
  */
 
 /**
- * UserSettingsData interface
- *
- * Defines the shape of the settings JSON column.
- * New settings fields should be added here with sensible defaults
- * reflected in DEFAULT_USER_SETTINGS.
- */
-/**
  * Cost basis tracking method for token lot disposals.
  *
  * - 'fifo': First In, First Out — oldest lots consumed first
@@ -22,13 +15,48 @@
  */
 export type CostBasisMethod = 'fifo' | 'lifo' | 'hifo' | 'wac';
 
+/**
+ * A single favorite-pool entry persisted in `UserSettingsData.favoritePoolHashes`.
+ *
+ * Pre-issue-#45 entries were plain strings (`hash`-only). The lazy
+ * backwards-compat read normalizes legacy string entries into this shape on
+ * the fly with `isToken0Quote` undefined; writes always use this object form.
+ */
+export interface FavoritePoolEntry {
+  /**
+   * Pool hash identifier — `{protocol}/{chainId}/{poolAddress}` (EIP-55).
+   * @example "uniswapv3/42161/0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640"
+   */
+  hash: string;
+
+  /**
+   * Optional base/quote orientation pinned to this favorite.
+   *
+   * `undefined` means no orientation was set (legacy entries or favorites
+   * added without a role context, e.g. from the Direct Address flow).
+   */
+  isToken0Quote?: boolean;
+}
+
+/**
+ * UserSettingsData interface
+ *
+ * Defines the shape of the settings JSON column.
+ * New settings fields should be added here with sensible defaults
+ * reflected in DEFAULT_USER_SETTINGS.
+ */
 export interface UserSettingsData {
   /**
-   * Pool hashes the user has favorited for quick access.
-   * Format: "{protocol}/{chainId}/{poolAddress}" (e.g. "uniswapv3/42161/0xABC...")
-   * Ordered most-recent-first (new favorites prepended).
+   * Pools the user has favorited for quick access.
+   *
+   * Each entry carries the pool hash and an optional pinned base/quote
+   * orientation. Ordered most-recent-first (new favorites prepended).
+   *
+   * **Storage compatibility**: legacy installations may have stored this
+   * field as `string[]`. Reads normalize legacy entries to
+   * `FavoritePoolEntry` on the fly; writes always emit the object shape.
    */
-  favoritePoolHashes: string[];
+  favoritePoolHashes: FavoritePoolEntry[];
 
   /**
    * Cost basis method for realized PnL calculations.

--- a/scripts/migrate-favorites-to-user-settings.ts
+++ b/scripts/migrate-favorites-to-user-settings.ts
@@ -18,7 +18,7 @@
  */
 
 import { PrismaClient } from '@midcurve/database';
-import type { UserSettingsData } from '@midcurve/shared';
+import type { FavoritePoolEntry, UserSettingsData } from '@midcurve/shared';
 import { DEFAULT_USER_SETTINGS } from '@midcurve/shared';
 
 const prisma = new PrismaClient();
@@ -94,8 +94,23 @@ async function main() {
     });
 
     if (existing) {
-      const existingSettings = existing.settings as unknown as UserSettingsData;
-      const existingSet = new Set(existingSettings.favoritePoolHashes);
+      const existingSettings = existing.settings as unknown as { favoritePoolHashes?: unknown[] };
+      const existingRawEntries = Array.isArray(existingSettings.favoritePoolHashes)
+        ? existingSettings.favoritePoolHashes
+        : [];
+      const existingEntries: FavoritePoolEntry[] = existingRawEntries
+        .map((e): FavoritePoolEntry | null => {
+          if (typeof e === 'string') return { hash: e };
+          if (e && typeof e === 'object' && typeof (e as { hash?: unknown }).hash === 'string') {
+            const obj = e as { hash: string; isToken0Quote?: unknown };
+            return typeof obj.isToken0Quote === 'boolean'
+              ? { hash: obj.hash, isToken0Quote: obj.isToken0Quote }
+              : { hash: obj.hash };
+          }
+          return null;
+        })
+        .filter((e): e is FavoritePoolEntry => e !== null);
+      const existingSet = new Set(existingEntries.map((e) => e.hash));
       const newHashes = poolHashes.filter((h) => !existingSet.has(h));
 
       if (newHashes.length === 0) {
@@ -104,8 +119,12 @@ async function main() {
       }
 
       const merged: UserSettingsData = {
-        ...existingSettings,
-        favoritePoolHashes: [...newHashes, ...existingSettings.favoritePoolHashes],
+        ...DEFAULT_USER_SETTINGS,
+        ...(existingSettings as unknown as Partial<UserSettingsData>),
+        favoritePoolHashes: [
+          ...newHashes.map((hash): FavoritePoolEntry => ({ hash })),
+          ...existingEntries,
+        ],
       };
 
       await prisma.userSettings.update({
@@ -119,7 +138,7 @@ async function main() {
     } else {
       const settings: UserSettingsData = {
         ...DEFAULT_USER_SETTINGS,
-        favoritePoolHashes: poolHashes,
+        favoritePoolHashes: poolHashes.map((hash): FavoritePoolEntry => ({ hash })),
       };
 
       await prisma.userSettings.create({


### PR DESCRIPTION
## Summary

- Promote base/quote role assignment from UI-local state to first-class API parameters. Pool search renames `tokenSetA`/`tokenSetB` → `base`/`quote`, and each result is annotated with `userProvidedInfo: { isToken0Quote }` derived per-chain from the request's quote set, so consumers can render pairs in user-intended orientation regardless of pool-native token order. Pool detail accepts an optional `isToken0Quote` query param it echoes back. Favorites persist orientation alongside the pool hash with lazy backwards-compat for legacy `string[]` entries.
- MCP `get_pool` gains the echo input; new `search_pools` tool surfaces the search endpoint with an exact-symbol-or-address contract documented in the tool's input schema.
- UI: `PoolTable` now pivots the pair label by `userProvidedInfo`; the wizard `SELECT_POOL` reducer reads the orientation; `handleToggleFavorite` forwards the active orientation when persisting a favorite.
- Adds a project-local `.mcp.json` midcurve entry (env-var-interpolated key) so anyone working on this repo overrides their global install with the local dev API.

Fixes #45

## Test plan

- [ ] `pnpm typecheck` clean across all 14 packages
- [ ] api-shared schema tests: `pnpm --filter @midcurve/api-shared test:run` — 8 tests cover trivial-case rejection, case-insensitive symbol compare, EIP-55 normalize, `[WETH,stETH]×[WETH,stETH]` passes, defaults applied
- [ ] services tests: `pnpm --filter @midcurve/services test:run` — 16 new UserSettings tests cover legacy-string/object/mixed normalization, lazy upgrade on re-add, idempotent removes
- [ ] mcp-server tests: `pnpm --filter @midcurve/mcp-server test:run` — 8 new tests cover `formatPool` userProvidedInfo echo and `formatPoolSearchResult`
- [ ] API smoke (against local dev):
      ```bash
      # Search returns userProvidedInfo per result, with per-chain orientation
      curl -s -X POST http://localhost:3001/api/v1/pools/uniswapv3/search \
        -H 'content-type: application/json' \
        -d '{"base":["WETH"],"quote":["USDC"],"chainIds":[1,8453]}' \
        | jq '.data[] | {chain: .chainName, pair: "\(.token0.symbol)/\(.token1.symbol)", isToken0Quote: .userProvidedInfo.isToken0Quote}'
      # Mainnet pools → isToken0Quote=true (USDC is token0); Base pools → false (WETH is token0)

      # Trivial-case rejection
      curl -s -X POST http://localhost:3001/api/v1/pools/uniswapv3/search \
        -H 'content-type: application/json' \
        -d '{"base":["WETH"],"quote":["WETH"],"chainIds":[1]}' -i | head -1
      # → HTTP/1.1 400

      # Detail endpoint echoes the role
      curl -s 'http://localhost:3001/api/v1/pools/uniswapv3/1/0x88e6A0c2dDD26FEEb64F039a2c41296FcB3f5640?isToken0Quote=true' \
        | jq '.data.userProvidedInfo'
      ```
- [ ] MCP smoke (verified via Claude Code against dev server): `search_pools` annotated each result with the correct per-chain `isToken0Quote`; `get_pool` with `isToken0Quote=true` echoed the field at the response root
- [ ] UI smoke (verified via Chrome DevTools MCP): wizard pool table now displays user-intended `base / quote` orientation across Mainnet (where USDC is token0) and Base (where WETH is token0); Direct-Address tab still uses pool-native ordering
- [ ] Favorites round-trip: starring a pool from the search tab persists `isToken0Quote`; the Favorites tab returns it; a legacy `favoritePoolHashes: string[]` row is normalized on read with `isToken0Quote` undefined

🤖 Generated with [Claude Code](https://claude.com/claude-code)