### PR TITLE
ci: add PR-trigger test workflow

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,0 +1,55 @@
+name: PR Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: pr-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Build, typecheck & unit tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test @midcurve/shared
+        run: pnpm --filter @midcurve/shared test:run
+
+      - name: Test @midcurve/api-shared
+        run: pnpm --filter @midcurve/api-shared test:run
+
+      - name: Test @midcurve/mcp-server
+        run: pnpm --filter @midcurve/mcp-server test:run


### PR DESCRIPTION
## Summary

Adds a separate GitHub Actions workflow that runs on `pull_request` events targeting `main`. The existing [.github/workflows/build-images.yml](.github/workflows/build-images.yml) is intentionally untouched so production image builds are not triggered by PRs.

The new workflow installs dependencies, builds (Turborepo prerequisite for `typecheck`), runs `pnpm typecheck` across the whole monorepo, and runs unit tests for the three packages whose tests are pure (no DB, no RPC keys, no `.env.test`).

Fixes #51

## What's covered

- ✅ Typecheck across all packages (`pnpm typecheck` via Turborepo).
- ✅ Unit tests:
  - `@midcurve/shared` (127 tests)
  - `@midcurve/api-shared` (8 tests)
  - `@midcurve/mcp-server` (13 tests)
- ✅ Concurrency group with `cancel-in-progress: true` so superseded pushes get cancelled.
- ✅ Read-only permissions (`contents: read`, `pull-requests: read`).
- ✅ pnpm cache via `actions/setup-node@v4`.

## Intentional gaps (follow-up)

Per discussion on the issue, the following are deliberate gaps in this iteration:

- **`@midcurve/services` tests** — the `test:run` script invokes `node --env-file=.env.test`, and `.env.test` is gitignored and contains real RPC / Etherscan / TheGraph API keys. Wiring CI secrets is a separate decision; a follow-up issue will be opened post-merge to track this.
- **`@midcurve/ui` test** — there's a single Vitest file at [apps/midcurve-ui/src/lib/\_\_tests\_\_/update-position-in-list-cache.test.ts](apps/midcurve-ui/src/lib/__tests__/update-position-in-list-cache.test.ts), but the existing [apps/midcurve-ui/vitest.config.ts](apps/midcurve-ui/vitest.config.ts) restricts `include` to `src/app/api/**/*.e2e.test.ts` (a stale path), and `vitest` is not declared in the package's `devDependencies`. Including this in CI requires fixing the test infrastructure first — separate concern.
- **Foundry tests** for `apps/midcurve-contracts` — separate toolchain.
- **ESLint** — not part of the existing `main` workflow either.
- **PRs targeting non-`main` branches** — YAGNI per issue out-of-scope.

## Local verification

```
$ pnpm --filter @midcurve/shared test:run        # 127 passed
$ pnpm --filter @midcurve/api-shared test:run    # 8 passed
$ pnpm --filter @midcurve/mcp-server test:run    # 13 passed
$ pnpm typecheck                                  # 14/14 successful
```

## Test plan

- [ ] CI run on this PR completes successfully (this PR is itself the first exercise of the workflow).
- [ ] Verify the check run appears in the PR's "Checks" tab and on the merge box.
- [ ] Confirm `build-images.yml` does not fire for this PR (only the new workflow should run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)