### PR TITLE
feat(sigma-filter): add LVR-coverage ratio and 5-band mapping

### DIFF
--- a/apps/midcurve-api/src/app/api/v1/pools/uniswapv3/[chainId]/[address]/metrics/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/pools/uniswapv3/[chainId]/[address]/metrics/route.ts
@@ -206,6 +206,8 @@ export async function GET(
           verdictLongTerm: 'INSUFFICIENT_DATA',
           verdictShortTerm: 'INSUFFICIENT_DATA',
           verdictAgreement: 'INSUFFICIENT_DATA',
+          coverageLongTerm: null,
+          coverageBand: 'insufficient_data',
         },
       };
 

--- a/apps/midcurve-api/src/lib/pool-metrics-block.ts
+++ b/apps/midcurve-api/src/lib/pool-metrics-block.ts
@@ -111,5 +111,7 @@ function emptySigmaFilter(): SigmaFilterBlock {
     verdictLongTerm: 'INSUFFICIENT_DATA',
     verdictShortTerm: 'INSUFFICIENT_DATA',
     verdictAgreement: 'INSUFFICIENT_DATA',
+    coverageLongTerm: null,
+    coverageBand: 'insufficient_data',
   };
 }

--- a/apps/midcurve-mcp-server/src/formatters.test.ts
+++ b/apps/midcurve-mcp-server/src/formatters.test.ts
@@ -258,6 +258,37 @@ function baseSearchResult(): SearchResult {
       feeApr7dAvg: 0.2512,
       feeAprPrimary: 0.2512,
       feeAprSource: '7d_avg',
+      volatility: {
+        token0: {
+          ref: '',
+          sigma60d: { status: 'insufficient_history' },
+          sigma365d: { status: 'insufficient_history' },
+        },
+        token1: {
+          ref: '',
+          sigma60d: { status: 'insufficient_history' },
+          sigma365d: { status: 'insufficient_history' },
+        },
+        pair: {
+          sigma60d: { status: 'insufficient_history' },
+          sigma365d: { status: 'insufficient_history' },
+        },
+        velocity: null,
+        pivotCurrency: 'usd',
+        computedAt: '2026-04-26T00:00:00.000Z',
+      },
+      sigmaFilter: {
+        feeApr: null,
+        sigmaSqOver8_365d: null,
+        sigmaSqOver8_60d: null,
+        marginLongTerm: null,
+        marginShortTerm: null,
+        verdictLongTerm: 'INSUFFICIENT_DATA',
+        verdictShortTerm: 'INSUFFICIENT_DATA',
+        verdictAgreement: 'INSUFFICIENT_DATA',
+        coverageLongTerm: null,
+        coverageBand: 'insufficient_data',
+      },
     },
   };
 }
@@ -301,12 +332,5 @@ describe('formatPoolSearchResult', () => {
       userProvidedInfo: { isToken0Quote: false },
     });
     expect(out2.userProvidedInfo).toEqual({ isToken0Quote: false });
-  });
-
-  it('handles missing volatility / sigmaFilter blocks (search results may omit them)', () => {
-    const out = formatPoolSearchResult(baseSearchResult());
-    const m = out.metrics as Record<string, unknown>;
-    expect(m.volatility).toBeNull();
-    expect(m.sigmaFilter).toBeNull();
   });
 });

--- a/apps/midcurve-mcp-server/src/formatters.test.ts
+++ b/apps/midcurve-mcp-server/src/formatters.test.ts
@@ -89,6 +89,8 @@ const HEALTHY_METRICS: NonNullable<PoolDetail['metrics']> = {
     verdictLongTerm: 'PASS',
     verdictShortTerm: 'PASS',
     verdictAgreement: 'AGREE',
+    coverageLongTerm: 3.93,
+    coverageBand: 'deep_green',
   },
 };
 
