### PR TITLE
feat: LVR-Coverage indicator + column manager in pool search table

### DIFF
--- a/apps/midcurve-api/src/app/api/v1/user/me/settings/pool-table-columns/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/user/me/settings/pool-table-columns/route.ts
@@ -1,0 +1,144 @@
+/**
+ * Pool Table Visible Columns Endpoints
+ *
+ * GET  /api/v1/user/me/settings/pool-table-columns - Returns the visible-column list
+ * PUT  /api/v1/user/me/settings/pool-table-columns - Replaces the visible-column list
+ *
+ * Authentication: Required (session only)
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  ApiErrorCode,
+  ErrorCodeToHttpStatus,
+  UpdatePoolTableColumnsRequestSchema,
+  type PoolTableColumnsData,
+} from '@midcurve/api-shared';
+import { withAuth } from '@/middleware/with-auth';
+import { apiLogger, apiLog } from '@/lib/logger';
+import { getUserSettingsService } from '@/lib/services';
+import { createPreflightResponse } from '@/lib/cors';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function OPTIONS(request: NextRequest): Promise<Response> {
+  return createPreflightResponse(request.headers.get('origin'));
+}
+
+export async function GET(request: NextRequest): Promise<Response> {
+  return withAuth(request, async (user, requestId) => {
+    const startTime = Date.now();
+
+    try {
+      const visibleColumns = await getUserSettingsService().getPoolTableVisibleColumns(
+        user.id
+      );
+
+      const data: PoolTableColumnsData = { visibleColumns };
+      const response = createSuccessResponse(data);
+
+      apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+
+      return NextResponse.json(response, {
+        status: 200,
+        headers: { 'Cache-Control': 'private, no-cache' },
+      });
+    } catch (error) {
+      apiLog.methodError(
+        apiLogger,
+        'GET /api/v1/user/me/settings/pool-table-columns',
+        error,
+        { requestId, userId: user.id }
+      );
+
+      const errorResponse = createErrorResponse(
+        ApiErrorCode.INTERNAL_SERVER_ERROR,
+        'Failed to retrieve pool table columns',
+        error instanceof Error ? error.message : String(error)
+      );
+
+      apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+
+      return NextResponse.json(errorResponse, {
+        status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+      });
+    }
+  });
+}
+
+export async function PUT(request: NextRequest): Promise<Response> {
+  return withAuth(request, async (user, requestId) => {
+    const startTime = Date.now();
+
+    try {
+      let body: unknown;
+      try {
+        body = await request.json();
+      } catch {
+        const errorResponse = createErrorResponse(
+          ApiErrorCode.VALIDATION_ERROR,
+          'Invalid JSON body'
+        );
+        apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+        return NextResponse.json(errorResponse, {
+          status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+        });
+      }
+
+      const validation = UpdatePoolTableColumnsRequestSchema.safeParse(body);
+      if (!validation.success) {
+        apiLog.validationError(apiLogger, requestId, validation.error.errors);
+
+        const errorResponse = createErrorResponse(
+          ApiErrorCode.VALIDATION_ERROR,
+          'Invalid request body',
+          validation.error.errors
+        );
+
+        apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+
+        return NextResponse.json(errorResponse, {
+          status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+        });
+      }
+
+      const { visibleColumns } = validation.data;
+
+      const updated = await getUserSettingsService().updatePoolTableVisibleColumns(
+        user.id,
+        visibleColumns
+      );
+
+      const data: PoolTableColumnsData = {
+        visibleColumns: updated.poolTableVisibleColumns,
+      };
+      const response = createSuccessResponse(data);
+
+      apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+
+      return NextResponse.json(response, { status: 200 });
+    } catch (error) {
+      apiLog.methodError(
+        apiLogger,
+        'PUT /api/v1/user/me/settings/pool-table-columns',
+        error,
+        { requestId, userId: user.id }
+      );
+
+      const errorResponse = createErrorResponse(
+        ApiErrorCode.INTERNAL_SERVER_ERROR,
+        'Failed to update pool table columns',
+        error instanceof Error ? error.message : String(error)
+      );
+
+      apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+
+      return NextResponse.json(errorResponse, {
+        status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+      });
+    }
+  });
+}

--- a/apps/midcurve-api/src/lib/services.ts
+++ b/apps/midcurve-api/src/lib/services.ts
@@ -37,6 +37,7 @@ import {
   UniswapV3VaultLedgerService,
   UserWalletService,
   PoolSigmaFilterService,
+  UserSettingsService,
 } from '@midcurve/services';
 
 // Service instances (lazy-initialized)
@@ -63,6 +64,7 @@ let _favoritePoolService: FavoritePoolService | null = null;
 let _swapRouterService: SwapRouterService | null = null;
 let _uniswapV3VaultPositionService: UniswapV3VaultPositionService | null = null;
 let _userWalletService: UserWalletService | null = null;
+let _userSettingsService: UserSettingsService | null = null;
 
 /**
  * Get singleton instance of AuthUserService
@@ -268,6 +270,16 @@ export function getFavoritePoolService(): FavoritePoolService {
     _favoritePoolService = new FavoritePoolService();
   }
   return _favoritePoolService;
+}
+
+/**
+ * Get singleton instance of UserSettingsService
+ */
+export function getUserSettingsService(): UserSettingsService {
+  if (!_userSettingsService) {
+    _userSettingsService = new UserSettingsService();
+  }
+  return _userSettingsService;
 }
 
 /**

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/LvrCoveragePill.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/LvrCoveragePill.tsx
@@ -1,0 +1,132 @@
+/**
+ * LVR-Coverage Pill
+ *
+ * Renders the 5-band LVR-Coverage indicator from RFC-0001 in the pool search
+ * table. Color encodes the band, text inside the pill is the coverage value
+ * (or `n/a` for `insufficient_data`). Hover surfaces the underlying numbers,
+ * or the reason why coverage couldn't be computed.
+ */
+
+import type {
+  CoverageBand,
+  PoolSearchResultItem,
+  SigmaFilterBlock,
+  SigmaStatus,
+  VolatilityBlock,
+} from '@midcurve/api-shared';
+
+interface LvrCoveragePillProps {
+  pool: PoolSearchResultItem;
+}
+
+const BAND_CLASS: Record<CoverageBand, string> = {
+  deep_red: 'bg-red-700',
+  red: 'bg-red-500',
+  yellow: 'bg-yellow-500',
+  green: 'bg-green-500',
+  deep_green: 'bg-green-700',
+  insufficient_data: 'bg-gray-500',
+};
+
+function formatCoverage(coverage: number | null): string {
+  if (coverage === null) return 'n/a';
+  if (coverage >= 5) return '>5×';
+  const rounded = coverage.toFixed(1);
+  if (rounded === '5.0') return '>5×';
+  return `${rounded}×`;
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null) return 'n/a';
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatRatio(value: number | null): string {
+  if (value === null) return 'n/a';
+  return value.toFixed(2);
+}
+
+/**
+ * Resolve the human-readable reason for an `insufficient_data` band.
+ * Priority order matches RFC-0002 §"Tooltip on hover".
+ */
+function resolveInsufficientDataReason(
+  pool: PoolSearchResultItem,
+  volatility: VolatilityBlock
+): string {
+  const t0Status: SigmaStatus = volatility.token0.sigma365d.status;
+  const t1Status: SigmaStatus = volatility.token1.sigma365d.status;
+  const pairStatus: SigmaStatus = volatility.pair.sigma365d.status;
+
+  if (t0Status === 'token_not_listed') {
+    return `${pool.token0.symbol} not listed on CoinGecko`;
+  }
+  if (t1Status === 'token_not_listed') {
+    return `${pool.token1.symbol} not listed on CoinGecko`;
+  }
+
+  if (
+    t0Status === 'insufficient_history' ||
+    t1Status === 'insufficient_history' ||
+    pairStatus === 'insufficient_history'
+  ) {
+    return 'Pool or token too young for σ calculation';
+  }
+
+  if (
+    t0Status === 'fetch_failed' ||
+    t1Status === 'fetch_failed' ||
+    pairStatus === 'fetch_failed'
+  ) {
+    return 'Volatility data temporarily unavailable — try again later';
+  }
+
+  return 'LVR coverage cannot be computed for this pool';
+}
+
+export function LvrCoveragePill({ pool }: LvrCoveragePillProps) {
+  const sigmaFilter: SigmaFilterBlock = pool.metrics.sigmaFilter;
+  const volatility: VolatilityBlock = pool.metrics.volatility;
+
+  const band: CoverageBand = sigmaFilter.coverageBand;
+  const coverage = sigmaFilter.coverageLongTerm;
+  const isInsufficient = band === 'insufficient_data';
+
+  const colorClass = BAND_CLASS[band];
+  const text = formatCoverage(coverage);
+
+  return (
+    <div className="relative inline-block group">
+      <span
+        className={`inline-flex items-center justify-center px-2 py-0.5 rounded-full text-xs font-medium text-white cursor-help ${colorClass}`}
+      >
+        {text}
+      </span>
+      <div
+        className="absolute right-0 top-full mt-1 z-20 hidden group-hover:block bg-slate-800/95 border border-slate-700 rounded-lg p-3 shadow-xl backdrop-blur-sm whitespace-nowrap text-left"
+        role="tooltip"
+      >
+        {isInsufficient ? (
+          <p className="text-slate-300 text-sm">
+            {resolveInsufficientDataReason(pool, volatility)}
+          </p>
+        ) : (
+          <>
+            <p className="text-slate-300 text-sm">
+              <span className="text-slate-400">LVR threshold (σ²/8, 365d):</span>{' '}
+              {formatPercent(sigmaFilter.sigmaSqOver8_365d)}
+            </p>
+            <p className="text-slate-300 text-sm">
+              <span className="text-slate-400">Coverage ratio:</span>{' '}
+              {formatRatio(coverage)}
+            </p>
+            <p className="text-slate-300 text-sm">
+              <span className="text-slate-400">Fee APR (7d):</span>{' '}
+              {formatPercent(sigmaFilter.feeApr)}
+            </p>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTable.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTable.tsx
@@ -1,9 +1,19 @@
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { Star, ChevronUp, ChevronDown } from 'lucide-react';
 import type { PoolSearchResultItem } from '@midcurve/api-shared';
+import type { PoolTableColumnId } from '@midcurve/shared';
+import { LvrCoveragePill } from './LvrCoveragePill';
 
-type SortColumn = 'tvlUSD' | 'volume24hUSD' | 'fees24hUSD' | 'apr7d';
+type SortColumn = 'tvlUSD' | 'volume24hUSD' | 'fees24hUSD' | 'apr7d' | 'volume7dAvgUSD';
 type SortDirection = 'asc' | 'desc';
+
+interface ColumnDef {
+  id: PoolTableColumnId;
+  label: string;
+  align: 'left' | 'right';
+  sortKey?: SortColumn;
+  render: (pool: PoolSearchResultItem) => ReactNode;
+}
 
 interface PoolTableProps {
   pools: PoolSearchResultItem[];
@@ -11,7 +21,182 @@ interface PoolTableProps {
   onSelectPool: (pool: PoolSearchResultItem) => void;
   onToggleFavorite?: (pool: PoolSearchResultItem) => void;
   isLoading?: boolean;
+  visibleColumns: PoolTableColumnId[];
 }
+
+const formatCurrency = (value: string | number) => {
+  const numValue = typeof value === 'string' ? parseFloat(value) : value;
+  if (numValue >= 1_000_000) {
+    return `$${(numValue / 1_000_000).toFixed(1)}M`;
+  }
+  if (numValue >= 1_000) {
+    return `$${(numValue / 1_000).toFixed(1)}K`;
+  }
+  return `$${numValue.toFixed(0)}`;
+};
+
+const formatPercent = (value: number) => `${value.toFixed(1)}%`;
+
+const formatSignedPercent = (value: number | null) => {
+  if (value === null) return 'n/a';
+  const pct = value * 100;
+  const sign = pct > 0 ? '+' : '';
+  return `${sign}${pct.toFixed(1)}%`;
+};
+
+const formatRatio = (value: number | null, digits = 2) => {
+  if (value === null) return 'n/a';
+  return value.toFixed(digits);
+};
+
+const formatRawPercent = (value: number | null) => {
+  if (value === null) return 'n/a';
+  return `${(value * 100).toFixed(1)}%`;
+};
+
+const formatFeeTier = (feeTier: number) => `${(feeTier / 10000).toFixed(2)}%`;
+
+/**
+ * APR may be unreliable when pool has low/no liquidity, volume, or fees.
+ */
+const shouldShowAprWarning = (pool: PoolSearchResultItem): boolean => {
+  const tvl = parseFloat(pool.metrics.tvlUSD) || 0;
+  const volume = parseFloat(pool.metrics.volume24hUSD) || 0;
+  const fees = parseFloat(pool.metrics.fees24hUSD) || 0;
+  const apr = pool.metrics.apr7d || 0;
+
+  if (apr > 0 && tvl === 0) return true;
+  if (apr > 0 && fees === 0) return true;
+  if (volume === 0) return true;
+
+  return false;
+};
+
+/**
+ * Column registry. Display order is the array order; visibility is controlled
+ * by the `visibleColumns` prop.
+ */
+const COLUMNS: ColumnDef[] = [
+  {
+    id: 'tvl',
+    label: 'TVL',
+    align: 'right',
+    sortKey: 'tvlUSD',
+    render: (pool) => formatCurrency(pool.metrics.tvlUSD),
+  },
+  {
+    id: 'feeApr7d',
+    label: 'ø APR 7d',
+    align: 'right',
+    sortKey: 'apr7d',
+    render: (pool) => (
+      <div className="flex items-center justify-end gap-1">
+        <span className="text-green-400">{formatPercent(pool.metrics.apr7d)}</span>
+        {shouldShowAprWarning(pool) && (
+          <span
+            className="text-yellow-400 text-xs font-bold cursor-help"
+            title="APR may be unreliable: low TVL, volume, or fees"
+          >
+            !
+          </span>
+        )}
+      </div>
+    ),
+  },
+  {
+    id: 'lvrCoverage',
+    label: 'LVR-Coverage',
+    align: 'right',
+    render: (pool) => (
+      <div className="flex justify-end">
+        <LvrCoveragePill pool={pool} />
+      </div>
+    ),
+  },
+  {
+    id: 'volume7dAvg',
+    label: 'Volume 7d avg',
+    align: 'right',
+    sortKey: 'volume7dAvgUSD',
+    render: (pool) => formatCurrency(pool.metrics.volume7dAvgUSD),
+  },
+  {
+    id: 'fees24h',
+    label: 'Fees 24h',
+    align: 'right',
+    sortKey: 'fees24hUSD',
+    render: (pool) => formatCurrency(pool.metrics.fees24hUSD),
+  },
+  {
+    id: 'lvrThreshold',
+    label: 'LVR threshold',
+    align: 'right',
+    render: (pool) => formatRawPercent(pool.metrics.sigmaFilter.sigmaSqOver8_365d),
+  },
+  {
+    id: 'margin',
+    label: 'Margin',
+    align: 'right',
+    render: (pool) => {
+      const v = pool.metrics.sigmaFilter.marginLongTerm;
+      if (v === null) return <span className="text-slate-500">n/a</span>;
+      const pct = v * 100;
+      const cls = pct >= 0 ? 'text-green-400' : 'text-red-400';
+      return <span className={cls}>{formatSignedPercent(v)}</span>;
+    },
+  },
+  {
+    id: 'coverageRatio',
+    label: 'Coverage ratio',
+    align: 'right',
+    render: (pool) => formatRatio(pool.metrics.sigmaFilter.coverageLongTerm),
+  },
+  {
+    id: 'sigmaPair365d',
+    label: 'σ pair (365d)',
+    align: 'right',
+    render: (pool) => {
+      const v = pool.metrics.volatility.pair.sigma365d.value;
+      return formatRawPercent(v ?? null);
+    },
+  },
+  {
+    id: 'velocity',
+    label: 'Velocity',
+    align: 'right',
+    render: (pool) => formatRatio(pool.metrics.volatility.velocity),
+  },
+  {
+    id: 'verdict60d',
+    label: 'Verdict 60d',
+    align: 'right',
+    render: (pool) => {
+      const v = pool.metrics.sigmaFilter.verdictShortTerm;
+      const cls =
+        v === 'PASS'
+          ? 'text-green-400'
+          : v === 'FAIL'
+            ? 'text-red-400'
+            : 'text-slate-500';
+      return <span className={cls}>{v === 'INSUFFICIENT_DATA' ? 'n/a' : v}</span>;
+    },
+  },
+  {
+    id: 'verdictAgreement',
+    label: 'Agreement',
+    align: 'right',
+    render: (pool) => {
+      const v = pool.metrics.sigmaFilter.verdictAgreement;
+      const cls =
+        v === 'AGREE'
+          ? 'text-green-400'
+          : v === 'DIVERGENT'
+            ? 'text-yellow-400'
+            : 'text-slate-500';
+      return <span className={cls}>{v === 'INSUFFICIENT_DATA' ? 'n/a' : v}</span>;
+    },
+  },
+];
 
 export function PoolTable({
   pools,
@@ -19,54 +204,15 @@ export function PoolTable({
   onSelectPool,
   onToggleFavorite,
   isLoading = false,
+  visibleColumns,
 }: PoolTableProps) {
   const [sortColumn, setSortColumn] = useState<SortColumn>('tvlUSD');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
 
-  const formatCurrency = (value: string | number) => {
-    const numValue = typeof value === 'string' ? parseFloat(value) : value;
-    if (numValue >= 1_000_000) {
-      return `$${(numValue / 1_000_000).toFixed(1)}M`;
-    }
-    if (numValue >= 1_000) {
-      return `$${(numValue / 1_000).toFixed(1)}K`;
-    }
-    return `$${numValue.toFixed(0)}`;
-  };
-
-  const formatPercent = (value: number) => {
-    return `${value.toFixed(1)}%`;
-  };
-
-  const formatFeeTier = (feeTier: number) => {
-    // feeTier is in basis points (e.g., 3000 = 0.3%)
-    return `${(feeTier / 10000).toFixed(2)}%`;
-  };
-
-  /**
-   * Check if APR warning should be shown
-   * APR may be unreliable when pool has low/no liquidity, volume, or fees
-   */
-  const shouldShowAprWarning = (pool: PoolSearchResultItem): boolean => {
-    const tvl = parseFloat(pool.metrics.tvlUSD) || 0;
-    const volume = parseFloat(pool.metrics.volume24hUSD) || 0;
-    const fees = parseFloat(pool.metrics.fees24hUSD) || 0;
-    const apr = pool.metrics.apr7d || 0;
-
-    // Warning if APR > 0 but pool metrics suggest unreliable data
-    if (apr > 0 && tvl === 0) return true; // Empty pool
-    if (apr > 0 && fees === 0) return true; // No recent fees
-    if (volume === 0) return true; // No trading activity
-
-    return false;
-  };
-
   const handleSort = (column: SortColumn) => {
     if (sortColumn === column) {
-      // Toggle direction if clicking same column
       setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
     } else {
-      // Default to descending for new column
       setSortColumn(column);
       setSortDirection('desc');
     }
@@ -80,61 +226,27 @@ export function PoolTable({
         return parseFloat(pool.metrics.volume24hUSD) || 0;
       case 'fees24hUSD':
         return parseFloat(pool.metrics.fees24hUSD) || 0;
+      case 'volume7dAvgUSD':
+        return parseFloat(pool.metrics.volume7dAvgUSD) || 0;
       case 'apr7d':
         return pool.metrics.apr7d || 0;
     }
   };
 
-  // Sort pools with favorites at top, then by selected column
   const sortedPools = [...pools].sort((a, b) => {
-    // Favorites always first
     if (a.isFavorite && !b.isFavorite) return -1;
     if (!a.isFavorite && b.isFavorite) return 1;
 
-    // Then sort by selected column
     const aValue = getNumericValue(a, sortColumn);
     const bValue = getNumericValue(b, sortColumn);
 
-    if (sortDirection === 'asc') {
-      return aValue - bValue;
-    }
+    if (sortDirection === 'asc') return aValue - bValue;
     return bValue - aValue;
   });
 
-  const SortHeader = ({
-    column,
-    label,
-    className = '',
-  }: {
-    column: SortColumn;
-    label: string;
-    className?: string;
-  }) => {
-    const isActive = sortColumn === column;
-    return (
-      <th
-        onClick={() => handleSort(column)}
-        className={`pb-3 font-medium cursor-pointer select-none transition-colors hover:text-slate-200 ${
-          isActive ? 'text-blue-400' : 'text-slate-400'
-        } ${className}`}
-      >
-        <div className="flex items-center justify-end gap-1">
-          <span>{label}</span>
-          <span className="w-4 h-4 flex items-center justify-center">
-            {isActive ? (
-              sortDirection === 'desc' ? (
-                <ChevronDown className="w-4 h-4" />
-              ) : (
-                <ChevronUp className="w-4 h-4" />
-              )
-            ) : (
-              <ChevronDown className="w-4 h-4 opacity-0 group-hover:opacity-30" />
-            )}
-          </span>
-        </div>
-      </th>
-    );
-  };
+  const orderedVisibleColumns: ColumnDef[] = COLUMNS.filter((c) =>
+    visibleColumns.includes(c.id)
+  );
 
   if (isLoading) {
     return (
@@ -154,18 +266,55 @@ export function PoolTable({
 
   return (
     <div className="h-full flex flex-col">
-      <h3 className="text-lg font-semibold text-white mb-4">Available Pools</h3>
-
       <div className="flex-1 overflow-auto">
         <table className="w-full text-left">
           <thead className="sticky top-0 bg-slate-800/90 backdrop-blur-sm">
             <tr className="border-b border-slate-700">
               <th className="pb-3 text-slate-400 font-medium w-10"></th>
               <th className="pb-3 text-slate-400 font-medium">Pool</th>
-              <SortHeader column="tvlUSD" label="TVL" className="text-right" />
-              <SortHeader column="volume24hUSD" label="Volume 24h" className="text-right" />
-              <SortHeader column="fees24hUSD" label="Fees 24h" className="text-right" />
-              <SortHeader column="apr7d" label="ø APR 7d" className="text-right" />
+              {orderedVisibleColumns.map((col) => {
+                const headerAlign = col.align === 'right' ? 'text-right' : 'text-left';
+                if (!col.sortKey) {
+                  return (
+                    <th
+                      key={col.id}
+                      className={`pb-3 font-medium text-slate-400 ${headerAlign}`}
+                    >
+                      {col.label}
+                    </th>
+                  );
+                }
+                const sortKey = col.sortKey;
+                const isActive = sortColumn === sortKey;
+                return (
+                  <th
+                    key={col.id}
+                    onClick={() => handleSort(sortKey)}
+                    className={`pb-3 font-medium cursor-pointer select-none transition-colors hover:text-slate-200 ${
+                      isActive ? 'text-blue-400' : 'text-slate-400'
+                    } ${headerAlign}`}
+                  >
+                    <div
+                      className={`flex items-center gap-1 ${
+                        col.align === 'right' ? 'justify-end' : 'justify-start'
+                      }`}
+                    >
+                      <span>{col.label}</span>
+                      <span className="w-4 h-4 flex items-center justify-center">
+                        {isActive ? (
+                          sortDirection === 'desc' ? (
+                            <ChevronDown className="w-4 h-4" />
+                          ) : (
+                            <ChevronUp className="w-4 h-4" />
+                          )
+                        ) : (
+                          <ChevronDown className="w-4 h-4 opacity-0 group-hover:opacity-30" />
+                        )}
+                      </span>
+                    </div>
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody className="text-white">
@@ -204,13 +353,11 @@ export function PoolTable({
                     <div className="flex flex-col">
                       <span className="font-medium">
                         {(() => {
-                          // Render in user-intended base/quote orientation when
-                          // the result carries userProvidedInfo (search / favorites).
-                          // Direct-Address results have no orientation → fall back
-                          // to pool-native token0/token1 ordering.
                           const isToken0Quote = pool.userProvidedInfo?.isToken0Quote;
-                          const baseSymbol = isToken0Quote === true ? pool.token1.symbol : pool.token0.symbol;
-                          const quoteSymbol = isToken0Quote === true ? pool.token0.symbol : pool.token1.symbol;
+                          const baseSymbol =
+                            isToken0Quote === true ? pool.token1.symbol : pool.token0.symbol;
+                          const quoteSymbol =
+                            isToken0Quote === true ? pool.token0.symbol : pool.token1.symbol;
                           return `${baseSymbol} / ${quoteSymbol}`;
                         })()}
                       </span>
@@ -219,24 +366,14 @@ export function PoolTable({
                       </span>
                     </div>
                   </td>
-                  <td className="py-3 text-right">{formatCurrency(pool.metrics.tvlUSD)}</td>
-                  <td className="py-3 text-right">{formatCurrency(pool.metrics.volume24hUSD)}</td>
-                  <td className="py-3 text-right">{formatCurrency(pool.metrics.fees24hUSD)}</td>
-                  <td className="py-3 text-right">
-                    <div className="flex items-center justify-end gap-1">
-                      <span className="text-green-400">
-                        {formatPercent(pool.metrics.apr7d)}
-                      </span>
-                      {shouldShowAprWarning(pool) && (
-                        <span
-                          className="text-yellow-400 text-xs font-bold cursor-help"
-                          title="APR may be unreliable: low TVL, volume, or fees"
-                        >
-                          !
-                        </span>
-                      )}
-                    </div>
-                  </td>
+                  {orderedVisibleColumns.map((col) => (
+                    <td
+                      key={col.id}
+                      className={`py-3 ${col.align === 'right' ? 'text-right' : 'text-left'}`}
+                    >
+                      {col.render(pool)}
+                    </td>
+                  ))}
                 </tr>
               );
             })}

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTable.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTable.tsx
@@ -268,7 +268,7 @@ export function PoolTable({
     <div className="h-full flex flex-col">
       <div className="flex-1 overflow-auto">
         <table className="w-full text-left">
-          <thead className="sticky top-0 bg-slate-800/90 backdrop-blur-sm">
+          <thead className="sticky top-0 z-10 bg-slate-800/90 backdrop-blur-sm">
             <tr className="border-b border-slate-700">
               <th className="pb-3 text-slate-400 font-medium w-10"></th>
               <th className="pb-3 text-slate-400 font-medium">Pool</th>

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
@@ -42,6 +42,16 @@ const ADDITIONAL_COLUMNS: ColumnDef[] = [
   { id: 'verdictAgreement', label: 'Verdict agreement' },
 ];
 
+const ITEMS_PER_COLUMN = 4;
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}
+
 export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManagerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
@@ -144,22 +154,36 @@ export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManage
         createPortal(
           <div
             ref={popoverRef}
-            className="fixed z-50 min-w-[220px] bg-slate-800/95 border border-slate-700 rounded-lg p-2 shadow-xl backdrop-blur-sm"
+            className="fixed z-50 bg-slate-800/95 border border-slate-700 rounded-lg p-2 shadow-xl backdrop-blur-sm"
             style={{
               top: `${menuPosition.top}px`,
               right: `${menuPosition.right}px`,
             }}
             role="menu"
           >
-            <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
-              Default columns
-            </div>
-            {DEFAULT_COLUMNS.map(renderRow)}
-            <div className="my-1 border-t border-slate-700/50" />
-            <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
-              Additional columns
-            </div>
-            {ADDITIONAL_COLUMNS.map(renderRow)}
+            {[
+              { title: 'Default columns', items: DEFAULT_COLUMNS },
+              { title: 'Additional columns', items: ADDITIONAL_COLUMNS },
+            ].map((section, sectionIdx) => (
+              <div
+                key={section.title}
+                className={sectionIdx === 0 ? 'mb-2' : ''}
+              >
+                <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
+                  {section.title}
+                </div>
+                <div className="flex gap-2">
+                  {chunk(section.items, ITEMS_PER_COLUMN).map((group, groupIdx) => (
+                    <div
+                      key={groupIdx}
+                      className="flex flex-col min-w-[200px]"
+                    >
+                      {group.map(renderRow)}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
           </div>,
           document.body
         )}

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
@@ -42,15 +42,6 @@ const ADDITIONAL_COLUMNS: ColumnDef[] = [
   { id: 'verdictAgreement', label: 'Verdict agreement' },
 ];
 
-const ITEMS_PER_COLUMN = 4;
-
-function chunk<T>(arr: T[], size: number): T[][] {
-  const result: T[][] = [];
-  for (let i = 0; i < arr.length; i += size) {
-    result.push(arr.slice(i, i + size));
-  }
-  return result;
-}
 
 export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManagerProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -154,36 +145,22 @@ export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManage
         createPortal(
           <div
             ref={popoverRef}
-            className="fixed z-50 bg-slate-800/95 border border-slate-700 rounded-lg p-2 shadow-xl backdrop-blur-sm"
+            className="fixed z-50 min-w-[220px] bg-slate-800/95 border border-slate-700 rounded-lg p-2 shadow-xl backdrop-blur-sm"
             style={{
               top: `${menuPosition.top}px`,
               right: `${menuPosition.right}px`,
             }}
             role="menu"
           >
-            {[
-              { title: 'Default columns', items: DEFAULT_COLUMNS },
-              { title: 'Additional columns', items: ADDITIONAL_COLUMNS },
-            ].map((section, sectionIdx) => (
-              <div
-                key={section.title}
-                className={sectionIdx === 0 ? 'mb-2' : ''}
-              >
-                <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
-                  {section.title}
-                </div>
-                <div className="flex gap-2">
-                  {chunk(section.items, ITEMS_PER_COLUMN).map((group, groupIdx) => (
-                    <div
-                      key={groupIdx}
-                      className="flex flex-col min-w-[200px]"
-                    >
-                      {group.map(renderRow)}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
+            <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
+              Default columns
+            </div>
+            {DEFAULT_COLUMNS.map(renderRow)}
+            <div className="my-1 border-t border-slate-700/50" />
+            <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
+              Additional columns
+            </div>
+            {ADDITIONAL_COLUMNS.map(renderRow)}
           </div>,
           document.body
         )}

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
@@ -56,7 +56,6 @@ function chunk<T>(arr: T[], size: number): T[][] {
 export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManagerProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
-  const [menuPosition, setMenuPosition] = useState({ top: 0, right: 0 });
   const buttonRef = useRef<HTMLButtonElement>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const updateMutation = useUpdatePoolTableColumns();
@@ -64,16 +63,6 @@ export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManage
   useEffect(() => {
     setMounted(true);
   }, []);
-
-  useEffect(() => {
-    if (isOpen && buttonRef.current) {
-      const rect = buttonRef.current.getBoundingClientRect();
-      setMenuPosition({
-        top: rect.bottom + 4,
-        right: window.innerWidth - rect.right,
-      });
-    }
-  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -120,7 +109,7 @@ export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManage
         key={id}
         type="button"
         onClick={() => toggle(id)}
-        className="w-full flex items-center gap-2 px-3 py-1.5 text-left text-sm text-slate-200 hover:bg-slate-700/50 cursor-pointer rounded transition-colors"
+        className="w-full flex items-center gap-2 px-2 py-1 text-left text-sm text-slate-200 hover:bg-slate-700/50 cursor-pointer rounded transition-colors"
       >
         <span
           className={`w-4 h-4 flex items-center justify-center rounded border ${
@@ -155,10 +144,11 @@ export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManage
         createPortal(
           <div
             ref={popoverRef}
-            className="fixed z-50 flex bg-slate-800/95 border border-slate-700 rounded-lg p-2 shadow-xl backdrop-blur-sm"
+            className="fixed z-50 flex bg-slate-800/95 border border-slate-700 rounded-lg p-1.5 shadow-xl backdrop-blur-sm"
             style={{
-              top: `${menuPosition.top}px`,
-              right: `${menuPosition.right}px`,
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
             }}
             role="menu"
           >
@@ -169,17 +159,17 @@ export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManage
               <div
                 key={section.title}
                 className={`flex flex-col ${
-                  sectionIdx > 0 ? 'border-l border-slate-700/50 pl-2 ml-2' : ''
+                  sectionIdx > 0 ? 'border-l border-slate-700/50 pl-1.5 ml-1.5' : ''
                 }`}
               >
-                <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
+                <div className="px-2 py-1 text-xs uppercase tracking-wide text-slate-500">
                   {section.title}
                 </div>
-                <div className="flex gap-2">
+                <div className="flex gap-1">
                   {chunk(section.items, ITEMS_PER_COLUMN).map((group, groupIdx) => (
                     <div
                       key={groupIdx}
-                      className="flex flex-col min-w-[200px]"
+                      className="flex flex-col min-w-[180px]"
                     >
                       {group.map(renderRow)}
                     </div>

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
@@ -42,6 +42,16 @@ const ADDITIONAL_COLUMNS: ColumnDef[] = [
   { id: 'verdictAgreement', label: 'Verdict agreement' },
 ];
 
+const ITEMS_PER_COLUMN = 4;
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const result: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    result.push(arr.slice(i, i + size));
+  }
+  return result;
+}
+
 
 export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManagerProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -145,22 +155,38 @@ export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManage
         createPortal(
           <div
             ref={popoverRef}
-            className="fixed z-50 min-w-[220px] bg-slate-800/95 border border-slate-700 rounded-lg p-2 shadow-xl backdrop-blur-sm"
+            className="fixed z-50 flex bg-slate-800/95 border border-slate-700 rounded-lg p-2 shadow-xl backdrop-blur-sm"
             style={{
               top: `${menuPosition.top}px`,
               right: `${menuPosition.right}px`,
             }}
             role="menu"
           >
-            <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
-              Default columns
-            </div>
-            {DEFAULT_COLUMNS.map(renderRow)}
-            <div className="my-1 border-t border-slate-700/50" />
-            <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
-              Additional columns
-            </div>
-            {ADDITIONAL_COLUMNS.map(renderRow)}
+            {[
+              { title: 'Default columns', items: DEFAULT_COLUMNS },
+              { title: 'Additional columns', items: ADDITIONAL_COLUMNS },
+            ].map((section, sectionIdx) => (
+              <div
+                key={section.title}
+                className={`flex flex-col ${
+                  sectionIdx > 0 ? 'border-l border-slate-700/50 pl-2 ml-2' : ''
+                }`}
+              >
+                <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
+                  {section.title}
+                </div>
+                <div className="flex gap-2">
+                  {chunk(section.items, ITEMS_PER_COLUMN).map((group, groupIdx) => (
+                    <div
+                      key={groupIdx}
+                      className="flex flex-col min-w-[200px]"
+                    >
+                      {group.map(renderRow)}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            ))}
           </div>,
           document.body
         )}

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
@@ -1,12 +1,16 @@
 /**
  * Pool Table Column Manager
  *
- * Gear icon + popover that lets the user toggle which metric columns are
- * visible in the pool search table. Persists immediately via the
+ * Gear icon + portal-rendered popover that lets the user toggle which metric
+ * columns are visible in the pool search table. Persists immediately via the
  * `useUpdatePoolTableColumns` mutation; optimistic update keeps it snappy.
+ *
+ * The popover renders into `document.body` via `createPortal` so it escapes
+ * any parent overflow/clipping context (e.g. the surrounding section card).
  */
 
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { Settings, Check } from 'lucide-react';
 import type { PoolTableColumnId } from '@midcurve/shared';
 import { useUpdatePoolTableColumns } from '@/hooks/user-settings/usePoolTableColumns';
@@ -40,15 +44,33 @@ const ADDITIONAL_COLUMNS: ColumnDef[] = [
 
 export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManagerProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [mounted, setMounted] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({ top: 0, right: 0 });
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
   const updateMutation = useUpdatePoolTableColumns();
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (isOpen && buttonRef.current) {
+      const rect = buttonRef.current.getBoundingClientRect();
+      setMenuPosition({
+        top: rect.bottom + 4,
+        right: window.innerWidth - rect.right,
+      });
+    }
+  }, [isOpen]);
 
   useEffect(() => {
     if (!isOpen) return;
     const handleClickOutside = (event: MouseEvent) => {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setIsOpen(false);
-      }
+      const target = event.target as Node;
+      if (buttonRef.current?.contains(target)) return;
+      if (popoverRef.current?.contains(target)) return;
+      setIsOpen(false);
     };
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') setIsOpen(false);
@@ -104,8 +126,9 @@ export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManage
   };
 
   return (
-    <div className="relative inline-block" ref={containerRef}>
+    <>
       <button
+        ref={buttonRef}
         type="button"
         onClick={() => setIsOpen((v) => !v)}
         className="p-1.5 rounded-md text-slate-400 hover:text-slate-200 hover:bg-slate-700/50 cursor-pointer transition-colors"
@@ -116,22 +139,30 @@ export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManage
         <Settings className="w-4 h-4" />
       </button>
 
-      {isOpen && (
-        <div
-          className="absolute right-0 top-full mt-1 z-30 min-w-[220px] bg-slate-800/95 border border-slate-700 rounded-lg p-2 shadow-xl backdrop-blur-sm"
-          role="menu"
-        >
-          <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
-            Default columns
-          </div>
-          {DEFAULT_COLUMNS.map(renderRow)}
-          <div className="my-1 border-t border-slate-700/50" />
-          <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
-            Additional columns
-          </div>
-          {ADDITIONAL_COLUMNS.map(renderRow)}
-        </div>
-      )}
-    </div>
+      {isOpen &&
+        mounted &&
+        createPortal(
+          <div
+            ref={popoverRef}
+            className="fixed z-50 min-w-[220px] bg-slate-800/95 border border-slate-700 rounded-lg p-2 shadow-xl backdrop-blur-sm"
+            style={{
+              top: `${menuPosition.top}px`,
+              right: `${menuPosition.right}px`,
+            }}
+            role="menu"
+          >
+            <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
+              Default columns
+            </div>
+            {DEFAULT_COLUMNS.map(renderRow)}
+            <div className="my-1 border-t border-slate-700/50" />
+            <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
+              Additional columns
+            </div>
+            {ADDITIONAL_COLUMNS.map(renderRow)}
+          </div>,
+          document.body
+        )}
+    </>
   );
 }

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableColumnManager.tsx
@@ -1,0 +1,137 @@
+/**
+ * Pool Table Column Manager
+ *
+ * Gear icon + popover that lets the user toggle which metric columns are
+ * visible in the pool search table. Persists immediately via the
+ * `useUpdatePoolTableColumns` mutation; optimistic update keeps it snappy.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Settings, Check } from 'lucide-react';
+import type { PoolTableColumnId } from '@midcurve/shared';
+import { useUpdatePoolTableColumns } from '@/hooks/user-settings/usePoolTableColumns';
+
+interface PoolTableColumnManagerProps {
+  visibleColumns: PoolTableColumnId[];
+}
+
+interface ColumnDef {
+  id: PoolTableColumnId;
+  label: string;
+}
+
+const DEFAULT_COLUMNS: ColumnDef[] = [
+  { id: 'tvl', label: 'TVL' },
+  { id: 'feeApr7d', label: 'Fee APR (7d)' },
+  { id: 'lvrCoverage', label: 'LVR-Coverage' },
+];
+
+const ADDITIONAL_COLUMNS: ColumnDef[] = [
+  { id: 'volume7dAvg', label: 'Volume (7d avg)' },
+  { id: 'fees24h', label: 'Fees (24h)' },
+  { id: 'lvrThreshold', label: 'LVR threshold (σ²/8)' },
+  { id: 'margin', label: 'Margin' },
+  { id: 'coverageRatio', label: 'Coverage ratio' },
+  { id: 'sigmaPair365d', label: 'σ pair (365d)' },
+  { id: 'velocity', label: 'Velocity (60d/365d)' },
+  { id: 'verdict60d', label: 'Verdict (60d)' },
+  { id: 'verdictAgreement', label: 'Verdict agreement' },
+];
+
+export function PoolTableColumnManager({ visibleColumns }: PoolTableColumnManagerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const updateMutation = useUpdatePoolTableColumns();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen]);
+
+  const visibleSet = new Set<PoolTableColumnId>(visibleColumns);
+
+  const toggle = (id: PoolTableColumnId) => {
+    const next = new Set(visibleSet);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    // Preserve canonical order: defaults first, then additional, both in
+    // their declaration order. This matches how PoolTable renders.
+    const ordered: PoolTableColumnId[] = [
+      ...DEFAULT_COLUMNS.map((c) => c.id),
+      ...ADDITIONAL_COLUMNS.map((c) => c.id),
+    ].filter((cid) => next.has(cid));
+
+    updateMutation.mutate(ordered);
+  };
+
+  const renderRow = ({ id, label }: ColumnDef) => {
+    const checked = visibleSet.has(id);
+    return (
+      <button
+        key={id}
+        type="button"
+        onClick={() => toggle(id)}
+        className="w-full flex items-center gap-2 px-3 py-1.5 text-left text-sm text-slate-200 hover:bg-slate-700/50 cursor-pointer rounded transition-colors"
+      >
+        <span
+          className={`w-4 h-4 flex items-center justify-center rounded border ${
+            checked
+              ? 'bg-blue-600 border-blue-600'
+              : 'bg-transparent border-slate-500'
+          }`}
+        >
+          {checked && <Check className="w-3 h-3 text-white" />}
+        </span>
+        <span>{label}</span>
+      </button>
+    );
+  };
+
+  return (
+    <div className="relative inline-block" ref={containerRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((v) => !v)}
+        className="p-1.5 rounded-md text-slate-400 hover:text-slate-200 hover:bg-slate-700/50 cursor-pointer transition-colors"
+        title="Manage visible columns"
+        aria-label="Manage visible columns"
+        aria-expanded={isOpen}
+      >
+        <Settings className="w-4 h-4" />
+      </button>
+
+      {isOpen && (
+        <div
+          className="absolute right-0 top-full mt-1 z-30 min-w-[220px] bg-slate-800/95 border border-slate-700 rounded-lg p-2 shadow-xl backdrop-blur-sm"
+          role="menu"
+        >
+          <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
+            Default columns
+          </div>
+          {DEFAULT_COLUMNS.map(renderRow)}
+          <div className="my-1 border-t border-slate-700/50" />
+          <div className="px-3 py-1.5 text-xs uppercase tracking-wide text-slate-500">
+            Additional columns
+          </div>
+          {ADDITIONAL_COLUMNS.map(renderRow)}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableSection.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableSection.tsx
@@ -1,0 +1,53 @@
+/**
+ * PoolTableSection
+ *
+ * Container for the pool search table: owns the visible-column persistence
+ * (`useGetPoolTableColumns`) and renders the section header, gear icon
+ * (column manager), and the presentational `PoolTable`.
+ */
+
+import type { PoolSearchResultItem } from '@midcurve/api-shared';
+import type { PoolTableColumnId } from '@midcurve/shared';
+import { useGetPoolTableColumns } from '@/hooks/user-settings/usePoolTableColumns';
+import { PoolTable } from './PoolTable';
+import { PoolTableColumnManager } from './PoolTableColumnManager';
+
+interface PoolTableSectionProps {
+  pools: PoolSearchResultItem[];
+  selectedPoolAddress: string | null;
+  onSelectPool: (pool: PoolSearchResultItem) => void;
+  onToggleFavorite?: (pool: PoolSearchResultItem) => void;
+  isLoading?: boolean;
+}
+
+const FALLBACK_COLUMNS: PoolTableColumnId[] = ['tvl', 'feeApr7d', 'lvrCoverage'];
+
+export function PoolTableSection({
+  pools,
+  selectedPoolAddress,
+  onSelectPool,
+  onToggleFavorite,
+  isLoading,
+}: PoolTableSectionProps) {
+  const { data } = useGetPoolTableColumns();
+  const visibleColumns = data?.visibleColumns ?? FALLBACK_COLUMNS;
+
+  return (
+    <div className="h-full flex flex-col">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-semibold text-white">Available Pools</h3>
+        <PoolTableColumnManager visibleColumns={visibleColumns} />
+      </div>
+      <div className="flex-1 min-h-0">
+        <PoolTable
+          pools={pools}
+          selectedPoolAddress={selectedPoolAddress}
+          onSelectPool={onSelectPool}
+          onToggleFavorite={onToggleFavorite}
+          isLoading={isLoading}
+          visibleColumns={visibleColumns}
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableSection.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableSection.tsx
@@ -34,7 +34,7 @@ export function PoolTableSection({
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between mb-4 relative z-20">
         <h3 className="text-lg font-semibold text-white">Available Pools</h3>
         <PoolTableColumnManager visibleColumns={visibleColumns} />
       </div>

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableSection.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/shared/PoolTableSection.tsx
@@ -34,7 +34,7 @@ export function PoolTableSection({
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex items-center justify-between mb-4 relative z-20">
+      <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-semibold text-white">Available Pools</h3>
         <PoolTableColumnManager visibleColumns={visibleColumns} />
       </div>

--- a/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/steps/PoolSelectionStep.tsx
+++ b/apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/steps/PoolSelectionStep.tsx
@@ -7,7 +7,7 @@ import {
   type PoolSelectionTab,
 } from '../context/CreatePositionWizardContext';
 import { WizardSummaryPanel } from '../shared/WizardSummaryPanel';
-import { PoolTable } from '../shared/PoolTable';
+import { PoolTableSection } from '../shared/PoolTableSection';
 import { TokenSetSearchInput } from '../shared/TokenSetSearchInput';
 import { usePoolSearch } from '@/hooks/pools/usePoolSearch';
 import { usePoolLookup } from '@/hooks/pools/usePoolLookup';
@@ -402,7 +402,7 @@ export function PoolSelectionStep() {
   const renderVisual = () => {
     if (state.poolSelectionTab === 'favorites') {
       return (
-        <PoolTable
+        <PoolTableSection
           pools={favoritePools}
           selectedPoolAddress={state.selectedPool?.poolAddress || null}
           onSelectPool={handleSelectPool}
@@ -414,7 +414,7 @@ export function PoolSelectionStep() {
 
     if (state.poolSelectionTab === 'direct') {
       return (
-        <PoolTable
+        <PoolTableSection
           pools={lookupPools}
           selectedPoolAddress={state.selectedPool?.poolAddress || null}
           onSelectPool={handleSelectPool}
@@ -425,7 +425,7 @@ export function PoolSelectionStep() {
     }
 
     return (
-      <PoolTable
+      <PoolTableSection
         pools={pools}
         selectedPoolAddress={state.selectedPool?.poolAddress || null}
         onSelectPool={handleSelectPool}

--- a/apps/midcurve-ui/src/hooks/user-settings/usePoolTableColumns.ts
+++ b/apps/midcurve-ui/src/hooks/user-settings/usePoolTableColumns.ts
@@ -1,0 +1,64 @@
+/**
+ * Pool Table Columns Hooks
+ *
+ * React Query hooks for the user's persisted pool-table column visibility.
+ *
+ * - useGetPoolTableColumns: read the visible-column list
+ * - useUpdatePoolTableColumns: replace the visible-column list (optimistic)
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { PoolTableColumnId } from '@midcurve/shared';
+import type { PoolTableColumnsData } from '@midcurve/api-shared';
+import { apiClient } from '@/lib/api-client';
+import { queryKeys } from '@/lib/query-keys';
+
+const ENDPOINT = '/api/v1/user/me/settings/pool-table-columns';
+
+export function useGetPoolTableColumns(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: queryKeys.user.settings.poolTableColumns(),
+    queryFn: async () => {
+      const response = await apiClient.get<PoolTableColumnsData>(ENDPOINT);
+      return response.data;
+    },
+    enabled: options?.enabled ?? true,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+}
+
+export function useUpdatePoolTableColumns() {
+  const queryClient = useQueryClient();
+  const queryKey = queryKeys.user.settings.poolTableColumns();
+
+  return useMutation<
+    PoolTableColumnsData,
+    Error,
+    PoolTableColumnId[],
+    { previous: PoolTableColumnsData | undefined }
+  >({
+    mutationFn: async (visibleColumns: PoolTableColumnId[]) => {
+      const response = await apiClient.put<PoolTableColumnsData>(ENDPOINT, {
+        visibleColumns,
+      });
+      return response.data;
+    },
+    onMutate: async (next) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<PoolTableColumnsData>(queryKey);
+      queryClient.setQueryData<PoolTableColumnsData>(queryKey, {
+        visibleColumns: next,
+      });
+      return { previous };
+    },
+    onError: (_err, _next, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData<PoolTableColumnsData>(queryKey, data);
+    },
+  });
+}

--- a/apps/midcurve-ui/src/lib/query-keys.ts
+++ b/apps/midcurve-ui/src/lib/query-keys.ts
@@ -206,6 +206,11 @@ export const queryKeys = {
     me: () => [...queryKeys.user.all, 'me'] as const,
     wallets: () => [...queryKeys.user.all, 'wallets'] as const,
     apiKeys: () => [...queryKeys.user.all, 'api-keys'] as const,
+    settings: {
+      all: () => [...queryKeys.user.all, 'settings'] as const,
+      poolTableColumns: () =>
+        [...queryKeys.user.settings.all(), 'pool-table-columns'] as const,
+    },
   },
 
   // ============================================

--- a/packages/midcurve-api-shared/src/types/index.ts
+++ b/packages/midcurve-api-shared/src/types/index.ts
@@ -20,3 +20,4 @@ export * from './shared-contracts/index.js';
 export * from './transactions/index.js';
 export * from './accounting/index.js';
 export * from './wallets/index.js';
+export * from './user-settings/index.js';

--- a/packages/midcurve-api-shared/src/types/user-settings/index.ts
+++ b/packages/midcurve-api-shared/src/types/user-settings/index.ts
@@ -1,0 +1,41 @@
+/**
+ * User Settings API Types
+ *
+ * Types for the per-user settings endpoints under
+ * `/api/v1/user/me/settings/...`.
+ */
+
+import { z } from 'zod';
+import { POOL_TABLE_COLUMN_IDS } from '@midcurve/shared';
+import type { PoolTableColumnId } from '@midcurve/shared';
+import type { ApiResponse } from '../common/index.js';
+
+// =============================================================================
+// POOL TABLE COLUMNS
+// =============================================================================
+
+/**
+ * Zod schema for a single column id. Validates against the runtime list of
+ * known ids exported from `@midcurve/shared`.
+ */
+export const PoolTableColumnIdSchema = z.enum(
+  POOL_TABLE_COLUMN_IDS as readonly [PoolTableColumnId, ...PoolTableColumnId[]]
+);
+
+/**
+ * Request body for `PUT /api/v1/user/me/settings/pool-table-columns`.
+ */
+export const UpdatePoolTableColumnsRequestSchema = z.object({
+  visibleColumns: z.array(PoolTableColumnIdSchema),
+});
+
+export type UpdatePoolTableColumnsRequest = z.infer<
+  typeof UpdatePoolTableColumnsRequestSchema
+>;
+
+export interface PoolTableColumnsData {
+  visibleColumns: PoolTableColumnId[];
+}
+
+export type GetPoolTableColumnsResponse = ApiResponse<PoolTableColumnsData>;
+export type UpdatePoolTableColumnsResponse = ApiResponse<PoolTableColumnsData>;

--- a/packages/midcurve-services/src/services/user-settings/user-settings-service.test.ts
+++ b/packages/midcurve-services/src/services/user-settings/user-settings-service.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { UserSettingsService } from './user-settings-service.js';
 import type { PrismaClient } from '@midcurve/database';
-import type { FavoritePoolEntry } from '@midcurve/shared';
+import type { FavoritePoolEntry, PoolTableColumnId } from '@midcurve/shared';
 
 /**
  * UserSettingsService — lazy backwards-compatibility for `favoritePoolHashes`.
@@ -268,6 +268,155 @@ describe('UserSettingsService — favoritePoolHashes lazy compat', () => {
       findUnique.mockResolvedValue(row([{ hash: 'uniswapv3/1/0xAAA' }]));
       const isFav = await service.isFavoritePoolHash('u1', 'uniswapv3/1/0xZZZ');
       expect(isFav).toBe(false);
+    });
+  });
+});
+
+describe('UserSettingsService — poolTableVisibleColumns', () => {
+  const findUnique = vi.fn();
+  const upsert = vi.fn();
+  const mockPrisma = {
+    userSettings: { findUnique, upsert },
+  } as unknown as PrismaClient;
+
+  let service: UserSettingsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new UserSettingsService({ prisma: mockPrisma });
+  });
+
+  function row(value: unknown): { settings: unknown } {
+    return {
+      settings: {
+        favoritePoolHashes: [],
+        costBasisMethod: 'fifo',
+        poolTableVisibleColumns: value,
+      },
+    };
+  }
+
+  const DEFAULT_COLUMNS: PoolTableColumnId[] = ['tvl', 'feeApr7d', 'lvrCoverage'];
+
+  describe('getPoolTableVisibleColumns — read normalization', () => {
+    it('returns defaults when no row exists', async () => {
+      findUnique.mockResolvedValue(null);
+      const cols = await service.getPoolTableVisibleColumns('u1');
+      expect(cols).toEqual(DEFAULT_COLUMNS);
+    });
+
+    it('returns defaults when the field is missing (legacy row)', async () => {
+      findUnique.mockResolvedValue({
+        settings: { favoritePoolHashes: [], costBasisMethod: 'fifo' },
+      });
+      const cols = await service.getPoolTableVisibleColumns('u1');
+      expect(cols).toEqual(DEFAULT_COLUMNS);
+    });
+
+    it('returns defaults when the field is not an array', async () => {
+      findUnique.mockResolvedValue(row('not-an-array'));
+      const cols = await service.getPoolTableVisibleColumns('u1');
+      expect(cols).toEqual(DEFAULT_COLUMNS);
+    });
+
+    it('round-trips a valid stored array', async () => {
+      findUnique.mockResolvedValue(
+        row(['tvl', 'feeApr7d', 'volume7dAvg', 'verdict60d'])
+      );
+      const cols = await service.getPoolTableVisibleColumns('u1');
+      expect(cols).toEqual<PoolTableColumnId[]>([
+        'tvl',
+        'feeApr7d',
+        'volume7dAvg',
+        'verdict60d',
+      ]);
+    });
+
+    it('drops unknown ids silently', async () => {
+      findUnique.mockResolvedValue(
+        row(['tvl', 'unknownColumn', 'feeApr7d', null, 42, 'lvrCoverage'])
+      );
+      const cols = await service.getPoolTableVisibleColumns('u1');
+      expect(cols).toEqual<PoolTableColumnId[]>([
+        'tvl',
+        'feeApr7d',
+        'lvrCoverage',
+      ]);
+    });
+
+    it('de-duplicates while preserving first occurrence', async () => {
+      findUnique.mockResolvedValue(
+        row(['tvl', 'feeApr7d', 'tvl', 'lvrCoverage', 'feeApr7d'])
+      );
+      const cols = await service.getPoolTableVisibleColumns('u1');
+      expect(cols).toEqual<PoolTableColumnId[]>([
+        'tvl',
+        'feeApr7d',
+        'lvrCoverage',
+      ]);
+    });
+
+    it('accepts an empty array (user can hide everything)', async () => {
+      findUnique.mockResolvedValue(row([]));
+      const cols = await service.getPoolTableVisibleColumns('u1');
+      expect(cols).toEqual([]);
+    });
+  });
+
+  describe('updatePoolTableVisibleColumns — write normalization', () => {
+    it('persists the validated set and returns the full settings', async () => {
+      findUnique.mockResolvedValue(row(DEFAULT_COLUMNS));
+      upsert.mockImplementation(async ({ update }: { update: { settings: unknown } }) => ({
+        settings: update.settings,
+      }));
+
+      const result = await service.updatePoolTableVisibleColumns('u1', [
+        'tvl',
+        'volume7dAvg',
+        'lvrThreshold',
+      ]);
+
+      expect(result.poolTableVisibleColumns).toEqual<PoolTableColumnId[]>([
+        'tvl',
+        'volume7dAvg',
+        'lvrThreshold',
+      ]);
+      const upsertArgs = upsert.mock.calls[0][0];
+      const persisted = upsertArgs.update.settings as {
+        poolTableVisibleColumns: unknown[];
+      };
+      expect(persisted.poolTableVisibleColumns).toEqual([
+        'tvl',
+        'volume7dAvg',
+        'lvrThreshold',
+      ]);
+    });
+
+    it('drops unknown ids before persisting', async () => {
+      findUnique.mockResolvedValue(row(DEFAULT_COLUMNS));
+      upsert.mockImplementation(async ({ update }: { update: { settings: unknown } }) => ({
+        settings: update.settings,
+      }));
+
+      const result = await service.updatePoolTableVisibleColumns('u1', [
+        'tvl',
+        'bogus',
+        'lvrCoverage',
+      ]);
+      expect(result.poolTableVisibleColumns).toEqual<PoolTableColumnId[]>([
+        'tvl',
+        'lvrCoverage',
+      ]);
+    });
+
+    it('persists an empty array verbatim', async () => {
+      findUnique.mockResolvedValue(row(DEFAULT_COLUMNS));
+      upsert.mockImplementation(async ({ update }: { update: { settings: unknown } }) => ({
+        settings: update.settings,
+      }));
+
+      const result = await service.updatePoolTableVisibleColumns('u1', []);
+      expect(result.poolTableVisibleColumns).toEqual([]);
     });
   });
 });

--- a/packages/midcurve-services/src/services/user-settings/user-settings-service.ts
+++ b/packages/midcurve-services/src/services/user-settings/user-settings-service.ts
@@ -19,8 +19,12 @@
 
 import { prisma as prismaClient, PrismaClient } from '@midcurve/database';
 import type { Prisma } from '@midcurve/database';
-import { DEFAULT_USER_SETTINGS } from '@midcurve/shared';
-import type { FavoritePoolEntry, UserSettingsData } from '@midcurve/shared';
+import { DEFAULT_USER_SETTINGS, POOL_TABLE_COLUMN_IDS } from '@midcurve/shared';
+import type {
+  FavoritePoolEntry,
+  PoolTableColumnId,
+  UserSettingsData,
+} from '@midcurve/shared';
 import { createServiceLogger, log } from '../../logging/index.js';
 import type { ServiceLogger } from '../../logging/index.js';
 
@@ -69,6 +73,33 @@ function normalizeEntries(raw: unknown): FavoritePoolEntry[] {
 }
 
 /**
+ * Normalize the raw `poolTableVisibleColumns` JSON value into a typed array.
+ *
+ * - Falls back to defaults when the stored value is missing or not an array
+ *   (covers legacy rows predating this field).
+ * - Drops unknown ids silently — schema may have removed columns since the
+ *   row was written.
+ * - De-duplicates while preserving first occurrence.
+ */
+function normalizeColumns(raw: unknown): PoolTableColumnId[] {
+  if (!Array.isArray(raw)) {
+    return [...DEFAULT_USER_SETTINGS.poolTableVisibleColumns];
+  }
+  const known = new Set<string>(POOL_TABLE_COLUMN_IDS);
+  const seen = new Set<PoolTableColumnId>();
+  const result: PoolTableColumnId[] = [];
+  for (const item of raw) {
+    if (typeof item !== 'string') continue;
+    if (!known.has(item)) continue;
+    const id = item as PoolTableColumnId;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    result.push(id);
+  }
+  return result;
+}
+
+/**
  * User Settings Service
  *
  * Manages per-user settings stored as a single JSON structure.
@@ -111,6 +142,7 @@ export class UserSettingsService {
       ...DEFAULT_USER_SETTINGS,
       ...(raw as Partial<UserSettingsData>),
       favoritePoolHashes: normalizeEntries(raw.favoritePoolHashes),
+      poolTableVisibleColumns: normalizeColumns(raw.poolTableVisibleColumns),
     };
 
     log.methodExit(this.logger, 'getByUserId', { found: true });
@@ -144,6 +176,7 @@ export class UserSettingsService {
       ...DEFAULT_USER_SETTINGS,
       ...(raw as Partial<UserSettingsData>),
       favoritePoolHashes: normalizeEntries(raw.favoritePoolHashes),
+      poolTableVisibleColumns: normalizeColumns(raw.poolTableVisibleColumns),
     };
 
     log.methodExit(this.logger, 'upsert', { userId });
@@ -232,5 +265,47 @@ export class UserSettingsService {
   ): Promise<boolean> {
     const entries = await this.getFavoritePoolEntries(userId);
     return entries.some((e) => e.hash === poolHash);
+  }
+
+  // ============================================================================
+  // POOL TABLE VISIBLE COLUMNS OPERATIONS
+  // ============================================================================
+
+  /**
+   * Returns the user's visible pool-table columns (lazy-defaulted from storage).
+   */
+  async getPoolTableVisibleColumns(
+    userId: string
+  ): Promise<PoolTableColumnId[]> {
+    const settings = await this.getByUserId(userId);
+    return settings.poolTableVisibleColumns;
+  }
+
+  /**
+   * Replaces the user's visible pool-table columns.
+   *
+   * Drops unknown ids and de-duplicates before persisting.
+   */
+  async updatePoolTableVisibleColumns(
+    userId: string,
+    columns: readonly string[]
+  ): Promise<UserSettingsData> {
+    log.methodEntry(this.logger, 'updatePoolTableVisibleColumns', {
+      userId,
+      columnCount: columns.length,
+    });
+
+    const normalized = normalizeColumns(columns);
+    const current = await this.getByUserId(userId);
+    const updated: UserSettingsData = {
+      ...current,
+      poolTableVisibleColumns: normalized,
+    };
+
+    const result = await this.upsert(userId, updated);
+    log.methodExit(this.logger, 'updatePoolTableVisibleColumns', {
+      columnCount: result.poolTableVisibleColumns.length,
+    });
+    return result;
   }
 }

--- a/packages/midcurve-shared/src/types/index.ts
+++ b/packages/midcurve-shared/src/types/index.ts
@@ -5,8 +5,8 @@
 
 // User types
 export type { User } from './user.js';
-export type { UserSettingsData, CostBasisMethod, FavoritePoolEntry } from './user-settings.js';
-export { DEFAULT_USER_SETTINGS } from './user-settings.js';
+export type { UserSettingsData, CostBasisMethod, FavoritePoolEntry, PoolTableColumnId } from './user-settings.js';
+export { DEFAULT_USER_SETTINGS, POOL_TABLE_COLUMN_IDS } from './user-settings.js';
 
 // ============================================================================
 // Accounting types (double-entry journal system)

--- a/packages/midcurve-shared/src/types/user-settings.ts
+++ b/packages/midcurve-shared/src/types/user-settings.ts
@@ -39,6 +39,47 @@ export interface FavoritePoolEntry {
 }
 
 /**
+ * Pool table column identifier — controls which metric columns the user
+ * has chosen to make visible in the pool search table.
+ *
+ * Column ordering inside the table is fixed in component code; the user
+ * controls visibility only.
+ */
+export type PoolTableColumnId =
+  | 'tvl'
+  | 'feeApr7d'
+  | 'lvrCoverage'
+  | 'volume7dAvg'
+  | 'fees24h'
+  | 'lvrThreshold'
+  | 'margin'
+  | 'coverageRatio'
+  | 'sigmaPair365d'
+  | 'velocity'
+  | 'verdict60d'
+  | 'verdictAgreement';
+
+/**
+ * Runtime list of all valid `PoolTableColumnId` values.
+ * Single source of truth for validation when reading stored settings or
+ * accepting user input.
+ */
+export const POOL_TABLE_COLUMN_IDS: readonly PoolTableColumnId[] = [
+  'tvl',
+  'feeApr7d',
+  'lvrCoverage',
+  'volume7dAvg',
+  'fees24h',
+  'lvrThreshold',
+  'margin',
+  'coverageRatio',
+  'sigmaPair365d',
+  'velocity',
+  'verdict60d',
+  'verdictAgreement',
+] as const;
+
+/**
  * UserSettingsData interface
  *
  * Defines the shape of the settings JSON column.
@@ -63,6 +104,19 @@ export interface UserSettingsData {
    * Determines how token lots are selected for disposal.
    */
   costBasisMethod: CostBasisMethod;
+
+  /**
+   * Pool search table columns the user has chosen to make visible.
+   *
+   * Column display order is hardcoded in the table component; this list
+   * only controls visibility. Star and Pool columns are always visible
+   * and not represented here.
+   *
+   * **Storage compatibility**: legacy installations predating this field
+   * fall back to `DEFAULT_USER_SETTINGS.poolTableVisibleColumns` via the
+   * read-side spread in `UserSettingsService.getByUserId`.
+   */
+  poolTableVisibleColumns: PoolTableColumnId[];
 }
 
 /**
@@ -71,4 +125,5 @@ export interface UserSettingsData {
 export const DEFAULT_USER_SETTINGS: UserSettingsData = {
   favoritePoolHashes: [],
   costBasisMethod: 'fifo',
+  poolTableVisibleColumns: ['tvl', 'feeApr7d', 'lvrCoverage'],
 };


### PR DESCRIPTION
## Summary

- Adds the RFC-0002 frontend treatment on top of RFC-0001's backend signals: 5-band LVR-Coverage pill with hover tooltip in the pool search table, plus a gear-icon column manager that lets users toggle which metric columns are visible.
- New persisted preference `poolTableVisibleColumns` on `UserSettingsData` (defaults to `Pool · TVL · Fee APR 7d · LVR-Coverage`); read/write via a dedicated `GET`/`PUT` at `/api/v1/user/me/settings/pool-table-columns` with optimistic-update mutation on the client.
- Lazy back-compat: legacy `UserSettings` rows automatically fall through to defaults via `UserSettingsService.getByUserId`. No Prisma migration.

## Test plan

- [x] `pnpm typecheck` (all 14 packages)
- [x] `pnpm --filter @midcurve/services test:run -- user-settings` (138 tests pass; new normalization + update tests cover defaults, unknown ids, dedup, empty arrays, round-trip)
- [ ] `pnpm dev`: in the create-position wizard, search for pools and verify
  - Default columns are Star · Pool · TVL · Fee APR 7d · LVR-Coverage
  - LVR-Coverage pill renders the band color and coverage value (`>5×` cap on rounded display)
  - Hovering a colored pill shows LVR threshold / Coverage ratio / Fee APR; gray pill shows derived reason
  - Gear icon opens popover with `Default columns` and `Additional columns` sections
  - Toggling columns updates the table immediately and persists across reload
  - The existing yellow `!` warning still fires alongside the LVR pill on degenerate-data pools

Fixes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)