### PR TITLE
fix: introduce UniswapV3PoolWire wire-shape type in @midcurve/api-shared

### DIFF
--- a/apps/midcurve-api/src/app/api/v1/pools/uniswapv3/[chainId]/[address]/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/pools/uniswapv3/[chainId]/[address]/route.ts
@@ -9,7 +9,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { withAuth } from '@/middleware/with-auth';
 import { UniswapV3SubgraphClient } from '@midcurve/services';
-import type { UniswapV3Pool } from '@midcurve/shared';
 import {
   createSuccessResponse,
   createErrorResponse,
@@ -237,10 +236,8 @@ export async function GET(
       const serializedPool = serializeUniswapV3Pool(pool);
 
       // 6. Build response
-      // Note: serializedPool has bigints/dates as strings for JSON compatibility
-      // The type cast is safe because the serialized structure matches UniswapV3Pool
       const responseData: GetUniswapV3PoolData = {
-        pool: serializedPool as unknown as UniswapV3Pool,
+        pool: serializedPool,
         ...(metricsData && { metrics: metricsData }),
         ...(feeData && { feeData }),
         ...(typeof isToken0Quote === 'boolean' && {

--- a/apps/midcurve-api/src/lib/serializers.ts
+++ b/apps/midcurve-api/src/lib/serializers.ts
@@ -23,6 +23,8 @@ import type {
   SerializedCloseOrder,
   AutomationState,
   SwapDirection,
+  UniswapV3PoolWire,
+  Erc20TokenWire,
 } from '@midcurve/api-shared';
 
 import type { CloseOrder } from '@midcurve/database';
@@ -90,14 +92,16 @@ export function serializeBigInt<T>(obj: T): SerializedValue {
  * Serialize UniswapV3Pool for JSON response
  *
  * Converts all bigint fields in pool state to strings for JSON compatibility.
+ * Return type is pinned to {@link UniswapV3PoolWire} so consumers can rely on
+ * the canonical wire shape (no class methods, bigints as strings).
  *
  * @param pool - UniswapV3Pool from service layer
- * @returns JSON-serializable pool object
+ * @returns JSON-serializable pool object matching UniswapV3PoolWire
  */
-export function serializeUniswapV3Pool(pool: UniswapV3Pool) {
+export function serializeUniswapV3Pool(pool: UniswapV3Pool): UniswapV3PoolWire {
   return {
     id: pool.id,
-    protocol: pool.protocol,
+    protocol: 'uniswapv3',
     token0: serializeErc20Token(pool.token0 as Erc20Token),
     token1: serializeErc20Token(pool.token1 as Erc20Token),
     feeBps: pool.feeBps,
@@ -136,16 +140,18 @@ export function serializeUniswapV3PoolState(state: UniswapV3PoolState) {
 /**
  * Serialize Erc20Token for JSON response
  *
- * Converts Date fields to ISO strings.
- * No bigint fields in token type.
+ * Converts Date fields to ISO strings. No bigint fields in token type.
+ * Return type is pinned to {@link Erc20TokenWire} for consistency with
+ * `serializeUniswapV3Pool`. The `tokenType` literal is fixed because the
+ * input is already narrowed to Erc20Token.
  *
  * @param token - Erc20Token from service layer
- * @returns JSON-serializable token object
+ * @returns JSON-serializable token object matching Erc20TokenWire
  */
-export function serializeErc20Token(token: Erc20Token) {
+export function serializeErc20Token(token: Erc20Token): Erc20TokenWire {
   return {
     id: token.id,
-    tokenType: token.tokenType,
+    tokenType: 'erc20',
     name: token.name,
     symbol: token.symbol,
     decimals: token.decimals,

--- a/apps/midcurve-mcp-server/src/formatters.test.ts
+++ b/apps/midcurve-mcp-server/src/formatters.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { Erc20TokenWire } from '@midcurve/api-shared';
 import { formatPool, formatPoolSearchResult } from './formatters.js';
 
 /**
@@ -10,27 +11,38 @@ import { formatPool, formatPoolSearchResult } from './formatters.js';
 
 type PoolDetail = Parameters<typeof formatPool>[0];
 
-const WETH = {
+const WETH: Erc20TokenWire = {
+  id: 'tok-weth-base',
+  tokenType: 'erc20',
+  name: 'Wrapped Ether',
   symbol: 'WETH',
   decimals: 18,
   config: {
     address: '0x4200000000000000000000000000000000000006',
     chainId: 8453,
   },
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
 };
 
-const USDC = {
+const USDC: Erc20TokenWire = {
+  id: 'tok-usdc-base',
+  tokenType: 'erc20',
+  name: 'USD Coin',
   symbol: 'USDC',
   decimals: 6,
   config: {
     address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
     chainId: 8453,
   },
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
 };
 
 function basePool(): PoolDetail {
   return {
     pool: {
+      id: 'pool-weth-usdc-base',
       protocol: 'uniswapv3',
       feeBps: 500,
       token0: WETH,
@@ -38,13 +50,20 @@ function basePool(): PoolDetail {
       config: {
         chainId: 8453,
         address: '0xd0b53D9277642d899DF5C87A3966A349A798F224',
+        token0: WETH.config.address,
+        token1: USDC.config.address,
+        feeBps: 500,
         tickSpacing: 10,
       },
       state: {
         sqrtPriceX96: '1234567890',
-        liquidity: '987654321',
         currentTick: 200000,
+        liquidity: '987654321',
+        feeGrowthGlobal0: '0',
+        feeGrowthGlobal1: '0',
       },
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
     },
   };
 }

--- a/apps/midcurve-mcp-server/src/formatters.ts
+++ b/apps/midcurve-mcp-server/src/formatters.ts
@@ -23,6 +23,7 @@ import type {
   PositionAccountingResponse,
   SerializedCloseOrder,
   SigmaFilterBlock,
+  UniswapV3PoolWire,
   VolatilityBlock,
 } from '@midcurve/api-shared';
 import type { PositionContext } from './lib/position-context.js';
@@ -358,19 +359,7 @@ export function formatPnl(pnl: PnlResponseRaw): Record<string, unknown> {
  * `metrics` (PoolMetricsBlock per PRD-pool-sigma-filter) and `feeData` siblings.
  */
 interface PoolDetailRaw {
-  // TODO(#52): replace this hand-written subset with the canonical pool wire
-  // shape once #52 introduces a true plain-object wire type in
-  // @midcurve/api-shared. The canonical `GetUniswapV3PoolData['pool']` is the
-  // UniswapV3Pool class type (Date fields, methods) — not what's actually on
-  // the wire. The subset below visibly advertises that gap.
-  pool: {
-    protocol: string;
-    feeBps: number;
-    token0: { symbol: string; decimals: number; config: { address: string; chainId: number } };
-    token1: { symbol: string; decimals: number; config: { address: string; chainId: number } };
-    config: { chainId: number; address: string; tickSpacing: number };
-    state: Record<string, unknown>;
-  };
+  pool: UniswapV3PoolWire;
   metrics?: {
     tvlUSD: string;
     volume24hUSD: string;

--- a/apps/midcurve-ui/src/hooks/pools/useDiscoverPool.ts
+++ b/apps/midcurve-ui/src/hooks/pools/useDiscoverPool.ts
@@ -28,8 +28,11 @@
  */
 
 import { useMutation } from '@tanstack/react-query';
-import type { UniswapV3Pool } from '@midcurve/shared';
-import type { GetUniswapV3PoolData, PoolUserProvidedInfo } from '@midcurve/api-shared';
+import type {
+  GetUniswapV3PoolData,
+  PoolUserProvidedInfo,
+  UniswapV3PoolWire,
+} from '@midcurve/api-shared';
 import { apiClient } from '@/lib/api-client';
 
 export interface DiscoverPoolParams {
@@ -52,9 +55,13 @@ export interface DiscoverPoolParams {
 
 export interface DiscoverPoolResult {
   /**
-   * The discovered pool data with fresh on-chain state
+   * The discovered pool data with fresh on-chain state.
+   *
+   * Wire shape from the API (bigints as strings, Dates as ISO strings, no
+   * class methods). Pass through `UniswapV3Pool.fromJSON()` if you need an
+   * in-memory class instance for math/formatting helpers.
    */
-  pool: UniswapV3Pool;
+  pool: UniswapV3PoolWire;
 
   /**
    * Echoed base/quote orientation when `isToken0Quote` was supplied in the

--- a/packages/midcurve-api-shared/src/types/pools/uniswapv3.ts
+++ b/packages/midcurve-api-shared/src/types/pools/uniswapv3.ts
@@ -6,10 +6,37 @@
  */
 
 import { z } from 'zod';
-import type { UniswapV3Pool } from '@midcurve/shared';
+import type {
+  UniswapV3PoolConfigJSON,
+  UniswapV3PoolStateJSON,
+} from '@midcurve/shared';
 import type { ApiResponse } from '../common/index.js';
+import type { Erc20TokenWire } from '../tokens/erc20.js';
 import type { PoolSearchResultItem, PoolUserProvidedInfo } from './pool-search.js';
 import type { PoolMetricsBlock } from './pool-metrics-shared.js';
+
+/**
+ * Wire shape of a UniswapV3Pool as returned by the API.
+ *
+ * Mirrors the output of `serializeUniswapV3Pool` in midcurve-api: bigints are
+ * `string`, `Date` fields are ISO 8601 strings, and there are no methods.
+ *
+ * Use this type for any payload that came back from `apiClient` (or for a
+ * formatter parameter that consumes one). The canonical `UniswapV3Pool` class
+ * type from `@midcurve/shared` is for in-memory domain use only — it advertises
+ * methods and bigint fields that don't survive JSON serialization.
+ */
+export interface UniswapV3PoolWire {
+  id: string;
+  protocol: 'uniswapv3';
+  token0: Erc20TokenWire;
+  token1: Erc20TokenWire;
+  feeBps: number;
+  config: UniswapV3PoolConfigJSON;
+  state: UniswapV3PoolStateJSON;
+  createdAt: string; // ISO 8601
+  updatedAt: string; // ISO 8601
+}
 
 /**
  * Path parameters for pool lookup
@@ -69,8 +96,11 @@ export interface GetUniswapV3PoolData {
   /**
    * Pool data with fresh on-chain state
    * State (price, liquidity, tick) is always current
+   *
+   * Wire shape (bigints as strings, no class methods) — see
+   * {@link UniswapV3PoolWire}.
    */
-  pool: UniswapV3Pool;
+  pool: UniswapV3PoolWire;
 
   /**
    * Pool metrics block — only included when `metrics=true` query param is set.

--- a/packages/midcurve-api-shared/src/types/tokens/erc20.ts
+++ b/packages/midcurve-api-shared/src/types/tokens/erc20.ts
@@ -61,6 +61,13 @@ export interface CreateErc20TokenData {
  */
 export type CreateErc20TokenResponse = ApiResponse<CreateErc20TokenData>;
 
+// Alias of CreateErc20TokenData — they share the wire shape today; split into
+// a standalone type if they ever diverge (e.g. create-input gains a field that
+// doesn't ship on the wire). Used for composing wire-shape types like
+// UniswapV3PoolWire where naming the create endpoint at the call site would be
+// misleading.
+export type Erc20TokenWire = CreateErc20TokenData;
+
 /**
  * Token search candidate from CoinGecko (lightweight, not in database yet)
  *


### PR DESCRIPTION
## Summary

- Adds `UniswapV3PoolWire` (and a renamed alias `Erc20TokenWire = CreateErc20TokenData`) in `@midcurve/api-shared`. Composed from existing typed JSON pieces (`UniswapV3PoolConfigJSON`, `UniswapV3PoolStateJSON` from `@midcurve/shared`, plus the existing token wire shape).
- Switches `GetUniswapV3PoolData.pool` from the `UniswapV3Pool` class type to `UniswapV3PoolWire`. Drops the `as unknown as UniswapV3Pool` cast from the API route handler and pins `serializeUniswapV3Pool` / `serializeErc20Token` return types so the wire shape becomes the contract at the API boundary.
- Replaces the hand-written `pool` subset and the `// TODO(#52):` comment in `apps/midcurve-mcp-server/src/formatters.ts` with the canonical wire type. Updates `useDiscoverPool` to return the wire type. No runtime change — purely type-system honesty.

## Why

PR #50 left a hand-written subset on `PoolDetailRaw.pool` because the canonical class type advertised methods and bigint fields that don't survive JSON serialization. This issue introduces a true wire-shape type so the MCP formatter and the API route handler can drop their lies without substituting new ones.

## Test plan

- [x] `pnpm typecheck` (whole monorepo, all 14 tasks pass)
- [x] `pnpm --filter @midcurve/mcp-server test` (13 formatter tests pass; fixtures are valid `UniswapV3PoolWire` values, no casts)
- [x] `pnpm --filter @midcurve/api-shared build && pnpm --filter @midcurve/mcp-server build && pnpm --filter @midcurve/api build`
- [ ] Smoke-check: hit `GET /api/v1/pools/uniswapv3/8453/0xd0b53D9277642d899DF5C87A3966A349A798F224` and confirm response keys are `[config, createdAt, feeBps, id, protocol, state, token0, token1, updatedAt]`. (Manual; no runtime change expected since serializer body is unchanged.)

## Out-of-scope follow-up

The UI wizards (e.g. `RiskTriggersWizard`, `IncreaseDepositWizard`, `WithdrawWizard`) still cast `result.pool as unknown as PoolJSON` before calling `UniswapV3Pool.fromJSON()`. That cast is unrelated tech debt — the boundary there is `PoolJSON` from `@midcurve/shared`, not `UniswapV3PoolWire` — and a clean fix likely teaches `UniswapV3Pool.fromJSON()` to accept the wire type directly. I'll open a follow-up issue once this lands so it doesn't get buried in PR history.

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)