@@ -174,6 +176,8 @@ describe('formatPool', () => {
       verdictLongTerm: 'INSUFFICIENT_DATA',
       verdictShortTerm: 'INSUFFICIENT_DATA',
       verdictAgreement: 'INSUFFICIENT_DATA',
+      coverageLongTerm: null,
+      coverageBand: 'insufficient_data',
     };
     const detail = { ...basePool(), metrics };
     const out = formatPool(detail);

--- a/apps/midcurve-mcp-server/src/formatters.ts
+++ b/apps/midcurve-mcp-server/src/formatters.ts
@@ -18,8 +18,12 @@ import {
 import type {
   AprPeriodData,
   AprPeriodsResponse,
+  PairSigmaResult,
+  PoolSearchResultItem,
   PositionAccountingResponse,
   SerializedCloseOrder,
+  SigmaFilterBlock,
+  VolatilityBlock,
 } from '@midcurve/api-shared';
 import type { PositionContext } from './lib/position-context.js';
 
@@ -353,38 +357,6 @@ export function formatPnl(pnl: PnlResponseRaw): Record<string, unknown> {
  * Matches the wire shape: serialized pool nested under `pool`, with optional
  * `metrics` (PoolMetricsBlock per PRD-pool-sigma-filter) and `feeData` siblings.
  */
-interface SigmaResultRaw {
-  status: 'ok' | 'insufficient_history' | 'token_not_listed' | 'fetch_failed';
-  value?: number;
-  sigmaSqOver8?: number;
-  nReturns?: number;
-}
-interface VolatilityBlockRaw {
-  token0: { ref: string; sigma60d: SigmaResultRaw; sigma365d: SigmaResultRaw };
-  token1: { ref: string; sigma60d: SigmaResultRaw; sigma365d: SigmaResultRaw };
-  pair: { sigma60d: SigmaResultRaw; sigma365d: SigmaResultRaw };
-  velocity: number | null;
-  pivotCurrency: 'usd';
-  computedAt: string;
-}
-interface SigmaFilterBlockRaw {
-  feeApr: number | null;
-  sigmaSqOver8_365d: number | null;
-  sigmaSqOver8_60d: number | null;
-  marginLongTerm: number | null;
-  marginShortTerm: number | null;
-  verdictLongTerm: 'PASS' | 'FAIL' | 'INSUFFICIENT_DATA';
-  verdictShortTerm: 'PASS' | 'FAIL' | 'INSUFFICIENT_DATA';
-  verdictAgreement: 'AGREE' | 'DIVERGENT' | 'INSUFFICIENT_DATA';
-  coverageLongTerm: number | null;
-  coverageBand:
-    | 'deep_red'
-    | 'red'
-    | 'yellow'
-    | 'green'
-    | 'deep_green'
-    | 'insufficient_data';
-}
 interface PoolDetailRaw {
   pool: {
     protocol: string;
@@ -406,8 +378,8 @@ interface PoolDetailRaw {
     feeApr7dAvg: number | null;
     feeAprPrimary: number | null;
     feeAprSource: '24h' | '7d_avg' | 'unavailable';
-    volatility?: VolatilityBlockRaw;
-    sigmaFilter?: SigmaFilterBlockRaw;
+    volatility?: VolatilityBlock;
+    sigmaFilter?: SigmaFilterBlock;
   };
   feeData?: Record<string, unknown>;
   /**
@@ -439,7 +411,7 @@ function fmtSignedRate(rate: number | null | undefined, decimals = 1): string | 
  * interpretation, so `sigmaSqOver8` is never present on the wire — emit
  * `{status, value, nReturns}` only.
  */
-function formatTokenSigmaResult(r: SigmaResultRaw): Record<string, unknown> {
+function formatTokenSigmaResult(r: PairSigmaResult): Record<string, unknown> {
   return {
     status: r.status,
     value: fmtRate(r.value),
@@ -451,7 +423,7 @@ function formatTokenSigmaResult(r: SigmaResultRaw): Record<string, unknown> {
  * Pair σ block. Carries `sigmaSqOver8` (the LVR rate of the synthetic
  * cross-pair) which feeds the σ-filter verdict.
  */
-function formatPairSigmaResult(r: SigmaResultRaw): Record<string, unknown> {
+function formatPairSigmaResult(r: PairSigmaResult): Record<string, unknown> {
   return {
     status: r.status,
     value: fmtRate(r.value),
@@ -460,7 +432,7 @@ function formatPairSigmaResult(r: SigmaResultRaw): Record<string, unknown> {
   };
 }
 
-function formatVolatility(v: VolatilityBlockRaw): Record<string, unknown> {
+function formatVolatility(v: VolatilityBlock): Record<string, unknown> {
   return {
     token0: {
       ref: v.token0.ref,
@@ -483,7 +455,7 @@ function formatVolatility(v: VolatilityBlockRaw): Record<string, unknown> {
   };
 }
 
-function formatSigmaFilter(s: SigmaFilterBlockRaw): Record<string, unknown> {
+function formatSigmaFilter(s: SigmaFilterBlock): Record<string, unknown> {
   return {
     feeApr: fmtRate(s.feeApr),
     sigmaSqOver8_365d: fmtRate(s.sigmaSqOver8_365d),
@@ -577,38 +549,6 @@ export function formatPool(detail: PoolDetailRaw): Record<string, unknown> {
 // Pool Search Result (POST /api/v1/pools/uniswapv3/search)
 // =============================================================================
 
-interface PoolSearchTokenInfoRaw {
-  address: string;
-  symbol: string;
-  decimals: number;
-}
-
-interface PoolSearchResultRaw {
-  poolAddress: string;
-  chainId: number;
-  chainName: string;
-  feeTier: number;
-  token0: PoolSearchTokenInfoRaw;
-  token1: PoolSearchTokenInfoRaw;
-  metrics: {
-    tvlUSD: string;
-    volume24hUSD: string;
-    fees24hUSD: string;
-    fees7dUSD: string;
-    volume7dAvgUSD: string;
-    fees7dAvgUSD: string;
-    apr7d: number | null;
-    feeApr24h?: number | null;
-    feeApr7dAvg?: number | null;
-    feeAprPrimary?: number | null;
-    feeAprSource?: '24h' | '7d_avg' | 'unavailable';
-    volatility?: VolatilityBlockRaw;
-    sigmaFilter?: SigmaFilterBlockRaw;
-  };
-  isFavorite?: boolean;
-  userProvidedInfo?: { isToken0Quote: boolean };
-}
-
 /**
  * Format a single pool search result for MCP output. Mirrors `formatPool`'s
  * shape (canonical token0/token1, dual-emitted USD fields, humanized
@@ -616,7 +556,7 @@ interface PoolSearchResultRaw {
  * (`isFavorite`, `userProvidedInfo`).
  */
 export function formatPoolSearchResult(
-  result: PoolSearchResultRaw
+  result: PoolSearchResultItem
 ): Record<string, unknown> {
   const fmtUsd = (raw: string | undefined): string | null =>
     raw ? formatUSDValue(raw) : null;

--- a/apps/midcurve-mcp-server/src/formatters.ts
+++ b/apps/midcurve-mcp-server/src/formatters.ts
@@ -358,6 +358,11 @@ export function formatPnl(pnl: PnlResponseRaw): Record<string, unknown> {
  * `metrics` (PoolMetricsBlock per PRD-pool-sigma-filter) and `feeData` siblings.
  */
 interface PoolDetailRaw {
+  // TODO(#52): replace this hand-written subset with the canonical pool wire
+  // shape once #52 introduces a true plain-object wire type in
+  // @midcurve/api-shared. The canonical `GetUniswapV3PoolData['pool']` is the
+  // UniswapV3Pool class type (Date fields, methods) — not what's actually on
+  // the wire. The subset below visibly advertises that gap.
   pool: {
     protocol: string;
     feeBps: number;

--- a/apps/midcurve-mcp-server/src/formatters.ts
+++ b/apps/midcurve-mcp-server/src/formatters.ts
@@ -376,6 +376,14 @@ interface SigmaFilterBlockRaw {
   verdictLongTerm: 'PASS' | 'FAIL' | 'INSUFFICIENT_DATA';
   verdictShortTerm: 'PASS' | 'FAIL' | 'INSUFFICIENT_DATA';
   verdictAgreement: 'AGREE' | 'DIVERGENT' | 'INSUFFICIENT_DATA';
+  coverageLongTerm: number | null;
+  coverageBand:
+    | 'deep_red'
+    | 'red'
+    | 'yellow'
+    | 'green'
+    | 'deep_green'
+    | 'insufficient_data';
 }
 interface PoolDetailRaw {
   pool: {
@@ -485,6 +493,11 @@ function formatSigmaFilter(s: SigmaFilterBlockRaw): Record<string, unknown> {
     verdictLongTerm: s.verdictLongTerm,
     verdictShortTerm: s.verdictShortTerm,
     verdictAgreement: s.verdictAgreement,
+    coverageLongTerm:
+      s.coverageLongTerm !== null && s.coverageLongTerm !== undefined
+        ? s.coverageLongTerm.toFixed(3)
+        : null,
+    coverageBand: s.coverageBand,
   };
 }
 

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/hooks/useWizardUrlState.ts
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/hooks/useWizardUrlState.ts
@@ -144,6 +144,8 @@ export function useWizardUrlState({
               verdictLongTerm: 'INSUFFICIENT_DATA',
               verdictShortTerm: 'INSUFFICIENT_DATA',
               verdictAgreement: 'INSUFFICIENT_DATA',
+              coverageLongTerm: null,
+              coverageBand: 'insufficient_data',
             },
           },
         };

--- a/packages/midcurve-api-shared/src/types/pools/sigma-filter.ts
+++ b/packages/midcurve-api-shared/src/types/pools/sigma-filter.ts
@@ -35,6 +35,26 @@ export type SigmaVerdict = 'PASS' | 'FAIL' | 'INSUFFICIENT_DATA';
 export type VerdictAgreement = 'AGREE' | 'DIVERGENT' | 'INSUFFICIENT_DATA';
 
 /**
+ * Discrete 5-band mapping derived from the LVR-coverage ratio
+ * (`feeApr / sigmaSqOver8_365d`). See RFC-0001 for canonical cutoffs.
+ *
+ * Cutoffs (half-open intervals, left bound inclusive):
+ * - `coverage < 0.5` → `deep_red`
+ * - `0.5 ≤ coverage < 0.9` → `red`
+ * - `0.9 ≤ coverage < 1.5` → `yellow`
+ * - `1.5 ≤ coverage < 3.0` → `green`
+ * - `coverage ≥ 3.0` → `deep_green`
+ * - `coverage === null` → `insufficient_data`
+ */
+export type CoverageBand =
+  | 'deep_red'
+  | 'red'
+  | 'yellow'
+  | 'green'
+  | 'deep_green'
+  | 'insufficient_data';
+
+/**
  * Source window used for `feeAprPrimary`.
  */
 export type FeeAprSource = '24h' | '7d_avg' | 'unavailable';
@@ -133,4 +153,22 @@ export interface SigmaFilterBlock {
   verdictShortTerm: SigmaVerdict;
   /** Agreement between long-term and short-term verdicts. */
   verdictAgreement: VerdictAgreement;
+  /**
+   * LVR-coverage ratio: `feeApr / sigmaSqOver8_365d`.
+   *
+   * Multiplicative analogue to `marginLongTerm`. `null` when either operand
+   * is null or `sigmaSqOver8_365d <= 0` (defensive — the σ-filter shouldn't
+   * produce non-positive σ²/8 for an `ok` window, but division-by-zero
+   * safety is cheap).
+   *
+   * See RFC-0001.
+   */
+  coverageLongTerm: number | null;
+  /**
+   * Discrete 5-band mapping derived from `coverageLongTerm`.
+   *
+   * `'insufficient_data'` exactly when `coverageLongTerm === null`.
+   * See RFC-0001 for cutoffs.
+   */
+  coverageBand: CoverageBand;
 }

--- a/packages/midcurve-services/src/services/pool-search/uniswapv3-pool-search-service.ts
+++ b/packages/midcurve-services/src/services/pool-search/uniswapv3-pool-search-service.ts
@@ -368,6 +368,8 @@ export class UniswapV3PoolSearchService {
             verdictLongTerm: 'INSUFFICIENT_DATA',
             verdictShortTerm: 'INSUFFICIENT_DATA',
             verdictAgreement: 'INSUFFICIENT_DATA',
+            coverageLongTerm: null,
+            coverageBand: 'insufficient_data',
           },
         };
 

--- a/packages/midcurve-services/src/services/volatility/pool-sigma-filter-service.test.ts
+++ b/packages/midcurve-services/src/services/volatility/pool-sigma-filter-service.test.ts
@@ -107,16 +107,25 @@ describe('PoolSigmaFilterService.enrichPools', () => {
 
   describe('happy path — both legs ok', () => {
     it('produces a PASS verdict when feeApr exceeds σ²/8', async () => {
-      // Token A: tiny vol (~0% daily change) → σ ≈ 0
-      // Token B: tiny vol → σ ≈ 0 → cross-pair σ ≈ 0 → σ²/8 ≈ 0
-      // feeApr from large fees / large tvl → comfortably > 0
+      // Token A: small alternating ±0.1% returns → small but non-zero σ →
+      // strictly positive σ²/8 (avoids the coverage-ratio defensive guard
+      // for zero-denominator while keeping σ²/8 ≪ feeApr).
+      // Token B: constant → σ ≈ 0 → cross-pair σ ≈ σ_A.
+      // feeApr from large fees / large tvl → comfortably > σ²/8.
+      const seriesA: DailyPriceSeries = {
+        ref: 'coingecko/token-a',
+        pivotCurrency: 'usd',
+        status: 'ok',
+        closes: makeAlternatingSeries(0.001, 366),
+        fetchedAt: new Date().toISOString(),
+      };
       const { service } = buildMocks({
         tokenResolutions: new Map([
           [TOKEN_A, 'token-a'],
           [TOKEN_B, 'token-b'],
         ]),
         seriesEntries: [
-          { geckoId: 'token-a', series: constantGrowthSeries('token-a', 1, 1.0) },
+          { geckoId: 'token-a', series: seriesA },
           { geckoId: 'token-b', series: constantGrowthSeries('token-b', 1, 1.0) },
         ],
       });
@@ -145,6 +154,10 @@ describe('PoolSigmaFilterService.enrichPools', () => {
       expect(pool!.sigmaFilter.verdictAgreement).toBe('AGREE');
       expect(pool!.sigmaFilter.marginLongTerm).not.toBeNull();
       expect(pool!.sigmaFilter.marginLongTerm!).toBeGreaterThan(0);
+      // RFC-0001: deep_green band when feeApr ≫ σ²/8 (constant series ⇒ σ ≈ 0).
+      expect(pool!.sigmaFilter.coverageLongTerm).not.toBeNull();
+      expect(pool!.sigmaFilter.coverageLongTerm!).toBeGreaterThan(3);
+      expect(pool!.sigmaFilter.coverageBand).toBe('deep_green');
     });
 
     it('produces a FAIL verdict when feeApr is below σ²/8', async () => {
@@ -184,6 +197,10 @@ describe('PoolSigmaFilterService.enrichPools', () => {
       expect(pool.sigmaFilter.verdictLongTerm).toBe('FAIL');
       expect(pool.sigmaFilter.verdictShortTerm).toBe('FAIL');
       expect(pool.sigmaFilter.verdictAgreement).toBe('AGREE');
+      // RFC-0001: tiny feeApr against large σ²/8 ⇒ coverage ≪ 0.5 ⇒ deep_red.
+      expect(pool.sigmaFilter.coverageLongTerm).not.toBeNull();
+      expect(pool.sigmaFilter.coverageLongTerm!).toBeLessThan(0.5);
+      expect(pool.sigmaFilter.coverageBand).toBe('deep_red');
     });
   });
 
@@ -220,6 +237,9 @@ describe('PoolSigmaFilterService.enrichPools', () => {
       expect(pool.sigmaFilter.verdictShortTerm).toBe('INSUFFICIENT_DATA');
       expect(pool.sigmaFilter.verdictAgreement).toBe('INSUFFICIENT_DATA');
       expect(pool.sigmaFilter.marginLongTerm).toBeNull();
+      // RFC-0001: null feeApr ⇒ null coverage ⇒ insufficient_data band.
+      expect(pool.sigmaFilter.coverageLongTerm).toBeNull();
+      expect(pool.sigmaFilter.coverageBand).toBe('insufficient_data');
     });
 
     it('cascades token_not_listed: if either leg is unlisted, pair is non-ok', async () => {

--- a/packages/midcurve-services/src/services/volatility/pool-sigma-filter-service.ts
+++ b/packages/midcurve-services/src/services/volatility/pool-sigma-filter-service.ts
@@ -36,6 +36,8 @@ import type {
 import {
   alignDailySeries,
   cascadeStatus,
+  coverageBand,
+  coverageRatio,
   feeAprFromTvlAndFees,
   pairSigmaForWindow,
   sigmaVerdict,
@@ -360,6 +362,8 @@ function buildSigmaFilter(
   const verdictShortTerm: SigmaVerdict = sigmaVerdict(feeApr, sigmaSqOver8_60d);
   const agreement = verdictAgreement(verdictLongTerm, verdictShortTerm);
 
+  const coverageLongTerm = coverageRatio(feeApr, sigmaSqOver8_365d);
+
   return {
     feeApr,
     sigmaSqOver8_365d,
@@ -369,5 +373,7 @@ function buildSigmaFilter(
     verdictLongTerm,
     verdictShortTerm,
     verdictAgreement: agreement,
+    coverageLongTerm,
+    coverageBand: coverageBand(coverageLongTerm),
   };
 }

--- a/packages/midcurve-services/src/services/volatility/types.ts
+++ b/packages/midcurve-services/src/services/volatility/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  CoverageBand,
   PairVolatilityBlock,
   SigmaFilterBlock,
   SigmaResult,
@@ -18,6 +19,7 @@ import type {
 } from '@midcurve/api-shared';
 
 export type {
+  CoverageBand,
   PairVolatilityBlock,
   SigmaFilterBlock,
   SigmaResult,

--- a/packages/midcurve-services/src/services/volatility/volatility-math.test.ts
+++ b/packages/midcurve-services/src/services/volatility/volatility-math.test.ts
@@ -4,6 +4,8 @@ import {
   annualisedSigma,
   bucketByIsoDate,
   cascadeStatus,
+  coverageBand,
+  coverageRatio,
   dailyLogReturns,
   feeAprFromTvlAndFees,
   pairSigmaForWindow,
@@ -427,6 +429,90 @@ describe('cascadeStatus', () => {
 
   it('returns ok for empty input', () => {
     expect(cascadeStatus()).toBe('ok');
+  });
+});
+
+describe('coverageRatio', () => {
+  it('returns null when feeApr is null', () => {
+    expect(coverageRatio(null, 0.05)).toBeNull();
+  });
+
+  it('returns null when sigmaSqOver8 is null', () => {
+    expect(coverageRatio(0.25, null)).toBeNull();
+  });
+
+  it('returns null when sigmaSqOver8 is zero', () => {
+    expect(coverageRatio(0.25, 0)).toBeNull();
+  });
+
+  it('returns null when sigmaSqOver8 is negative (defensive)', () => {
+    expect(coverageRatio(0.25, -0.01)).toBeNull();
+  });
+
+  it('computes feeApr / sigmaSqOver8 when both operands are valid', () => {
+    expect(coverageRatio(0.25, 0.1)).toBeCloseTo(2.5, 12);
+    expect(coverageRatio(0.05, 0.1)).toBeCloseTo(0.5, 12);
+  });
+
+  it('handles a zero feeApr (degenerate but well-defined)', () => {
+    expect(coverageRatio(0, 0.1)).toBe(0);
+  });
+});
+
+describe('coverageBand', () => {
+  it('returns insufficient_data when coverage is null', () => {
+    expect(coverageBand(null)).toBe('insufficient_data');
+  });
+
+  it('returns deep_red for coverage strictly below 0.5', () => {
+    expect(coverageBand(0)).toBe('deep_red');
+    expect(coverageBand(0.4999)).toBe('deep_red');
+  });
+
+  it('returns red on the inclusive lower bound 0.5', () => {
+    expect(coverageBand(0.5)).toBe('red');
+  });
+
+  it('returns red across [0.5, 0.9)', () => {
+    expect(coverageBand(0.7)).toBe('red');
+    expect(coverageBand(0.8999)).toBe('red');
+  });
+
+  it('returns yellow on the inclusive lower bound 0.9', () => {
+    expect(coverageBand(0.9)).toBe('yellow');
+  });
+
+  it('returns yellow across [0.9, 1.5)', () => {
+    expect(coverageBand(1.0)).toBe('yellow');
+    expect(coverageBand(1.4999)).toBe('yellow');
+  });
+
+  it('returns green on the inclusive lower bound 1.5', () => {
+    expect(coverageBand(1.5)).toBe('green');
+  });
+
+  it('returns green across [1.5, 3.0)', () => {
+    expect(coverageBand(2.0)).toBe('green');
+    expect(coverageBand(2.9999)).toBe('green');
+  });
+
+  it('returns deep_green on the inclusive lower bound 3.0', () => {
+    expect(coverageBand(3.0)).toBe('deep_green');
+  });
+
+  it('returns deep_green for arbitrarily large coverage', () => {
+    expect(coverageBand(10)).toBe('deep_green');
+    expect(coverageBand(1_000)).toBe('deep_green');
+  });
+
+  it('round-trip with sigmaVerdict: coverage < 1 ⇒ FAIL, coverage > 1 ⇒ PASS', () => {
+    // The verdict uses strict feeApr > sigmaSqOver8, so the ↔ at exactly
+    // coverage = 1.0 lands on FAIL — we test strict inequalities only.
+    const feeApr = 0.05;
+    expect(coverageRatio(feeApr, feeApr * 2)).toBeCloseTo(0.5, 12); // < 1
+    expect(sigmaVerdict(feeApr, feeApr * 2)).toBe('FAIL');
+    expect(coverageRatio(feeApr, feeApr / 2)).toBeCloseTo(2.0, 12); // > 1
+    expect(sigmaVerdict(feeApr, feeApr / 2)).toBe('PASS');
   });
 });
 

--- a/packages/midcurve-services/src/services/volatility/volatility-math.ts
+++ b/packages/midcurve-services/src/services/volatility/volatility-math.ts
@@ -13,6 +13,7 @@
  */
 
 import type {
+  CoverageBand,
   PairSigmaResult,
   SigmaResult,
   SigmaStatus,
@@ -225,6 +226,42 @@ export function sigmaVerdict(
   if (sigmaSqOver8 === null || feeApr === null) return 'INSUFFICIENT_DATA';
   if (feeApr > sigmaSqOver8) return 'PASS';
   return 'FAIL';
+}
+
+/**
+ * LVR-coverage ratio — `feeApr / sigmaSqOver8` (RFC-0001).
+ *
+ * Multiplicative analogue to the additive `feeApr - sigmaSqOver8` margin.
+ * Returns `null` when either operand is null or `sigmaSqOver8 <= 0`
+ * (defensive — division-by-zero / negative-denominator guard).
+ */
+export function coverageRatio(
+  feeApr: number | null,
+  sigmaSqOver8: number | null,
+): number | null {
+  if (feeApr === null || sigmaSqOver8 === null) return null;
+  if (sigmaSqOver8 <= 0) return null;
+  return feeApr / sigmaSqOver8;
+}
+
+/**
+ * Discrete 5-band mapping for the LVR-coverage ratio (RFC-0001).
+ *
+ * Half-open intervals, left bound inclusive:
+ * - `coverage < 0.5` → `deep_red`
+ * - `0.5 ≤ coverage < 0.9` → `red`
+ * - `0.9 ≤ coverage < 1.5` → `yellow`
+ * - `1.5 ≤ coverage < 3.0` → `green`
+ * - `coverage ≥ 3.0` → `deep_green`
+ * - `coverage === null` → `insufficient_data`
+ */
+export function coverageBand(coverage: number | null): CoverageBand {
+  if (coverage === null) return 'insufficient_data';
+  if (coverage < 0.5) return 'deep_red';
+  if (coverage < 0.9) return 'red';
+  if (coverage < 1.5) return 'yellow';
+  if (coverage < 3.0) return 'green';
+  return 'deep_green';
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements [RFC-0001](https://github.com/0xNedAlbo/midcurve-finance/issues/48). Extends `SigmaFilterBlock` with two new fields so every consumer (UI, MCP server, future clients) gets the LVR-coverage indicator pre-computed and avoids drift on the cutoff mapping.

- `coverageLongTerm: number | null` — the multiplicative coverage ratio `feeApr / sigmaSqOver8_365d`. `null` when either operand is null or `sigmaSqOver8_365d <= 0` (defensive division-by-zero guard, per the RFC).
- `coverageBand: CoverageBand` — discrete 5-band enum (`deep_red` / `red` / `yellow` / `green` / `deep_green`), or `insufficient_data` exactly when `coverageLongTerm === null`. Cutoffs match the RFC table verbatim (half-open intervals, left bound inclusive: `<0.5`, `[0.5, 0.9)`, `[0.9, 1.5)`, `[1.5, 3.0)`, `≥3.0`).

Computation lives in the σ-filter pipeline next to `marginLongTerm` and `verdictLongTerm` — no new data dependency. The four hand-built `INSUFFICIENT_DATA` scaffolds (pool-search service, API empty-block helper, metrics route, wizard hook) and the MCP formatter's local `SigmaFilterBlockRaw` were updated to stay type-correct; the MCP `formatSigmaFilter` passes `coverageLongTerm` as `.toFixed(3)` (matching the existing `velocity` pattern) and `coverageBand` as the raw enum.

A follow-up commit then drops the σ-filter / pool-search local `*Raw` interfaces in `formatters.ts` (`SigmaResultRaw`, `VolatilityBlockRaw`, `SigmaFilterBlockRaw`, `PoolSearchTokenInfoRaw`, `PoolSearchResultRaw`) and imports the canonical types from `@midcurve/api-shared`, so future schema changes only need a single edit.

Frontend rendering, the 5-band pill, the `>5×` display cap, short-term coverage, and dynamic cutoffs are explicitly out of scope here — see RFC-0001's "Out of Scope" section.

## Test plan
- [x] Unit tests for `coverageRatio`: null/zero/negative-denominator guards, finite arithmetic.
- [x] Unit tests for `coverageBand`: every cutoff boundary from the RFC table, both sides.
- [x] Round-trip sanity check between `coverageRatio` and `sigmaVerdict` on strict inequalities (the boundary at `coverage === 1.0` is intentionally not asserted because the verdict uses strict `>`).
- [x] Service-level assertions on PASS / FAIL / INSUFFICIENT_DATA cases that the new fields are populated correctly. PASS-case fixture tweaked to use small alternating ±0.1% returns so σ²/8 > 0 (the original constant series produced σ = 0 exactly, tripping the defensive guard).
- [x] MCP formatter test fixtures updated.
- [x] After the refactor commit: search-result test fixture extended with the now-required `volatility` / `sigmaFilter` blocks; the obsolete "missing volatility / sigmaFilter" test removed (unreachable under the canonical type).
- [x] Typecheck clean across `@midcurve/services`, `@midcurve/mcp-server`, `@midcurve/api`, `@midcurve/ui`.
- [x] All 128 services tests + 13 MCP tests pass.

Fixes #48
Also closes #50

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>