### PR TITLE
feat: staking vault SPEC-0003a (top-up, partial unstake, fractional flashClose)

### DIFF
--- a/apps/midcurve-contracts/contracts/staking-vault/UniswapV3StakingVault.sol
+++ b/apps/midcurve-contracts/contracts/staking-vault/UniswapV3StakingVault.sol
@@ -5,6 +5,7 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import {Multicall} from "@openzeppelin/contracts/utils/Multicall.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 
 import {INonfungiblePositionManagerMinimal} from
     "../interfaces/INonfungiblePositionManagerMinimal.sol";
@@ -13,13 +14,20 @@ import {LiquidityAmounts} from "../libraries/LiquidityAmounts.sol";
 import {TickMath} from "../libraries/TickMath.sol";
 import {LibUniswapV3Fees} from "../libraries/LibUniswapV3Fees.sol";
 
-import {IStakingVault, StakeParams, SwapStatus, SwapQuote} from "./interfaces/IStakingVault.sol";
+import {
+    IStakingVault,
+    StakeParams,
+    TopUpParams,
+    SwapStatus,
+    SwapQuote
+} from "./interfaces/IStakingVault.sol";
 import {IFlashCloseCallback} from "./interfaces/IFlashCloseCallback.sol";
 
 /// @title UniswapV3StakingVault
 /// @notice Per-stake vault wrapping a single Uniswap V3 NFT position with a quote-side
 ///         yield target. Deployed as an EIP-1167 clone via UniswapV3StakingVaultFactory.
-/// @dev Implements RFC-0003 (issue #58). Non-transferable owner; one-shot lifecycle.
+/// @dev Implements SPEC-0003a (issue #61). Non-transferable owner; multi-cycle lifecycle
+///      with top-up, partial unstake, and fractional flashClose.
 contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
     using SafeERC20 for IERC20;
 
@@ -30,6 +38,8 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
         Settled
     }
 
+    uint16 internal constant BPS_DENOM = 10000;
+
     // ============ Implementation immutables (baked into runtime code) ============
 
     INonfungiblePositionManagerMinimal public immutable positionManager;
@@ -38,7 +48,7 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
 
     address public owner;
 
-    // Position details cached during stake()
+    // Position details cached during initial stake().
     address public pool;
     uint256 public tokenId;
     address public token0;
@@ -46,22 +56,26 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
     int24 internal _tickLower;
     int24 internal _tickUpper;
 
-    // Stake terms
+    // Stake terms.
     bool public isToken0Quote;
     uint256 public stakedBase;
     uint256 public stakedQuote;
     uint256 public yieldTarget;
 
-    // Lifecycle state
+    // Partial unstake counter.
+    uint16 internal _pendingBps;
+
+    // Lifecycle state.
     State internal _state;
 
-    // Settlement-time snapshots
-    uint256 public baseReward;
-    uint256 public quoteReward;
-    bool public principalUnstaked;
-    bool public rewardsClaimed;
+    // Settlement buffers — refilled on each swap()/flashClose(), drained on each
+    // unstake()/claimRewards(). All four reset to zero on drain.
+    uint256 public unstakeBufferBase;
+    uint256 public unstakeBufferQuote;
+    uint256 public rewardBufferBase;
+    uint256 public rewardBufferQuote;
 
-    // One-shot init guard
+    // One-shot init guard.
     bool internal _initialized;
 
     // ============ Errors ============
@@ -74,7 +88,9 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
     error TokenMismatch();
     error InsufficientAmountIn();
     error SlippageExceeded();
-    error AlreadyConsumed();
+    error InvalidBps();
+    error NothingToUnstake();
+    error NothingToClaim();
     error InsufficientBaseReturned();
     error InsufficientQuoteReturned();
     error PoolResolutionFailed();
@@ -132,7 +148,12 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
         return isToken0Quote ? token0 : token1;
     }
 
-    // ============ stake ============
+    /// @inheritdoc IStakingVault
+    function partialUnstakeBps() external view override returns (uint16) {
+        return _pendingBps;
+    }
+
+    // ============ stake — initial mint ============
 
     /// @inheritdoc IStakingVault
     function stake(
@@ -219,12 +240,81 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
         }
 
         // Resolve pool address via NFPM.factory().getPool(token0, token1, fee)
-        address resolvedPool = _resolvePool(positionParams.token0, positionParams.token1, positionParams.fee);
-        pool = resolvedPool;
+        pool = _resolvePool(positionParams.token0, positionParams.token1, positionParams.fee);
 
         _state = State.Staked;
 
         emit Stake(owner, stakedBase, stakedQuote, yieldTarget_, mintedTokenId);
+    }
+
+    // ============ stakeTopUp — additive ============
+
+    /// @inheritdoc IStakingVault
+    function stakeTopUp(TopUpParams calldata p)
+        external
+        override
+        onlyOwner
+        inState(State.Staked)
+        nonReentrant
+    {
+        address t0 = token0;
+        address t1 = token1;
+
+        if (p.amount0Desired > 0) {
+            IERC20(t0).safeTransferFrom(msg.sender, address(this), p.amount0Desired);
+            IERC20(t0).forceApprove(address(positionManager), p.amount0Desired);
+        }
+        if (p.amount1Desired > 0) {
+            IERC20(t1).safeTransferFrom(msg.sender, address(this), p.amount1Desired);
+            IERC20(t1).forceApprove(address(positionManager), p.amount1Desired);
+        }
+
+        (, uint256 amount0Used, uint256 amount1Used) = positionManager.increaseLiquidity(
+            INonfungiblePositionManagerMinimal.IncreaseLiquidityParams({
+                tokenId: tokenId,
+                amount0Desired: p.amount0Desired,
+                amount1Desired: p.amount1Desired,
+                amount0Min: p.amount0Min,
+                amount1Min: p.amount1Min,
+                deadline: p.deadline
+            })
+        );
+
+        if (p.amount0Desired > 0) IERC20(t0).forceApprove(address(positionManager), 0);
+        if (p.amount1Desired > 0) IERC20(t1).forceApprove(address(positionManager), 0);
+
+        uint256 refund0 = p.amount0Desired - amount0Used;
+        uint256 refund1 = p.amount1Desired - amount1Used;
+        if (refund0 > 0) IERC20(t0).safeTransfer(msg.sender, refund0);
+        if (refund1 > 0) IERC20(t1).safeTransfer(msg.sender, refund1);
+
+        uint256 baseAdded;
+        uint256 quoteAdded;
+        if (isToken0Quote) {
+            quoteAdded = amount0Used;
+            baseAdded = amount1Used;
+        } else {
+            quoteAdded = amount1Used;
+            baseAdded = amount0Used;
+        }
+
+        // Scale T proportionally so the implicit yield rate stays constant.
+        // T_new = T_old × (Q + ΔQ) / Q, ceil-rounded to avoid downward drift on
+        // repeated tiny top-ups. Skip if Q == 0 — no anchor to scale against.
+        uint256 oldQ = stakedQuote;
+        if (oldQ > 0 && quoteAdded > 0) {
+            uint256 oldT = yieldTarget;
+            uint256 newT = Math.mulDiv(oldT, oldQ + quoteAdded, oldQ, Math.Rounding.Up);
+            if (newT != oldT) {
+                yieldTarget = newT;
+                emit YieldTargetSet(owner, oldT, newT);
+            }
+        }
+
+        stakedBase += baseAdded;
+        stakedQuote += quoteAdded;
+
+        emit Stake(owner, baseAdded, quoteAdded, yieldTarget, tokenId);
     }
 
     // ============ setYieldTarget ============
@@ -235,25 +325,61 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
         override
         onlyOwner
         inState(State.Staked)
+        nonReentrant
     {
         uint256 old = yieldTarget;
         yieldTarget = newTarget;
         emit YieldTargetSet(owner, old, newTarget);
     }
 
+    // ============ pendingBps controls ============
+
+    /// @inheritdoc IStakingVault
+    function setPartialUnstakeBps(uint16 newBps)
+        external
+        override
+        onlyOwner
+        inState(State.Staked)
+        nonReentrant
+    {
+        if (newBps > BPS_DENOM) revert InvalidBps();
+        uint16 oldBps = _pendingBps;
+        _pendingBps = newBps;
+        emit PartialUnstakeBpsSet(owner, oldBps, newBps);
+    }
+
+    /// @inheritdoc IStakingVault
+    function increasePartialUnstakeBps(uint16 bpsToAdd)
+        external
+        override
+        onlyOwner
+        inState(State.Staked)
+        nonReentrant
+    {
+        uint16 oldBps = _pendingBps;
+        uint256 candidate = uint256(oldBps) + uint256(bpsToAdd);
+        if (candidate > BPS_DENOM) revert InvalidBps();
+        // forge-lint: disable-next-line(unsafe-typecast)
+        _pendingBps = uint16(candidate);
+        emit PartialUnstakeBpsSet(owner, oldBps, _pendingBps);
+    }
+
     // ============ quoteSwap ============
 
     /// @inheritdoc IStakingVault
-    function quoteSwap() external view override returns (SwapQuote memory q) {
+    function quoteSwap() external view override returns (SwapQuote memory) {
         if (_state != State.Staked) {
             return SwapQuote({
                 status: SwapStatus.NotApplicable,
+                effectiveBps: 0,
                 tokenIn: address(0),
                 minAmountIn: 0,
                 tokenOut: address(0),
                 amountOut: 0
             });
         }
+
+        uint16 effectiveBps = _effectiveBps();
 
         // Overflow guard: Q + T
         uint256 Q = stakedQuote;
@@ -262,6 +388,7 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
             if (Q + T < Q) {
                 return SwapQuote({
                     status: SwapStatus.Underwater,
+                    effectiveBps: effectiveBps,
                     tokenIn: address(0),
                     minAmountIn: 0,
                     tokenOut: address(0),
@@ -269,46 +396,50 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
                 });
             }
         }
-        uint256 quoteFloor = Q + T;
         uint256 B = stakedBase;
+        uint256 targetBase = (B * uint256(effectiveBps)) / BPS_DENOM;
+        uint256 targetQuote = ((Q + T) * uint256(effectiveBps)) / BPS_DENOM;
 
-        // Simulate close: principal + uncollected fees
-        (uint256 b, uint256 qBal) = _expectedBalancesAfterClose();
+        // Simulate partial close: principal × bps + ALL collectable fees (collect is all-or-nothing).
+        (uint256 b, uint256 qBal) = _expectedBalancesAfterPartialClose(effectiveBps);
 
-        // Classify per spec §10
-        if (b >= B && qBal >= quoteFloor) {
+        if (b >= targetBase && qBal >= targetQuote) {
             // Case 1
             return SwapQuote({
                 status: SwapStatus.NoSwapNeeded,
+                effectiveBps: effectiveBps,
                 tokenIn: address(0),
                 minAmountIn: 0,
                 tokenOut: address(0),
                 amountOut: 0
             });
         }
-        if (b > B && qBal < quoteFloor) {
+        if (b > targetBase && qBal < targetQuote) {
             // Case 2: executor sends quote, receives base
             return SwapQuote({
                 status: SwapStatus.Executable,
+                effectiveBps: effectiveBps,
                 tokenIn: quoteToken(),
-                minAmountIn: quoteFloor - qBal,
+                minAmountIn: targetQuote - qBal,
                 tokenOut: baseToken(),
-                amountOut: b - B
+                amountOut: b - targetBase
             });
         }
-        if (b < B && qBal > quoteFloor) {
+        if (b < targetBase && qBal > targetQuote) {
             // Case 3: executor sends base, receives quote
             return SwapQuote({
                 status: SwapStatus.Executable,
+                effectiveBps: effectiveBps,
                 tokenIn: baseToken(),
-                minAmountIn: B - b,
+                minAmountIn: targetBase - b,
                 tokenOut: quoteToken(),
-                amountOut: qBal - quoteFloor
+                amountOut: qBal - targetQuote
             });
         }
         // Case 4
         return SwapQuote({
             status: SwapStatus.Underwater,
+            effectiveBps: effectiveBps,
             tokenIn: address(0),
             minAmountIn: 0,
             tokenOut: address(0),
@@ -316,14 +447,15 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
         });
     }
 
-    /// @dev Compute (base, quote) the vault would hold after closing the UV3 position
-    ///      and collecting fees. Includes BOTH already-snapshotted fees from
-    ///      `tokensOwed*` AND not-yet-snapshotted fees living in the pool's
-    ///      `feeGrowthInside` state (the only place fees accrue while the NFT
-    ///      sits idle in the vault). Without the live component this view would
-    ///      report `Underwater`/Case 4 for the entire active life of the
-    ///      position whenever the path to settlement runs through fees.
-    function _expectedBalancesAfterClose() internal view returns (uint256 b, uint256 q) {
+    /// @dev Compute (base, quote) the vault WOULD newly receive from a partial close at `bps`,
+    ///      including ALL uncollected fees (`collect` is all-or-nothing). Result is the
+    ///      delta that classification compares against `(targetBase, targetQuote)`; existing
+    ///      buffer slots are tracked separately and NOT folded into this view.
+    function _expectedBalancesAfterPartialClose(uint16 bps)
+        internal
+        view
+        returns (uint256 b, uint256 q)
+    {
         (
             ,
             ,
@@ -339,18 +471,23 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
             uint128 owed1
         ) = positionManager.positions(tokenId);
 
-        // Principal at current pool price
+        // Principal at current pool price for the partial liquidity burn.
         uint256 amount0;
         uint256 amount1;
         if (liquidity > 0) {
-            (uint160 sqrtPriceX96,,,,,,) = IUniswapV3PoolMinimal(pool).slot0();
-            uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(_tickLower);
-            uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(_tickUpper);
-            (amount0, amount1) =
-                LiquidityAmounts.getAmountsForLiquidity(sqrtPriceX96, sqrtRatioAX96, sqrtRatioBX96, liquidity);
+            // forge-lint: disable-next-line(unsafe-typecast)
+            uint128 partialLiquidity = uint128((uint256(liquidity) * uint256(bps)) / BPS_DENOM);
+            if (partialLiquidity > 0) {
+                (uint160 sqrtPriceX96,,,,,,) = IUniswapV3PoolMinimal(pool).slot0();
+                uint160 sqrtRatioAX96 = TickMath.getSqrtRatioAtTick(_tickLower);
+                uint160 sqrtRatioBX96 = TickMath.getSqrtRatioAtTick(_tickUpper);
+                (amount0, amount1) = LiquidityAmounts.getAmountsForLiquidity(
+                    sqrtPriceX96, sqrtRatioAX96, sqrtRatioBX96, partialLiquidity
+                );
+            }
         }
 
-        // All uncollected fees: snapshotted (tokensOwed*) + live (feeGrowthInside delta).
+        // All uncollected fees (snapshotted + live). NOT pro-rated by bps — collect is all-or-nothing.
         (uint256 fees0, uint256 fees1) = LibUniswapV3Fees.uncollectedFees(
             pool, _tickLower, _tickUpper, liquidity, fgInside0Last, fgInside1Last, owed0, owed1
         );
@@ -376,175 +513,246 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
         inState(State.Staked)
         returns (uint256 amountOut)
     {
-        // Close UV3 position + collect everything to vault
-        _closePosition();
-
-        address baseTok = baseToken();
-        address quoteTok = quoteToken();
-        uint256 b = IERC20(baseTok).balanceOf(address(this));
-        uint256 qBal = IERC20(quoteTok).balanceOf(address(this));
+        uint16 effectiveBps = _effectiveBps();
 
         uint256 B = stakedBase;
         uint256 Q = stakedQuote;
         uint256 T = yieldTarget;
 
         // Overflow guard: Q + T
-        uint256 quoteFloor;
+        uint256 quoteFloorTotal;
         unchecked {
-            quoteFloor = Q + T;
-            if (quoteFloor < Q) revert Underwater();
+            quoteFloorTotal = Q + T;
+            if (quoteFloorTotal < Q) revert Underwater();
         }
 
-        // Case 1: no-swap settle
-        if (b >= B && qBal >= quoteFloor) {
-            if (amountIn != 0) revert InsufficientAmountIn(); // amountIn must be zero
-            // Tokens may be address(0) for Case 1; do not validate them here.
-            baseReward = b - B;
-            quoteReward = qBal - Q;
-            _state = State.Settled;
-            emit Swap(msg.sender, address(0), 0, address(0), 0);
-            return 0;
-        }
+        address baseTok = baseToken();
+        address quoteTok = quoteToken();
 
-        // Case 2: executor sends quote, receives base
-        if (b > B && qBal < quoteFloor) {
+        // Snapshot pre-swap balances so we can compute the delta from this partial close.
+        uint256 preBase = IERC20(baseTok).balanceOf(address(this));
+        uint256 preQuote = IERC20(quoteTok).balanceOf(address(this));
+
+        _closePartial(effectiveBps);
+
+        uint256 b = IERC20(baseTok).balanceOf(address(this)) - preBase;
+        uint256 qBal = IERC20(quoteTok).balanceOf(address(this)) - preQuote;
+
+        uint256 targetBase = (B * uint256(effectiveBps)) / BPS_DENOM;
+        uint256 targetQuote = (quoteFloorTotal * uint256(effectiveBps)) / BPS_DENOM;
+
+        // Case classification + execution
+        if (b >= targetBase && qBal >= targetQuote) {
+            // Case 1: no-swap settle
+            if (amountIn != 0) revert InsufficientAmountIn();
+            amountOut = 0;
+            emit Swap(msg.sender, address(0), 0, address(0), 0, effectiveBps);
+        } else if (b > targetBase && qBal < targetQuote) {
+            // Case 2: executor sends quote, receives base
             if (tokenIn != quoteTok) revert TokenMismatch();
             if (tokenOut != baseTok) revert TokenMismatch();
-            uint256 requiredMin = quoteFloor - qBal;
+            uint256 requiredMin = targetQuote - qBal;
             if (amountIn < requiredMin) revert InsufficientAmountIn();
-            amountOut = b - B;
+            amountOut = b - targetBase;
             if (amountOut < minAmountOut) revert SlippageExceeded();
-
             IERC20(quoteTok).safeTransferFrom(msg.sender, address(this), amountIn);
             IERC20(baseTok).safeTransfer(msg.sender, amountOut);
-
-            baseReward = 0;
-            quoteReward = (qBal + amountIn) - Q;
-            _state = State.Settled;
-            emit Swap(msg.sender, tokenIn, amountIn, tokenOut, amountOut);
-            return amountOut;
-        }
-
-        // Case 3: executor sends base, receives quote
-        if (b < B && qBal > quoteFloor) {
+            emit Swap(msg.sender, tokenIn, amountIn, tokenOut, amountOut, effectiveBps);
+        } else if (b < targetBase && qBal > targetQuote) {
+            // Case 3: executor sends base, receives quote
             if (tokenIn != baseTok) revert TokenMismatch();
             if (tokenOut != quoteTok) revert TokenMismatch();
-            uint256 requiredMin = B - b;
+            uint256 requiredMin = targetBase - b;
             if (amountIn < requiredMin) revert InsufficientAmountIn();
-            amountOut = qBal - quoteFloor;
+            amountOut = qBal - targetQuote;
             if (amountOut < minAmountOut) revert SlippageExceeded();
-
             IERC20(baseTok).safeTransferFrom(msg.sender, address(this), amountIn);
             IERC20(quoteTok).safeTransfer(msg.sender, amountOut);
-
-            baseReward = (b + amountIn) - B;
-            quoteReward = T;
-            _state = State.Settled;
-            emit Swap(msg.sender, tokenIn, amountIn, tokenOut, amountOut);
-            return amountOut;
+            emit Swap(msg.sender, tokenIn, amountIn, tokenOut, amountOut, effectiveBps);
+        } else {
+            // Case 4
+            revert Underwater();
         }
 
-        // Case 4
-        revert Underwater();
+        // Recompute deltas after executor token movements to fill buffers.
+        uint256 newFreeBase = IERC20(baseTok).balanceOf(address(this)) - preBase;
+        uint256 newFreeQuote = IERC20(quoteTok).balanceOf(address(this)) - preQuote;
+
+        uint256 unstakeBaseDelta = (B * uint256(effectiveBps)) / BPS_DENOM;
+        uint256 unstakeQuoteDelta = (Q * uint256(effectiveBps)) / BPS_DENOM;
+
+        // Buffer increments (case classification guarantees newFree* >= unstake*Delta).
+        unstakeBufferBase += unstakeBaseDelta;
+        unstakeBufferQuote += unstakeQuoteDelta;
+        rewardBufferBase += newFreeBase - unstakeBaseDelta;
+        rewardBufferQuote += newFreeQuote - unstakeQuoteDelta;
+
+        // Reduce active stake proportionally.
+        stakedBase = B - unstakeBaseDelta;
+        stakedQuote = Q - unstakeQuoteDelta;
+        yieldTarget = T - ((T * uint256(effectiveBps)) / BPS_DENOM);
+
+        // Clear pending counter and update state if fully closed.
+        _pendingBps = 0;
+        if (effectiveBps == BPS_DENOM) {
+            _state = State.Settled;
+        }
+
+        return amountOut;
     }
 
-    // ============ unstake / claimRewards ============
+    // ============ unstake / claimRewards — buffer drain ============
 
     /// @inheritdoc IStakingVault
-    function unstake() external override onlyOwner inState(State.Settled) nonReentrant {
-        if (principalUnstaked) revert AlreadyConsumed();
-        principalUnstaked = true;
-        IERC20(baseToken()).safeTransfer(owner, stakedBase);
-        IERC20(quoteToken()).safeTransfer(owner, stakedQuote);
-        emit Unstake(owner, stakedBase, stakedQuote);
+    function unstake() external override onlyOwner nonReentrant {
+        if (_state != State.Staked && _state != State.Settled) revert WrongState();
+        uint256 baseAmt = unstakeBufferBase;
+        uint256 quoteAmt = unstakeBufferQuote;
+        if (baseAmt == 0 && quoteAmt == 0) revert NothingToUnstake();
+
+        unstakeBufferBase = 0;
+        unstakeBufferQuote = 0;
+
+        if (baseAmt > 0) IERC20(baseToken()).safeTransfer(owner, baseAmt);
+        if (quoteAmt > 0) IERC20(quoteToken()).safeTransfer(owner, quoteAmt);
+
+        emit Unstake(owner, baseAmt, quoteAmt);
     }
 
     /// @inheritdoc IStakingVault
-    function claimRewards() external override onlyOwner inState(State.Settled) nonReentrant {
-        if (rewardsClaimed) revert AlreadyConsumed();
-        rewardsClaimed = true;
-        uint256 br = baseReward;
-        uint256 qr = quoteReward;
-        if (br > 0) IERC20(baseToken()).safeTransfer(owner, br);
-        if (qr > 0) IERC20(quoteToken()).safeTransfer(owner, qr);
-        emit ClaimRewards(owner, br, qr);
+    function claimRewards() external override onlyOwner nonReentrant {
+        if (_state != State.Staked && _state != State.Settled) revert WrongState();
+        uint256 baseAmt = rewardBufferBase;
+        uint256 quoteAmt = rewardBufferQuote;
+        if (baseAmt == 0 && quoteAmt == 0) revert NothingToClaim();
+
+        rewardBufferBase = 0;
+        rewardBufferQuote = 0;
+
+        if (baseAmt > 0) IERC20(baseToken()).safeTransfer(owner, baseAmt);
+        if (quoteAmt > 0) IERC20(quoteToken()).safeTransfer(owner, quoteAmt);
+
+        emit ClaimRewards(owner, baseAmt, quoteAmt);
     }
 
     // ============ flashClose ============
 
     /// @inheritdoc IStakingVault
-    function flashClose(address callbackTarget, bytes calldata data)
+    function flashClose(uint16 bps, address callbackTarget, bytes calldata data)
         external
         override
         onlyOwner
         inState(State.Staked)
         nonReentrant
     {
-        // Close the UV3 position
-        _closePosition();
+        if (bps == 0 || bps > BPS_DENOM) revert InvalidBps();
 
-        uint256 expectedBase = stakedBase;
-        uint256 expectedQuote;
+        uint256 B = stakedBase;
+        uint256 Q = stakedQuote;
+        uint256 T = yieldTarget;
+
+        // Overflow guard: Q + T
+        uint256 quoteFloorTotal;
         unchecked {
-            expectedQuote = stakedQuote + yieldTarget;
-            if (expectedQuote < stakedQuote) revert YieldTargetOverflow();
+            quoteFloorTotal = Q + T;
+            if (quoteFloorTotal < Q) revert YieldTargetOverflow();
         }
 
-        // Lock + emit BEFORE callback
-        _state = State.FlashCloseInProgress;
-        emit FlashCloseInitiated(owner, callbackTarget, data);
+        uint256 expectedBase = (B * uint256(bps)) / BPS_DENOM;
+        uint256 expectedQuote = (quoteFloorTotal * uint256(bps)) / BPS_DENOM;
 
-        // Push current vault balances to callback target
         address baseTok = baseToken();
         address quoteTok = quoteToken();
-        uint256 currentBase = IERC20(baseTok).balanceOf(address(this));
-        uint256 currentQuote = IERC20(quoteTok).balanceOf(address(this));
-        if (currentBase > 0) IERC20(baseTok).safeTransfer(callbackTarget, currentBase);
-        if (currentQuote > 0) IERC20(quoteTok).safeTransfer(callbackTarget, currentQuote);
 
-        // Run helper
+        // Snapshot pre-call balances so we can isolate the freed delta from prior buffers.
+        uint256 preBase = IERC20(baseTok).balanceOf(address(this));
+        uint256 preQuote = IERC20(quoteTok).balanceOf(address(this));
+
+        _closePartial(bps);
+
+        uint256 freedBase = IERC20(baseTok).balanceOf(address(this)) - preBase;
+        uint256 freedQuote = IERC20(quoteTok).balanceOf(address(this)) - preQuote;
+
+        // Lock + emit BEFORE callback. Re-entry into any other vault function
+        // reverts via `inState` checks while we're in this state.
+        _state = State.FlashCloseInProgress;
+        emit FlashCloseInitiated(owner, bps, callbackTarget, data);
+
+        // Push only the freed delta to the callback. Existing buffers stay in the vault.
+        if (freedBase > 0) IERC20(baseTok).safeTransfer(callbackTarget, freedBase);
+        if (freedQuote > 0) IERC20(quoteTok).safeTransfer(callbackTarget, freedQuote);
+
         IFlashCloseCallback(callbackTarget).flashCloseCallback(expectedBase, expectedQuote, data);
 
-        // Verify post-balances
-        uint256 finalBase = IERC20(baseTok).balanceOf(address(this));
-        uint256 finalQuote = IERC20(quoteTok).balanceOf(address(this));
-        if (finalBase < expectedBase) revert InsufficientBaseReturned();
-        if (finalQuote < expectedQuote) revert InsufficientQuoteReturned();
+        // Verify the freed delta returned at least the expected amounts.
+        uint256 postBase = IERC20(baseTok).balanceOf(address(this)) - preBase;
+        uint256 postQuote = IERC20(quoteTok).balanceOf(address(this)) - preQuote;
+        if (postBase < expectedBase) revert InsufficientBaseReturned();
+        if (postQuote < expectedQuote) revert InsufficientQuoteReturned();
 
-        // Snapshot rewards
-        uint256 br = finalBase - stakedBase;
-        uint256 qr = finalQuote - stakedQuote;
-        baseReward = br;
-        quoteReward = qr;
+        // Buffer increments (same accounting as swap()).
+        uint256 unstakeBaseDelta = (B * uint256(bps)) / BPS_DENOM;
+        uint256 unstakeQuoteDelta = (Q * uint256(bps)) / BPS_DENOM;
+        unstakeBufferBase += unstakeBaseDelta;
+        unstakeBufferQuote += unstakeQuoteDelta;
+        rewardBufferBase += postBase - unstakeBaseDelta;
+        rewardBufferQuote += postQuote - unstakeQuoteDelta;
 
-        _state = State.Settled;
+        // Reduce active stake proportionally.
+        stakedBase = B - unstakeBaseDelta;
+        stakedQuote = Q - unstakeQuoteDelta;
+        yieldTarget = T - ((T * uint256(bps)) / BPS_DENOM);
 
-        // Auto-settle: combined unstake + claimRewards
-        principalUnstaked = true;
-        rewardsClaimed = true;
-        IERC20(baseTok).safeTransfer(owner, stakedBase);
-        IERC20(quoteTok).safeTransfer(owner, stakedQuote);
-        emit Unstake(owner, stakedBase, stakedQuote);
-        if (br > 0) IERC20(baseTok).safeTransfer(owner, br);
-        if (qr > 0) IERC20(quoteTok).safeTransfer(owner, qr);
-        emit ClaimRewards(owner, br, qr);
+        // Update state. pendingBps is intentionally untouched.
+        _state = (bps == BPS_DENOM) ? State.Settled : State.Staked;
+
+        // Auto-drain BOTH buffers (including any pre-existing amounts from prior partial settlements).
+        uint256 ub = unstakeBufferBase;
+        uint256 uq = unstakeBufferQuote;
+        uint256 rb = rewardBufferBase;
+        uint256 rq = rewardBufferQuote;
+
+        unstakeBufferBase = 0;
+        unstakeBufferQuote = 0;
+        rewardBufferBase = 0;
+        rewardBufferQuote = 0;
+
+        if (ub > 0) IERC20(baseTok).safeTransfer(owner, ub);
+        if (uq > 0) IERC20(quoteTok).safeTransfer(owner, uq);
+        emit Unstake(owner, ub, uq);
+
+        if (rb > 0) IERC20(baseTok).safeTransfer(owner, rb);
+        if (rq > 0) IERC20(quoteTok).safeTransfer(owner, rq);
+        emit ClaimRewards(owner, rb, rq);
     }
 
     // ============ Internal helpers ============
 
-    function _closePosition() internal {
-        // Decrease all liquidity (if any), then collect everything to vault.
+    /// @dev Effective bps for the next swap: `pendingBps` if set, otherwise full close (10000).
+    function _effectiveBps() internal view returns (uint16) {
+        uint16 p = _pendingBps;
+        return p == 0 ? BPS_DENOM : p;
+    }
+
+    /// @dev Decrease `bps` of the position's liquidity (rounded down) and collect everything
+    ///      currently owed to the position. `bps` MUST be in [1, 10000]; caller is responsible
+    ///      for that bound.
+    function _closePartial(uint16 bps) internal {
         (,,,,,,, uint128 liquidity,,,,) = positionManager.positions(tokenId);
         if (liquidity > 0) {
-            positionManager.decreaseLiquidity(
-                INonfungiblePositionManagerMinimal.DecreaseLiquidityParams({
-                    tokenId: tokenId,
-                    liquidity: liquidity,
-                    amount0Min: 0,
-                    amount1Min: 0,
-                    deadline: block.timestamp
-                })
-            );
+            // forge-lint: disable-next-line(unsafe-typecast)
+            uint128 partialLiquidity = uint128((uint256(liquidity) * uint256(bps)) / BPS_DENOM);
+            if (partialLiquidity > 0) {
+                positionManager.decreaseLiquidity(
+                    INonfungiblePositionManagerMinimal.DecreaseLiquidityParams({
+                        tokenId: tokenId,
+                        liquidity: partialLiquidity,
+                        amount0Min: 0,
+                        amount1Min: 0,
+                        deadline: block.timestamp
+                    })
+                );
+            }
         }
         positionManager.collect(
             INonfungiblePositionManagerMinimal.CollectParams({
@@ -559,7 +767,11 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
     // Multicall is provided by OZ's `Multicall` mixin (see inheritance list).
     // Per-call state checks remain authoritative — multicall does not bypass them.
 
-    function _resolvePool(address t0, address t1, uint24 fee) internal view returns (address resolved) {
+    function _resolvePool(address t0, address t1, uint24 fee)
+        internal
+        view
+        returns (address resolved)
+    {
         address uniFactory = positionManager.factory();
         (bool ok, bytes memory ret) = uniFactory.staticcall(
             abi.encodeWithSignature("getPool(address,address,uint24)", t0, t1, fee)
@@ -568,5 +780,4 @@ contract UniswapV3StakingVault is IStakingVault, ReentrancyGuard, Multicall {
         resolved = abi.decode(ret, (address));
         if (resolved == address(0)) revert PoolResolutionFailed();
     }
-
 }

--- a/apps/midcurve-contracts/contracts/staking-vault/interfaces/IFlashCloseCallback.sol
+++ b/apps/midcurve-contracts/contracts/staking-vault/interfaces/IFlashCloseCallback.sol
@@ -8,9 +8,14 @@ pragma solidity ^0.8.20;
 ///         the vault. The callback must return at least `expectedBase` of base tokens and
 ///         `expectedQuote` of quote tokens to the vault before the call returns.
 interface IFlashCloseCallback {
-    /// @param expectedBase  = stakedBase × bps / 10000.
-    /// @param expectedQuote = (stakedQuote + yieldTarget) × bps / 10000.
+    /// @param expectedBase  = floor(stakedBase × bps / 10000).
+    /// @param expectedQuote = floor((stakedQuote + yieldTarget) × bps / 10000).
     /// @param data          opaque calldata forwarded from `flashClose()`.
+    /// @dev Both expected amounts use floor (truncating) division — the same rounding the
+    ///      vault applies internally. A callback that does its own bps math (e.g. sizing a
+    ///      flash loan from `bps` and the staked totals) MUST use floor division to stay
+    ///      consistent with these values; rounding up by even 1 wei can leave the
+    ///      callback short on the actual amount it owes the vault.
     function flashCloseCallback(uint256 expectedBase, uint256 expectedQuote, bytes calldata data)
         external;
 }

--- a/apps/midcurve-contracts/contracts/staking-vault/interfaces/IFlashCloseCallback.sol
+++ b/apps/midcurve-contracts/contracts/staking-vault/interfaces/IFlashCloseCallback.sol
@@ -2,13 +2,14 @@
 pragma solidity ^0.8.20;
 
 /// @title IFlashCloseCallback
-/// @notice Callback contract used by `IStakingVault.flashClose()`. The vault transfers
-///         its full balance to the callback target before invoking this method, and
-///         requires the target to return at least `expectedBase` of base tokens and
+/// @notice Callback contract used by `IStakingVault.flashClose(bps, ...)`. Before invoking
+///         this method the vault transfers the freed (just-closed) balance to the callback
+///         target — prior unstake/reward buffers from earlier partial settlements stay in
+///         the vault. The callback must return at least `expectedBase` of base tokens and
 ///         `expectedQuote` of quote tokens to the vault before the call returns.
 interface IFlashCloseCallback {
-    /// @param expectedBase  = stakedBase (B); the vault requires this much base back.
-    /// @param expectedQuote = stakedQuote + yieldTarget (Q + T); required quote back.
+    /// @param expectedBase  = stakedBase × bps / 10000.
+    /// @param expectedQuote = (stakedQuote + yieldTarget) × bps / 10000.
     /// @param data          opaque calldata forwarded from `flashClose()`.
     function flashCloseCallback(uint256 expectedBase, uint256 expectedQuote, bytes calldata data)
         external;

--- a/apps/midcurve-contracts/contracts/staking-vault/interfaces/IStakingVault.sol
+++ b/apps/midcurve-contracts/contracts/staking-vault/interfaces/IStakingVault.sol
@@ -16,18 +16,29 @@ struct StakeParams {
     uint256 deadline;
 }
 
+/// @notice Top-up parameters mirror NFPM.IncreaseLiquidityParams without `tokenId`
+/// (the vault knows its own position).
+struct TopUpParams {
+    uint256 amount0Desired;
+    uint256 amount1Desired;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    uint256 deadline;
+}
+
 /// @notice Status of a swap quote returned by `quoteSwap()`.
 enum SwapStatus {
-    NotApplicable, // state != Staked
-    NoSwapNeeded, // Case 1: b >= B AND q >= Q+T already; swap() with amountIn = 0 settles
-    Executable, // Case 2 or 3: swap() works with the returned params
-    Underwater // Case 4: swap() reverts; use flashClose()
+    NotApplicable, // state ∉ {Staked} — no swap possible/needed
+    NoSwapNeeded, // Case 1 at current effectiveBps; swap() with amountIn = 0 settles
+    Executable, // Case 2 or 3 at current effectiveBps
+    Underwater // Case 4 at current effectiveBps; swap() reverts; use flashClose()
 
 }
 
 /// @notice Result of `quoteSwap()`. Terminology is from the executor's perspective.
 struct SwapQuote {
     SwapStatus status;
+    uint16 effectiveBps; // pendingBps if > 0, else 10000 (zero for non-Staked states)
     address tokenIn; // executor's payment token (zero address if not Executable)
     uint256 minAmountIn; // executor must send at least this much
     address tokenOut; // executor's receipt token (zero address if not Executable)
@@ -36,29 +47,35 @@ struct SwapQuote {
 
 /// @title IStakingVault
 /// @notice Per-stake vault wrapping a single Uniswap V3 NFT position with a quote-side yield target.
-/// @dev See RFC-0003 spec (issue #58) for the full state machine and mechanics.
+/// @dev See SPEC-0003a (issue #61) for the full state machine and mechanics.
 interface IStakingVault {
     // ============ Events ============
 
+    /// @notice Emitted on initial stake (totals) and on top-up (deltas).
     event Stake(
         address indexed owner, uint256 base, uint256 quote, uint256 yieldTarget, uint256 tokenId
     );
 
     event YieldTargetSet(address indexed owner, uint256 oldTarget, uint256 newTarget);
 
+    event PartialUnstakeBpsSet(address indexed owner, uint16 oldBps, uint16 newBps);
+
     event Swap(
         address indexed executor,
         address tokenIn, // address(0) in Case 1 (no-swap settle)
         uint256 amountIn, // 0 in Case 1
         address tokenOut, // address(0) in Case 1
-        uint256 amountOut // 0 in Case 1
+        uint256 amountOut, // 0 in Case 1
+        uint16 effectiveBps // 1..10000
     );
 
     event Unstake(address indexed owner, uint256 base, uint256 quote);
 
     event ClaimRewards(address indexed owner, uint256 baseAmount, uint256 quoteAmount);
 
-    event FlashCloseInitiated(address indexed owner, address indexed callbackTarget, bytes data);
+    event FlashCloseInitiated(
+        address indexed owner, uint16 bps, address indexed callbackTarget, bytes data
+    );
 
     // ============ Initialization ============
 
@@ -67,7 +84,7 @@ interface IStakingVault {
 
     // ============ Lifecycle — owner-only ============
 
-    /// @notice Open a fresh UV3 position and stake it.
+    /// @notice Open a fresh UV3 position and stake it. Only valid in `Empty`.
     /// @param positionParams Parameters forwarded to NFPM.mint() (recipient = this clone).
     /// @param isToken0Quote True iff token0 is the quote token (false = token1 is quote).
     /// @param yieldTarget Required quote-side reward floor (T).
@@ -76,32 +93,47 @@ interface IStakingVault {
         external
         returns (uint256 tokenId);
 
+    /// @notice Top-up an existing staked position with additional liquidity. Only valid in `Staked`.
+    function stakeTopUp(TopUpParams calldata params) external;
+
     /// @notice Update the yield target. Only valid in `Staked`.
     function setYieldTarget(uint256 newTarget) external;
+
+    /// @notice Set the bps fraction of the position to unstake at the next executor swap.
+    function setPartialUnstakeBps(uint16 newBps) external;
+
+    /// @notice Increment `pendingBps` by `bpsToAdd`. Reverts if the result exceeds 10000.
+    function increasePartialUnstakeBps(uint16 bpsToAdd) external;
+
+    /// @notice Returns the current `pendingBps` value (0..10000).
+    function partialUnstakeBps() external view returns (uint16);
 
     // ============ Lifecycle — permissionless ============
 
     /// @notice Returns whether (and how) `swap()` can settle the vault right now.
     function quoteSwap() external view returns (SwapQuote memory);
 
-    /// @notice Settle the vault as the executor. Vault closes its UV3 position,
-    ///         takes the executor's `amountIn`, and pays out `amountOut`.
+    /// @notice Settle the vault as the executor. Vault closes its UV3 position by
+    ///         `effectiveBps`, takes the executor's `amountIn`, and pays out `amountOut`.
     function swap(address tokenIn, uint256 amountIn, address tokenOut, uint256 minAmountOut)
         external
         returns (uint256 amountOut);
 
     // ============ Settlement — owner-only ============
 
-    /// @notice Owner withdraws principal `(stakedBase, stakedQuote)`. One-shot.
+    /// @notice Drain accumulated principal from `unstakeBuffer*` to owner. Reverts if both empty.
     function unstake() external;
 
-    /// @notice Owner withdraws rewards `(baseReward, quoteReward)`. One-shot.
+    /// @notice Drain accumulated rewards from `rewardBuffer*` to owner. Reverts if both empty.
     function claimRewards() external;
 
     // ============ Convenience — owner-only ============
 
-    /// @notice Owner-driven exit using a flash-loan / external-swap helper contract.
-    function flashClose(address callbackTarget, bytes calldata data) external;
+    /// @notice Owner-driven (partial or full) exit using a flash-loan / external-swap helper.
+    /// @param bps Fraction of the active position to close, in basis points (1..10000).
+    /// @param callbackTarget Helper contract implementing IFlashCloseCallback.
+    /// @param data Opaque calldata forwarded to the callback.
+    function flashClose(uint16 bps, address callbackTarget, bytes calldata data) external;
 
     // OZ `Multicall` mixin (`function multicall(bytes[] calldata) external returns (bytes[] memory)`)
     // is provided directly by the implementation via inheritance — see UniswapV3StakingVault.

--- a/apps/midcurve-contracts/test/staking-vault/UniswapV3StakingVault.t.sol
+++ b/apps/midcurve-contracts/test/staking-vault/UniswapV3StakingVault.t.sol
@@ -7,14 +7,15 @@ import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import {Clones} from "@openzeppelin/contracts/proxy/Clones.sol";
 
 import {UniswapV3StakingVault} from "../../contracts/staking-vault/UniswapV3StakingVault.sol";
-import {StakeParams, SwapStatus, SwapQuote} from
-    "../../contracts/staking-vault/interfaces/IStakingVault.sol";
-
 import {
-    MockStakingNFPM,
-    MockUniFactory,
-    MockUniPool
-} from "./mocks/MockStakingNFPM.sol";
+    IStakingVault,
+    StakeParams,
+    TopUpParams,
+    SwapStatus,
+    SwapQuote
+} from "../../contracts/staking-vault/interfaces/IStakingVault.sol";
+
+import {MockStakingNFPM, MockUniFactory, MockUniPool} from "./mocks/MockStakingNFPM.sol";
 import {MockFlashCloseCallback} from "./mocks/MockFlashCloseCallback.sol";
 
 contract MockERC20 is ERC20 {
@@ -46,6 +47,10 @@ contract UniswapV3StakingVaultTest is Test {
     uint160 internal constant SQRT_PRICE_X96 = 79228162514264337593543950336; // tick 0
     uint256 internal constant DEADLINE = type(uint256).max;
 
+    // Liquidity high enough that partial bps in [1, 10000] always yields a positive
+    // partialLiquidity bucket for the mock's decreaseLiquidity flow.
+    uint128 internal constant L_BIG = 10_000;
+
     function setUp() public {
         uniFactory = new MockUniFactory();
         nfpm = new MockStakingNFPM(address(uniFactory));
@@ -71,13 +76,11 @@ contract UniswapV3StakingVaultTest is Test {
 
     // ============ helpers ============
 
-    /// @dev Standard stake: alice mints 1000 base + 1000 quote with `T` yield target.
-    ///      Returns the minted tokenId. `isQ0` selects which token is quote.
+    /// @dev Standard initial stake. `desired0/1` are the consumed amounts (mock returns desired==used).
     function _stake(uint256 desired0, uint256 desired1, uint128 liquidity, bool isQ0, uint256 T)
         internal
         returns (uint256 tokenId)
     {
-        // Set what mint() will return as "consumed"
         nfpm.setNextMintResult(liquidity, desired0, desired1);
 
         tokenA.mint(alice, desired0);
@@ -102,14 +105,12 @@ contract UniswapV3StakingVaultTest is Test {
         vm.stopPrank();
     }
 
-    /// @dev Set up a swap()-time scenario: pre-load NFPM with the tokens that
-    ///      decreaseLiquidity+collect will transfer to the vault, set the next
-    ///      decrease result, and set position liquidity to a positive value
-    ///      (so _closePosition actually decreases something).
+    /// @dev Configure the next decrease/collect to deliver `(amount0Out, amount1Out)` to the
+    ///      vault, and set position liquidity to L_BIG so any bps yields a positive partial
+    ///      liquidity bucket.
     function _arrangeClose(uint256 tokenId, uint256 amount0Out, uint256 amount1Out) internal {
-        nfpm.setLiquidityForTesting(tokenId, 1); // any positive
+        nfpm.setLiquidityForTesting(tokenId, L_BIG);
         nfpm.setNextDecreaseResult(tokenId, amount0Out, amount1Out);
-        // Fund NFPM so collect() can pay out to the vault
         if (amount0Out > 0) tokenA.mint(address(nfpm), amount0Out);
         if (amount1Out > 0) tokenB.mint(address(nfpm), amount1Out);
     }
@@ -145,23 +146,23 @@ contract UniswapV3StakingVaultTest is Test {
 
         assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Staked));
         assertEq(vault.isToken0Quote(), true);
-        assertEq(vault.stakedQuote(), 1_000); // amount0Used
-        assertEq(vault.stakedBase(), 800); // amount1Used
+        assertEq(vault.stakedQuote(), 1_000);
+        assertEq(vault.stakedBase(), 800);
         assertEq(vault.yieldTarget(), 100);
         assertEq(vault.tokenId(), tokenId);
         assertEq(vault.pool(), address(pool));
         assertEq(vault.token0(), address(tokenA));
         assertEq(vault.token1(), address(tokenB));
+        assertEq(vault.partialUnstakeBps(), 0);
     }
 
     function test_stake_happyPath_isToken0Quote_false() public {
         _stake(800, 1_000, 500, false, 100);
-        assertEq(vault.stakedBase(), 800); // amount0Used
-        assertEq(vault.stakedQuote(), 1_000); // amount1Used
+        assertEq(vault.stakedBase(), 800);
+        assertEq(vault.stakedQuote(), 1_000);
     }
 
     function test_stake_refundsUnconsumed() public {
-        // mint() will only consume 600 of 1000 token0 and 400 of 800 token1
         nfpm.setNextMintResult(300, 600, 400);
         tokenA.mint(alice, 1_000);
         tokenB.mint(alice, 800);
@@ -187,8 +188,8 @@ contract UniswapV3StakingVaultTest is Test {
         vault.stake(p, true, 100);
         vm.stopPrank();
 
-        assertEq(tokenA.balanceOf(alice), aliceA0 - 600); // refunded 400
-        assertEq(tokenB.balanceOf(alice), aliceB0 - 400); // refunded 400
+        assertEq(tokenA.balanceOf(alice), aliceA0 - 600);
+        assertEq(tokenB.balanceOf(alice), aliceB0 - 400);
         assertEq(vault.stakedQuote(), 600);
         assertEq(vault.stakedBase(), 400);
     }
@@ -242,6 +243,114 @@ contract UniswapV3StakingVaultTest is Test {
         vm.stopPrank();
     }
 
+    // ============ stakeTopUp ============
+
+    function _topUp(uint256 d0, uint256 d1, uint256 used0, uint256 used1, uint128 dL) internal {
+        uint256 tid = vault.tokenId();
+        nfpm.setNextIncreaseResult(tid, dL, used0, used1);
+        tokenA.mint(alice, d0);
+        tokenB.mint(alice, d1);
+        vm.startPrank(alice);
+        tokenA.approve(address(vault), d0);
+        tokenB.approve(address(vault), d1);
+        TopUpParams memory p = TopUpParams({
+            amount0Desired: d0,
+            amount1Desired: d1,
+            amount0Min: 0,
+            amount1Min: 0,
+            deadline: DEADLINE
+        });
+        vault.stakeTopUp(p);
+        vm.stopPrank();
+    }
+
+    function test_stakeTopUp_addsDeltas() public {
+        _stake(1_000, 800, 500, true, 100); // Q=1000, B=800, T=100
+
+        _topUp(500, 400, 500, 400, 200);
+
+        assertEq(vault.stakedQuote(), 1_500); // 1000 + 500 (token0 = quote)
+        assertEq(vault.stakedBase(), 1_200); // 800 + 400 (token1 = base)
+    }
+
+    function test_stakeTopUp_scalesYieldTarget_ceilRounded() public {
+        _stake(1_000, 800, 500, true, 100); // Q=1000, T=100
+        _topUp(500, 400, 500, 400, 200);
+
+        // T_new = ceil(100 * 1500 / 1000) = 150
+        assertEq(vault.yieldTarget(), 150);
+    }
+
+    function test_stakeTopUp_ceilingRoundsUp() public {
+        // Choose values that produce a non-integer T_new to confirm ceil rounding.
+        _stake(1_000, 800, 500, true, 7); // Q=1000, T=7
+        _topUp(3, 2, 3, 2, 5);
+
+        // T_new = ceil(7 * 1003 / 1000) = ceil(7.021) = 8
+        assertEq(vault.yieldTarget(), 8);
+    }
+
+    function test_stakeTopUp_zeroQuote_leavesYieldTargetUnchanged() public {
+        // Initial stake: token1 (base) only; quote consumed = 0.
+        _stake(0, 1_000, 500, true, 100); // Q=0, B=1000, T=100
+        _topUp(0, 200, 0, 200, 100);
+
+        // Q == 0 → no anchor; T stays at 100.
+        assertEq(vault.yieldTarget(), 100);
+        assertEq(vault.stakedQuote(), 0);
+        assertEq(vault.stakedBase(), 1_200);
+    }
+
+    function test_stakeTopUp_refundsUnconsumed() public {
+        _stake(1_000, 800, 500, true, 100);
+
+        uint256 tid = vault.tokenId();
+        nfpm.setNextIncreaseResult(tid, 100, 200, 100); // used 200 of 500, 100 of 400
+        tokenA.mint(alice, 500);
+        tokenB.mint(alice, 400);
+        uint256 a0 = tokenA.balanceOf(alice);
+        uint256 b0 = tokenB.balanceOf(alice);
+        vm.startPrank(alice);
+        tokenA.approve(address(vault), 500);
+        tokenB.approve(address(vault), 400);
+        vault.stakeTopUp(TopUpParams({
+            amount0Desired: 500,
+            amount1Desired: 400,
+            amount0Min: 0,
+            amount1Min: 0,
+            deadline: DEADLINE
+        }));
+        vm.stopPrank();
+
+        assertEq(tokenA.balanceOf(alice), a0 - 200); // refunded 300
+        assertEq(tokenB.balanceOf(alice), b0 - 100); // refunded 300
+    }
+
+    function test_stakeTopUp_revertsIfNotOwner() public {
+        _stake(1_000, 800, 500, true, 100);
+        vm.prank(bob);
+        vm.expectRevert(UniswapV3StakingVault.NotOwner.selector);
+        vault.stakeTopUp(TopUpParams({
+            amount0Desired: 1,
+            amount1Desired: 1,
+            amount0Min: 0,
+            amount1Min: 0,
+            deadline: DEADLINE
+        }));
+    }
+
+    function test_stakeTopUp_revertsIfEmpty() public {
+        vm.prank(alice);
+        vm.expectRevert(UniswapV3StakingVault.WrongState.selector);
+        vault.stakeTopUp(TopUpParams({
+            amount0Desired: 1,
+            amount1Desired: 1,
+            amount0Min: 0,
+            amount1Min: 0,
+            deadline: DEADLINE
+        }));
+    }
+
     // ============ setYieldTarget ============
 
     function test_setYieldTarget_owner_inStaked() public {
@@ -259,69 +368,141 @@ contract UniswapV3StakingVaultTest is Test {
     }
 
     function test_setYieldTarget_revertsIfWrongState() public {
-        // Empty state
         vm.prank(alice);
         vm.expectRevert(UniswapV3StakingVault.WrongState.selector);
         vault.setYieldTarget(250);
     }
 
-    // ============ swap — Case 1 (no swap needed) ============
+    // ============ partial unstake control ============
+
+    function test_setPartialUnstakeBps_setsAndEmits() public {
+        _stake(1_000, 800, 500, true, 100);
+
+        vm.expectEmit(true, false, false, true, address(vault));
+        emit IStakingVault.PartialUnstakeBpsSet(alice, 0, 3_000);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(3_000);
+        assertEq(vault.partialUnstakeBps(), 3_000);
+    }
+
+    function test_setPartialUnstakeBps_zeroAndMaxAllowed() public {
+        _stake(1_000, 800, 500, true, 100);
+        vm.startPrank(alice);
+        vault.setPartialUnstakeBps(0);
+        assertEq(vault.partialUnstakeBps(), 0);
+        vault.setPartialUnstakeBps(10_000);
+        assertEq(vault.partialUnstakeBps(), 10_000);
+        vm.stopPrank();
+    }
+
+    function test_setPartialUnstakeBps_revertsAbove10000() public {
+        _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vm.expectRevert(UniswapV3StakingVault.InvalidBps.selector);
+        vault.setPartialUnstakeBps(10_001);
+    }
+
+    function test_setPartialUnstakeBps_revertsIfNotOwner() public {
+        _stake(1_000, 800, 500, true, 100);
+        vm.prank(bob);
+        vm.expectRevert(UniswapV3StakingVault.NotOwner.selector);
+        vault.setPartialUnstakeBps(100);
+    }
+
+    function test_setPartialUnstakeBps_revertsIfEmpty() public {
+        vm.prank(alice);
+        vm.expectRevert(UniswapV3StakingVault.WrongState.selector);
+        vault.setPartialUnstakeBps(100);
+    }
+
+    function test_increasePartialUnstakeBps_addsToCounter() public {
+        _stake(1_000, 800, 500, true, 100);
+        vm.startPrank(alice);
+        vault.setPartialUnstakeBps(3_000);
+        vault.increasePartialUnstakeBps(2_000);
+        assertEq(vault.partialUnstakeBps(), 5_000);
+        vm.stopPrank();
+    }
+
+    function test_increasePartialUnstakeBps_revertsOnOverflow() public {
+        _stake(1_000, 800, 500, true, 100);
+        vm.startPrank(alice);
+        vault.setPartialUnstakeBps(9_000);
+        vm.expectRevert(UniswapV3StakingVault.InvalidBps.selector);
+        vault.increasePartialUnstakeBps(2_000);
+        vm.stopPrank();
+    }
+
+    function test_increasePartialUnstakeBps_zeroIsNoOp_emits() public {
+        _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(2_500);
+
+        vm.expectEmit(true, false, false, true, address(vault));
+        emit IStakingVault.PartialUnstakeBpsSet(alice, 2_500, 2_500);
+        vm.prank(alice);
+        vault.increasePartialUnstakeBps(0);
+        assertEq(vault.partialUnstakeBps(), 2_500);
+    }
+
+    // ============ swap — full close (effectiveBps == 10000, default pendingBps == 0) ============
 
     function test_swap_case1_settles_with_zero_amountIn() public {
         uint256 T = 100;
         uint256 tokenId = _stake(1_000, 800, 500, true, T); // Q=1000, B=800
+        _arrangeClose(tokenId, 1_200, 900); // b=900>=B, q=1200>=Q+T → Case 1
 
-        // After close: b=900 (>=B=800), q=1200 (>=Q+T=1100). Case 1.
-        // isToken0Quote = true → token0 = quote, token1 = base
-        _arrangeClose(tokenId, 1_200, 900);
+        vm.expectEmit(true, false, false, true, address(vault));
+        emit IStakingVault.Swap(executor, address(0), 0, address(0), 0, 10_000);
 
         vm.prank(executor);
         vault.swap(address(0), 0, address(0), 0);
 
         assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Settled));
-        assertEq(vault.baseReward(), 100); // 900 - 800
-        assertEq(vault.quoteReward(), 200); // 1200 - 1000
+        assertEq(vault.unstakeBufferBase(), 800);
+        assertEq(vault.unstakeBufferQuote(), 1_000);
+        assertEq(vault.rewardBufferBase(), 100); // 900 - 800
+        assertEq(vault.rewardBufferQuote(), 200); // 1200 - 1000
+        assertEq(vault.stakedBase(), 0);
+        assertEq(vault.stakedQuote(), 0);
+        assertEq(vault.yieldTarget(), 0);
+        assertEq(vault.partialUnstakeBps(), 0);
     }
 
     function test_swap_case1_revertsIfAmountInNonZero() public {
-        uint256 T = 100;
-        uint256 tokenId = _stake(1_000, 800, 500, true, T);
-        _arrangeClose(tokenId, 1_200, 900); // Case 1
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        _arrangeClose(tokenId, 1_200, 900);
 
         vm.prank(executor);
         vm.expectRevert(UniswapV3StakingVault.InsufficientAmountIn.selector);
         vault.swap(address(0), 1, address(0), 0);
     }
 
-    // ============ swap — Case 2 (executor sends quote, receives base) ============
-
     function test_swap_case2_executor_pays_quote() public {
-        uint256 T = 100;
-        uint256 tokenId = _stake(1_000, 800, 500, true, T); // Q=1000, B=800
-        // After close: b=900 (>B=800), q=900 (<Q+T=1100). Case 2.
-        _arrangeClose(tokenId, 900, 900);
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100); // Q=1000, B=800
+        _arrangeClose(tokenId, 900, 900); // b=900>B, q=900<Q+T=1100 → Case 2
 
-        // requiredMin = (Q+T)-q = 200; amountOut = b-B = 100
-        _approveExecutor(tokenA, 250); // tokenA = quote
-        uint256 baseBefore = tokenB.balanceOf(executor); // tokenB = base
+        _approveExecutor(tokenA, 250);
+        uint256 baseBefore = tokenB.balanceOf(executor);
 
         vm.prank(executor);
         uint256 out = vault.swap(address(tokenA), 250, address(tokenB), 50);
 
         assertEq(out, 100);
         assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Settled));
-        assertEq(vault.baseReward(), 0);
-        assertEq(vault.quoteReward(), 150); // (q + amountIn) - Q = (900+250)-1000
+        assertEq(vault.unstakeBufferBase(), 800);
+        assertEq(vault.unstakeBufferQuote(), 1_000);
+        assertEq(vault.rewardBufferBase(), 0);
+        assertEq(vault.rewardBufferQuote(), 150); // (900 + 250) - 1000
         assertEq(tokenB.balanceOf(executor), baseBefore + 100);
-        // Vault now holds B base and (q+amountIn) quote
+        // Vault holds buffers: 800 base, 1150 quote.
         assertEq(tokenB.balanceOf(address(vault)), 800);
         assertEq(tokenA.balanceOf(address(vault)), 1_150);
     }
 
     function test_swap_case2_revertsIfAmountInBelowRequiredMin() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        _arrangeClose(tokenId, 900, 900); // requiredMin = 200
-
+        _arrangeClose(tokenId, 900, 900);
         _approveExecutor(tokenA, 199);
         vm.prank(executor);
         vm.expectRevert(UniswapV3StakingVault.InsufficientAmountIn.selector);
@@ -330,8 +511,7 @@ contract UniswapV3StakingVaultTest is Test {
 
     function test_swap_case2_revertsIfMinAmountOutTooHigh() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        _arrangeClose(tokenId, 900, 900); // amountOut = 100
-
+        _arrangeClose(tokenId, 900, 900);
         _approveExecutor(tokenA, 250);
         vm.prank(executor);
         vm.expectRevert(UniswapV3StakingVault.SlippageExceeded.selector);
@@ -341,34 +521,27 @@ contract UniswapV3StakingVaultTest is Test {
     function test_swap_case2_revertsOnTokenMismatch() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         _arrangeClose(tokenId, 900, 900);
-
-        _approveExecutor(tokenB, 250); // wrong direction
+        _approveExecutor(tokenB, 250);
         vm.prank(executor);
         vm.expectRevert(UniswapV3StakingVault.TokenMismatch.selector);
         vault.swap(address(tokenB), 250, address(tokenA), 0);
     }
 
-    function test_swap_case2_overpayment_flowsToQuoteReward() public {
+    function test_swap_case2_overpayment_flowsToQuoteRewardBuffer() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        _arrangeClose(tokenId, 900, 900); // Case 2: requiredMin=200, amountOut=100
-
-        _approveExecutor(tokenA, 500); // overpay 300
+        _arrangeClose(tokenId, 900, 900);
+        _approveExecutor(tokenA, 500);
         vm.prank(executor);
         uint256 out = vault.swap(address(tokenA), 500, address(tokenB), 0);
-        assertEq(out, 100); // unchanged
-        assertEq(vault.quoteReward(), 400); // (900+500)-1000
+        assertEq(out, 100);
+        assertEq(vault.rewardBufferQuote(), 400); // (900+500) - 1000
     }
 
-    // ============ swap — Case 3 (executor sends base, receives quote) ============
-
     function test_swap_case3_executor_pays_base() public {
-        uint256 T = 100;
-        uint256 tokenId = _stake(1_000, 800, 500, true, T); // Q=1000, B=800
-        // After close: b=700 (<B=800), q=1300 (>Q+T=1100). Case 3.
-        _arrangeClose(tokenId, 1_300, 700);
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100); // Q=1000, B=800, T=100
+        _arrangeClose(tokenId, 1_300, 700); // b=700<B, q=1300>Q+T=1100 → Case 3
 
-        // requiredMin = B-b = 100; amountOut = q-(Q+T) = 200
-        _approveExecutor(tokenB, 150); // tokenB = base
+        _approveExecutor(tokenB, 150);
         uint256 quoteBefore = tokenA.balanceOf(executor);
 
         vm.prank(executor);
@@ -376,30 +549,25 @@ contract UniswapV3StakingVaultTest is Test {
 
         assertEq(out, 200);
         assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Settled));
-        assertEq(vault.baseReward(), 50); // (b + amountIn) - B = (700+150)-800
-        assertEq(vault.quoteReward(), 100); // = T
+        assertEq(vault.rewardBufferBase(), 50); // (700 + 150) - 800
+        assertEq(vault.rewardBufferQuote(), 100); // = T
         assertEq(tokenA.balanceOf(executor), quoteBefore + 200);
     }
 
-    function test_swap_case3_overpayment_flowsToBaseReward() public {
+    function test_swap_case3_overpayment_flowsToBaseRewardBuffer() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        _arrangeClose(tokenId, 1_300, 700); // requiredMin=100, amountOut=200
-
-        _approveExecutor(tokenB, 500); // overpay
+        _arrangeClose(tokenId, 1_300, 700);
+        _approveExecutor(tokenB, 500);
         vm.prank(executor);
         uint256 out = vault.swap(address(tokenB), 500, address(tokenA), 0);
         assertEq(out, 200);
-        assertEq(vault.baseReward(), 400); // (700+500)-800
-        assertEq(vault.quoteReward(), 100);
+        assertEq(vault.rewardBufferBase(), 400); // (700+500) - 800
+        assertEq(vault.rewardBufferQuote(), 100);
     }
 
-    // ============ swap — Case 4 (underwater) ============
-
     function test_swap_case4_reverts() public {
-        // Deficit on both sides
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         _arrangeClose(tokenId, 500, 500);
-
         _approveExecutor(tokenA, 1_000);
         vm.prank(executor);
         vm.expectRevert(UniswapV3StakingVault.Underwater.selector);
@@ -407,10 +575,8 @@ contract UniswapV3StakingVaultTest is Test {
     }
 
     function test_swap_case4_boundary_b_eq_B_q_lt_floor() public {
-        // b == B AND q < Q+T → spec §10 boundary: Case 4
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        _arrangeClose(tokenId, 1_000, 800); // b=800=B, q=1000<1100
-
+        _arrangeClose(tokenId, 1_000, 800); // b=B, q<Q+T
         _approveExecutor(tokenA, 1_000);
         vm.prank(executor);
         vm.expectRevert(UniswapV3StakingVault.Underwater.selector);
@@ -419,8 +585,7 @@ contract UniswapV3StakingVaultTest is Test {
 
     function test_swap_case4_boundary_b_lt_B_q_eq_floor() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        _arrangeClose(tokenId, 1_100, 700); // b=700<B, q=1100==Q+T
-
+        _arrangeClose(tokenId, 1_100, 700);
         _approveExecutor(tokenB, 1_000);
         vm.prank(executor);
         vm.expectRevert(UniswapV3StakingVault.Underwater.selector);
@@ -428,55 +593,178 @@ contract UniswapV3StakingVaultTest is Test {
     }
 
     function test_swap_case1_boundary_b_eq_B_q_eq_floor() public {
-        // Degenerate Case 1: both at exact floor
-        uint256 T = 100;
-        uint256 tokenId = _stake(1_000, 800, 500, true, T);
-        _arrangeClose(tokenId, 1_100, 800); // b=B, q=Q+T
-
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        _arrangeClose(tokenId, 1_100, 800);
         vm.prank(executor);
         vault.swap(address(0), 0, address(0), 0);
-        assertEq(vault.baseReward(), 0);
-        assertEq(vault.quoteReward(), 100); // q-Q = T
+        assertEq(vault.rewardBufferBase(), 0);
+        assertEq(vault.rewardBufferQuote(), 100);
     }
 
     function test_swap_case1_boundary_b_eq_B_q_gt_floor() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        _arrangeClose(tokenId, 1_500, 800); // b=B, q>Q+T
-
+        _arrangeClose(tokenId, 1_500, 800);
         vm.prank(executor);
         vault.swap(address(0), 0, address(0), 0);
-        assertEq(vault.baseReward(), 0);
-        assertEq(vault.quoteReward(), 500);
+        assertEq(vault.rewardBufferBase(), 0);
+        assertEq(vault.rewardBufferQuote(), 500);
     }
 
     function test_swap_case1_boundary_b_gt_B_q_eq_floor() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        _arrangeClose(tokenId, 1_100, 1_000); // b>B, q=Q+T
-
+        _arrangeClose(tokenId, 1_100, 1_000);
         vm.prank(executor);
         vault.swap(address(0), 0, address(0), 0);
-        assertEq(vault.baseReward(), 200);
-        assertEq(vault.quoteReward(), 100);
+        assertEq(vault.rewardBufferBase(), 200);
+        assertEq(vault.rewardBufferQuote(), 100);
     }
-
-    // ============ Yield target overflow ============
 
     function test_swap_overflow_isUnderwater() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, type(uint256).max);
-        _arrangeClose(tokenId, 5_000, 5_000); // any balances
-
+        _arrangeClose(tokenId, 5_000, 5_000);
         _approveExecutor(tokenA, 1_000);
         vm.prank(executor);
         vm.expectRevert(UniswapV3StakingVault.Underwater.selector);
         vault.swap(address(tokenA), 1_000, address(tokenB), 0);
     }
 
-    // ============ unstake / claimRewards — settlement & one-shot ============
+    // ============ swap — partial close (effectiveBps < 10000) ============
+
+    function test_swap_partial_case1_staysStaked() public {
+        // Q=1000, B=800, T=100. pendingBps=5000 → targetBase=400, targetQuote=550.
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(5_000);
+        // partial close yields b=500, q=600 → both >= targets → Case 1
+        _arrangeClose(tokenId, 600, 500);
+
+        vm.expectEmit(true, false, false, true, address(vault));
+        emit IStakingVault.Swap(executor, address(0), 0, address(0), 0, 5_000);
+        vm.prank(executor);
+        vault.swap(address(0), 0, address(0), 0);
+
+        assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Staked));
+        assertEq(vault.partialUnstakeBps(), 0);
+        assertEq(vault.unstakeBufferBase(), 400); // B*0.5
+        assertEq(vault.unstakeBufferQuote(), 500); // Q*0.5
+        assertEq(vault.rewardBufferBase(), 100); // 500 - 400
+        assertEq(vault.rewardBufferQuote(), 100); // 600 - 500
+        assertEq(vault.stakedBase(), 400);
+        assertEq(vault.stakedQuote(), 500);
+        assertEq(vault.yieldTarget(), 50);
+    }
+
+    function test_swap_partial_case2() public {
+        // pendingBps=5000. targetBase=400, targetQuote=550. After partial: b=500, q=400 → Case 2.
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(5_000);
+        _arrangeClose(tokenId, 400, 500);
+
+        // requiredMin = 550 - 400 = 150; amountOut = 500 - 400 = 100
+        _approveExecutor(tokenA, 200);
+        vm.prank(executor);
+        uint256 out = vault.swap(address(tokenA), 200, address(tokenB), 0);
+        assertEq(out, 100);
+        assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Staked));
+        assertEq(vault.unstakeBufferBase(), 400);
+        assertEq(vault.unstakeBufferQuote(), 500);
+        assertEq(vault.rewardBufferBase(), 0);
+        assertEq(vault.rewardBufferQuote(), 100); // (400 + 200) - 500
+    }
+
+    function test_swap_partial_case3() public {
+        // pendingBps=5000. After partial: b=300, q=700 → b<400, q>550 → Case 3.
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(5_000);
+        _arrangeClose(tokenId, 700, 300);
+
+        // requiredMin = 400 - 300 = 100; amountOut = 700 - 550 = 150
+        _approveExecutor(tokenB, 100);
+        vm.prank(executor);
+        uint256 out = vault.swap(address(tokenB), 100, address(tokenA), 0);
+        assertEq(out, 150);
+        assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Staked));
+        assertEq(vault.rewardBufferBase(), 0); // (300 + 100) - 400
+        assertEq(vault.rewardBufferQuote(), 50); // 550 - 500 (T*0.5 = 50)
+    }
+
+    function test_swap_partial_case4_reverts() public {
+        // pendingBps=5000. After partial: b=200, q=300 → both deficit → Case 4.
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(5_000);
+        _arrangeClose(tokenId, 300, 200);
+        _approveExecutor(tokenA, 1_000);
+        vm.prank(executor);
+        vm.expectRevert(UniswapV3StakingVault.Underwater.selector);
+        vault.swap(address(tokenA), 1_000, address(tokenB), 0);
+    }
+
+    function test_swap_partial_explicitFullViaPendingBps10000() public {
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(10_000);
+        _arrangeClose(tokenId, 1_200, 900); // identical to default-0 full close
+
+        vm.expectEmit(true, false, false, true, address(vault));
+        emit IStakingVault.Swap(executor, address(0), 0, address(0), 0, 10_000);
+        vm.prank(executor);
+        vault.swap(address(0), 0, address(0), 0);
+        assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Settled));
+    }
+
+    function test_swap_sequentialPartials_buffersAccumulate() public {
+        // 30% then 30% partials. Confirm buffers sum and (B,Q,T) reduce monotonically.
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+
+        // First partial — pendingBps = 3000.
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(3_000);
+        // partial close: b=400, q=400; targets: tB=240, tQ=330. Case 1 (both surplus).
+        _arrangeClose(tokenId, 400, 400);
+        vm.prank(executor);
+        vault.swap(address(0), 0, address(0), 0);
+
+        // After 1st: unstakeBufBase=240, unstakeBufQuote=300, rewardBufBase=160, rewardBufQuote=100.
+        // staked: B=560, Q=700, T=70; state=Staked.
+        assertEq(vault.unstakeBufferBase(), 240);
+        assertEq(vault.unstakeBufferQuote(), 300);
+        assertEq(vault.rewardBufferBase(), 160);
+        assertEq(vault.rewardBufferQuote(), 100);
+        assertEq(vault.stakedBase(), 560);
+        assertEq(vault.stakedQuote(), 700);
+        assertEq(vault.yieldTarget(), 70);
+        assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Staked));
+
+        // Second partial — pendingBps = 3000 again.
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(3_000);
+        // Now B=560, Q=700, T=70. Targets: tB=168, tQ=231.
+        // Arrange b=200, q=300 → Case 1 (both surplus).
+        nfpm.setNextDecreaseResult(tokenId, 300, 200);
+        tokenA.mint(address(nfpm), 300);
+        tokenB.mint(address(nfpm), 200);
+        vm.prank(executor);
+        vault.swap(address(0), 0, address(0), 0);
+
+        // Buffers accumulate. New deltas: unstakeBaseDelta=168, unstakeQuoteDelta=210.
+        // rewardBufBase += 200 - 168 = 32 → total 192. rewardBufQuote += 300 - 210 = 90 → total 190.
+        assertEq(vault.unstakeBufferBase(), 240 + 168);
+        assertEq(vault.unstakeBufferQuote(), 300 + 210);
+        assertEq(vault.rewardBufferBase(), 160 + 32);
+        assertEq(vault.rewardBufferQuote(), 100 + 90);
+        assertEq(vault.stakedBase(), 560 - 168);
+        assertEq(vault.stakedQuote(), 700 - 210);
+        assertEq(vault.yieldTarget(), 70 - 21); // 70 * 3000 / 10000 = 21
+    }
+
+    // ============ unstake / claimRewards (buffer drain) ============
 
     function test_unstake_then_claim_paysOwner_full() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        _arrangeClose(tokenId, 1_200, 900); // Case 1: baseReward=100, quoteReward=200
-
+        _arrangeClose(tokenId, 1_200, 900); // Case 1 → reward 100/200
         vm.prank(executor);
         vault.swap(address(0), 0, address(0), 0);
 
@@ -488,32 +776,31 @@ contract UniswapV3StakingVaultTest is Test {
         vault.claimRewards();
         vm.stopPrank();
 
-        assertEq(tokenA.balanceOf(alice), quoteBefore + 1_000 + 200); // stakedQuote + quoteReward
-        assertEq(tokenB.balanceOf(alice), baseBefore + 800 + 100); // stakedBase + baseReward
+        assertEq(tokenA.balanceOf(alice), quoteBefore + 1_000 + 200);
+        assertEq(tokenB.balanceOf(alice), baseBefore + 800 + 100);
         assertEq(tokenA.balanceOf(address(vault)), 0);
         assertEq(tokenB.balanceOf(address(vault)), 0);
+        assertEq(vault.unstakeBufferBase(), 0);
+        assertEq(vault.unstakeBufferQuote(), 0);
+        assertEq(vault.rewardBufferBase(), 0);
+        assertEq(vault.rewardBufferQuote(), 0);
     }
 
     function test_claim_then_unstake_orderIndependent() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         _arrangeClose(tokenId, 1_200, 900);
-
         vm.prank(executor);
         vault.swap(address(0), 0, address(0), 0);
-
-        uint256 quoteBefore = tokenA.balanceOf(alice);
-        uint256 baseBefore = tokenB.balanceOf(alice);
 
         vm.startPrank(alice);
         vault.claimRewards();
         vault.unstake();
         vm.stopPrank();
-
-        assertEq(tokenA.balanceOf(alice), quoteBefore + 1_000 + 200);
-        assertEq(tokenB.balanceOf(alice), baseBefore + 800 + 100);
+        assertEq(vault.unstakeBufferBase(), 0);
+        assertEq(vault.rewardBufferBase(), 0);
     }
 
-    function test_unstake_isOneShot() public {
+    function test_unstake_revertsIfBuffersEmpty() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         _arrangeClose(tokenId, 1_200, 900);
         vm.prank(executor);
@@ -521,12 +808,12 @@ contract UniswapV3StakingVaultTest is Test {
 
         vm.startPrank(alice);
         vault.unstake();
-        vm.expectRevert(UniswapV3StakingVault.AlreadyConsumed.selector);
+        vm.expectRevert(UniswapV3StakingVault.NothingToUnstake.selector);
         vault.unstake();
         vm.stopPrank();
     }
 
-    function test_claim_isOneShot() public {
+    function test_claim_revertsIfBuffersEmpty() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         _arrangeClose(tokenId, 1_200, 900);
         vm.prank(executor);
@@ -534,13 +821,13 @@ contract UniswapV3StakingVaultTest is Test {
 
         vm.startPrank(alice);
         vault.claimRewards();
-        vm.expectRevert(UniswapV3StakingVault.AlreadyConsumed.selector);
+        vm.expectRevert(UniswapV3StakingVault.NothingToClaim.selector);
         vault.claimRewards();
         vm.stopPrank();
     }
 
-    function test_unstake_revertsIfNotSettled() public {
-        _stake(1_000, 800, 500, true, 100);
+    function test_unstake_revertsIfEmpty_state() public {
+        // Empty state — no buffers exist yet.
         vm.prank(alice);
         vm.expectRevert(UniswapV3StakingVault.WrongState.selector);
         vault.unstake();
@@ -557,115 +844,300 @@ contract UniswapV3StakingVaultTest is Test {
         vault.claimRewards();
     }
 
-    // ============ flashClose ============
+    function test_unstake_callableInStaked_partialCycle() public {
+        // After a partial swap the state is Staked but buffers are non-empty.
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(5_000);
+        _arrangeClose(tokenId, 600, 500); // Case 1 partial
+
+        vm.prank(executor);
+        vault.swap(address(0), 0, address(0), 0);
+        assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Staked));
+
+        uint256 baseBefore = tokenB.balanceOf(alice);
+        uint256 quoteBefore = tokenA.balanceOf(alice);
+        vm.startPrank(alice);
+        vault.unstake();
+        vault.claimRewards();
+        vm.stopPrank();
+        // unstake: 400 base, 500 quote. claim: 100 base, 100 quote.
+        assertEq(tokenB.balanceOf(alice), baseBefore + 400 + 100);
+        assertEq(tokenA.balanceOf(alice), quoteBefore + 500 + 100);
+    }
+
+    function test_unstake_multipleCycles_acrossSettlements() public {
+        // Drain after partial 1, then settle full → drain again.
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(3_000);
+        _arrangeClose(tokenId, 400, 400); // Case 1 partial → buffers populated
+
+        vm.prank(executor);
+        vault.swap(address(0), 0, address(0), 0);
+
+        uint256 baseBefore = tokenB.balanceOf(alice);
+        uint256 quoteBefore = tokenA.balanceOf(alice);
+
+        vm.startPrank(alice);
+        vault.unstake();
+        vault.claimRewards();
+        vm.stopPrank();
+        assertEq(vault.unstakeBufferBase(), 0);
+        assertEq(vault.rewardBufferBase(), 0);
+
+        // Now do full close on the remaining 70% position.
+        // B=560, Q=700, T=70. Partial close: vault gets, say, 700 base + 800 quote.
+        nfpm.setNextDecreaseResult(tokenId, 800, 700);
+        tokenA.mint(address(nfpm), 800);
+        tokenB.mint(address(nfpm), 700);
+        vm.prank(executor);
+        vault.swap(address(0), 0, address(0), 0); // pendingBps=0 → effectiveBps=10000
+
+        // Second drain.
+        vm.startPrank(alice);
+        vault.unstake();
+        vault.claimRewards();
+        vm.stopPrank();
+        // First drain delivered: 240 base + 300 quote (unstake) + 160 base + 100 quote (claim).
+        // Second drain delivered: 560 base + 700 quote (unstake) + (700-560)=140 base + (800-700)=100 quote (claim).
+        // Total alice received: 240+160+560+140 = 1100 base, 300+100+700+100 = 1200 quote.
+        assertEq(tokenB.balanceOf(alice) - baseBefore, 1_100);
+        assertEq(tokenA.balanceOf(alice) - quoteBefore, 1_200);
+    }
+
+    // ============ flashClose — full (bps == 10000) ============
 
     function _setupFlashCallback() internal returns (MockFlashCloseCallback cb) {
-        // alice = base recipient, but tokens map: tokenA=quote, tokenB=base when isToken0Quote=true
+        // tokenA = quote, tokenB = base when isToken0Quote=true.
         cb = new MockFlashCloseCallback(address(vault), tokenB, tokenA);
     }
 
-    function test_flashClose_case1_exact_returnsAllRewards() public {
+    function test_flashClose_full_case1_autoDrains() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        _arrangeClose(tokenId, 1_200, 900); // Case 1: surplus
+        _arrangeClose(tokenId, 1_200, 900); // Case 1 surplus
 
         MockFlashCloseCallback cb = _setupFlashCallback();
-        // Vault will push (900 base, 1200 quote) to callback. Callback returns
-        // exactly (expectedBase=800, expectedQuote=1100). Surplus 100 base + 100
-        // quote stays with the callback. To prove vault accounting, fund callback
-        // with nothing extra; Mode.Exact returns exactly required.
-
         cb.setMode(MockFlashCloseCallback.Mode.Exact);
 
         uint256 baseBefore = tokenB.balanceOf(alice);
         uint256 quoteBefore = tokenA.balanceOf(alice);
 
+        vm.expectEmit(true, false, true, true, address(vault));
+        emit IStakingVault.FlashCloseInitiated(alice, 10_000, address(cb), "");
+
         vm.prank(alice);
-        vault.flashClose(address(cb), "");
+        vault.flashClose(10_000, address(cb), "");
 
         assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Settled));
-        // baseReward = finalBase - stakedBase = 800-800 = 0
-        // quoteReward = finalQuote - stakedQuote = 1100-1000 = 100
-        assertEq(vault.baseReward(), 0);
-        assertEq(vault.quoteReward(), 100);
+        // Auto-drain: buffers all zero post-call.
+        assertEq(vault.unstakeBufferBase(), 0);
+        assertEq(vault.unstakeBufferQuote(), 0);
+        assertEq(vault.rewardBufferBase(), 0);
+        assertEq(vault.rewardBufferQuote(), 0);
+        // expected returned: 800 base, 1100 quote.
+        // unstake delivers 800 base + 1000 quote; claim delivers 0 base + 100 quote.
         assertEq(tokenB.balanceOf(alice), baseBefore + 800);
         assertEq(tokenA.balanceOf(alice), quoteBefore + 1_100);
-        assertTrue(vault.principalUnstaked());
-        assertTrue(vault.rewardsClaimed());
     }
 
     function test_flashClose_returnsSurplus_flowsToClaimRewards() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        // Vault closes with q=1200, b=900 → enough to satisfy expected (B=800, Q+T=1100).
         _arrangeClose(tokenId, 1_200, 900);
 
         MockFlashCloseCallback cb = _setupFlashCallback();
-        tokenB.mint(address(cb), 50); // pre-fund surplus base
+        tokenB.mint(address(cb), 50); // surplus base seed
         cb.setMode(MockFlashCloseCallback.Mode.SurplusBase);
         cb.setSurplus(50, 0);
 
         uint256 baseBefore = tokenB.balanceOf(alice);
-
         vm.prank(alice);
-        vault.flashClose(address(cb), "");
-
-        // baseReward = finalBase(850) - stakedBase(800) = 50
-        assertEq(vault.baseReward(), 50);
-        assertEq(tokenB.balanceOf(alice), baseBefore + 800 + 50);
+        vault.flashClose(10_000, address(cb), "");
+        // Alice gets stakedBase + surplus: 800 + 50 = 850 base.
+        assertEq(tokenB.balanceOf(alice), baseBefore + 850);
     }
 
     function test_flashClose_revertsOnInsufficientBase() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         _arrangeClose(tokenId, 1_200, 900);
-
         MockFlashCloseCallback cb = _setupFlashCallback();
         cb.setMode(MockFlashCloseCallback.Mode.InsufficientBase);
-
         vm.prank(alice);
         vm.expectRevert(UniswapV3StakingVault.InsufficientBaseReturned.selector);
-        vault.flashClose(address(cb), "");
+        vault.flashClose(10_000, address(cb), "");
     }
 
     function test_flashClose_revertsOnInsufficientQuote() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         _arrangeClose(tokenId, 1_200, 900);
-
         MockFlashCloseCallback cb = _setupFlashCallback();
         cb.setMode(MockFlashCloseCallback.Mode.InsufficientQuote);
-
         vm.prank(alice);
         vm.expectRevert(UniswapV3StakingVault.InsufficientQuoteReturned.selector);
-        vault.flashClose(address(cb), "");
+        vault.flashClose(10_000, address(cb), "");
     }
 
     function test_flashClose_revertsIfNotOwner() public {
         _stake(1_000, 800, 500, true, 100);
         vm.prank(bob);
         vm.expectRevert(UniswapV3StakingVault.NotOwner.selector);
-        vault.flashClose(address(0xdead), "");
+        vault.flashClose(10_000, address(0xdead), "");
     }
 
-    function test_flashClose_reentrantSwap_revertsViaNonReentrant() public {
+    function test_flashClose_reentrantSwap_revertsViaStateLock() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         _arrangeClose(tokenId, 1_200, 900);
-
         MockFlashCloseCallback cb = _setupFlashCallback();
         cb.setMode(MockFlashCloseCallback.Mode.ReentrantSwap);
-
         vm.prank(alice);
-        vm.expectRevert(); // OZ ReentrancyGuard "ReentrancyGuard: reentrant call"
-        vault.flashClose(address(cb), "");
+        vm.expectRevert();
+        vault.flashClose(10_000, address(cb), "");
     }
 
     function test_flashClose_overflowYieldTarget_reverts() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, type(uint256).max);
         _arrangeClose(tokenId, 1_200, 900);
+        MockFlashCloseCallback cb = _setupFlashCallback();
+        cb.setMode(MockFlashCloseCallback.Mode.Exact);
+        vm.prank(alice);
+        vm.expectRevert(UniswapV3StakingVault.YieldTargetOverflow.selector);
+        vault.flashClose(10_000, address(cb), "");
+    }
 
+    function test_flashClose_revertsIfBpsZero() public {
+        _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vm.expectRevert(UniswapV3StakingVault.InvalidBps.selector);
+        vault.flashClose(0, address(0xdead), "");
+    }
+
+    function test_flashClose_revertsIfBpsAbove10000() public {
+        _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vm.expectRevert(UniswapV3StakingVault.InvalidBps.selector);
+        vault.flashClose(10_001, address(0xdead), "");
+    }
+
+    function test_flashClose_full_case2_callbackBridgesQuoteDeficit() public {
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        _arrangeClose(tokenId, 900, 900); // Case 2
+
+        MockFlashCloseCallback cb = _setupFlashCallback();
+        tokenA.mint(address(cb), 200); // bridge 200 quote
+        cb.setMode(MockFlashCloseCallback.Mode.Exact);
+
+        uint256 baseBefore = tokenB.balanceOf(alice);
+        uint256 quoteBefore = tokenA.balanceOf(alice);
+        vm.prank(alice);
+        vault.flashClose(10_000, address(cb), "");
+        assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Settled));
+        assertEq(tokenB.balanceOf(alice), baseBefore + 800);
+        assertEq(tokenA.balanceOf(alice), quoteBefore + 1_100);
+    }
+
+    function test_flashClose_full_case3_callbackBridgesBaseDeficit() public {
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        _arrangeClose(tokenId, 1_300, 700);
+        MockFlashCloseCallback cb = _setupFlashCallback();
+        tokenB.mint(address(cb), 100);
+        cb.setMode(MockFlashCloseCallback.Mode.Exact);
+
+        uint256 baseBefore = tokenB.balanceOf(alice);
+        uint256 quoteBefore = tokenA.balanceOf(alice);
+        vm.prank(alice);
+        vault.flashClose(10_000, address(cb), "");
+        assertEq(tokenB.balanceOf(alice), baseBefore + 800);
+        assertEq(tokenA.balanceOf(alice), quoteBefore + 1_100);
+    }
+
+    function test_flashClose_full_case4_callbackBridgesBoth() public {
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        _arrangeClose(tokenId, 500, 500);
+        MockFlashCloseCallback cb = _setupFlashCallback();
+        tokenB.mint(address(cb), 300);
+        tokenA.mint(address(cb), 600);
+        cb.setMode(MockFlashCloseCallback.Mode.Exact);
+
+        uint256 baseBefore = tokenB.balanceOf(alice);
+        uint256 quoteBefore = tokenA.balanceOf(alice);
+        vm.prank(alice);
+        vault.flashClose(10_000, address(cb), "");
+        assertEq(tokenB.balanceOf(alice), baseBefore + 800);
+        assertEq(tokenA.balanceOf(alice), quoteBefore + 1_100);
+    }
+
+    // ============ flashClose — partial (bps < 10000) ============
+
+    function test_flashClose_partial_returnsToStaked_pendingBpsUntouched() public {
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100); // Q=1000, B=800, T=100
+        // Set a pendingBps that flashClose must NOT touch.
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(2_000);
+
+        // Partial flashClose at bps=5000.
+        // expectedBase = 400, expectedQuote = 550. partial close yields b=500, q=600.
+        _arrangeClose(tokenId, 600, 500);
         MockFlashCloseCallback cb = _setupFlashCallback();
         cb.setMode(MockFlashCloseCallback.Mode.Exact);
 
+        uint256 baseBefore = tokenB.balanceOf(alice);
+        uint256 quoteBefore = tokenA.balanceOf(alice);
         vm.prank(alice);
-        vm.expectRevert(UniswapV3StakingVault.YieldTargetOverflow.selector);
-        vault.flashClose(address(cb), "");
+        vault.flashClose(5_000, address(cb), "");
+
+        // State returned to Staked, pendingBps preserved.
+        assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Staked));
+        assertEq(vault.partialUnstakeBps(), 2_000);
+        // (B,Q,T) reduced proportionally.
+        assertEq(vault.stakedBase(), 400);
+        assertEq(vault.stakedQuote(), 500);
+        assertEq(vault.yieldTarget(), 50);
+        // Auto-drain: alice receives expected amounts.
+        assertEq(tokenB.balanceOf(alice), baseBefore + 400);
+        assertEq(tokenA.balanceOf(alice), quoteBefore + 550);
+        // Buffers cleared.
+        assertEq(vault.unstakeBufferBase(), 0);
+        assertEq(vault.rewardBufferBase(), 0);
+    }
+
+    function test_flashClose_partial_drainsPreExistingBuffers() public {
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+
+        // First, do a partial swap that fills buffers but doesn't drain.
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(3_000);
+        _arrangeClose(tokenId, 400, 400); // Case 1 partial
+        vm.prank(executor);
+        vault.swap(address(0), 0, address(0), 0);
+        // Buffers now: unstake (240, 300), reward (160, 100). State: Staked.
+
+        // Now flashClose the remaining 50% of position. B=560, Q=700, T=70.
+        // expectedBase = 280, expectedQuote = (770)*0.5 = 385.
+        // Pre-balances at flashClose entry: vault holds 240+160=400 base, 300+100=400 quote.
+        nfpm.setNextDecreaseResult(tokenId, 500, 400);
+        tokenA.mint(address(nfpm), 500);
+        tokenB.mint(address(nfpm), 400);
+        MockFlashCloseCallback cb = _setupFlashCallback();
+        cb.setMode(MockFlashCloseCallback.Mode.Exact);
+
+        uint256 baseBefore = tokenB.balanceOf(alice);
+        uint256 quoteBefore = tokenA.balanceOf(alice);
+        vm.prank(alice);
+        vault.flashClose(5_000, address(cb), "");
+
+        // Alice receives the pre-existing buffers PLUS the new partial settlement.
+        // Mode.Exact returns exactly (expectedBase=280, expectedQuote=385) to the vault.
+        // New unstake delta: (280, 350). New reward delta: (0, 35). Combined with the
+        // pre-existing buffers (240/300 unstake, 160/100 reward) the auto-drain yields:
+        //   alice base  += 240 + 160 + 280 +  0 = 680
+        //   alice quote += 300 + 100 + 350 + 35 = 785
+        assertEq(tokenB.balanceOf(alice), baseBefore + 680);
+        assertEq(tokenA.balanceOf(alice), quoteBefore + 785);
+        assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Staked));
+        // Remaining staked: B=280, Q=350, T=35 (70 - 35).
+        assertEq(vault.stakedBase(), 280);
+        assertEq(vault.stakedQuote(), 350);
+        assertEq(vault.yieldTarget(), 35);
     }
 
     // ============ quoteSwap (state-dependent) ============
@@ -673,6 +1145,7 @@ contract UniswapV3StakingVaultTest is Test {
     function test_quoteSwap_notApplicable_inEmpty() public view {
         SwapQuote memory q = vault.quoteSwap();
         assertEq(uint256(q.status), uint256(SwapStatus.NotApplicable));
+        assertEq(q.effectiveBps, 0);
     }
 
     function test_quoteSwap_notApplicable_inSettled() public {
@@ -682,48 +1155,47 @@ contract UniswapV3StakingVaultTest is Test {
         vault.swap(address(0), 0, address(0), 0);
         SwapQuote memory q = vault.quoteSwap();
         assertEq(uint256(q.status), uint256(SwapStatus.NotApplicable));
+        assertEq(q.effectiveBps, 0);
     }
 
     function test_quoteSwap_underwater_onOverflow() public {
         _stake(1_000, 800, 500, true, type(uint256).max);
         SwapQuote memory q = vault.quoteSwap();
         assertEq(uint256(q.status), uint256(SwapStatus.Underwater));
+        assertEq(q.effectiveBps, 10_000);
     }
 
     function test_quoteSwap_noSwapNeeded_via_owedFees() public {
-        // Stake; then drop liquidity to 0 in NFPM and accrue fees so that
-        // (principal=0) + (owed) >= (B, Q+T). Should classify as NoSwapNeeded.
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         nfpm.setLiquidityForTesting(tokenId, 0);
-        // owed = (1200, 900) → quote=1200>=1100, base=900>=800
-        nfpm.accrueFeesForTesting(tokenId, 1_200, 900);
+        nfpm.accrueFeesForTesting(tokenId, 1_200, 900); // q=1200>=1100, b=900>=800
 
         SwapQuote memory q = vault.quoteSwap();
         assertEq(uint256(q.status), uint256(SwapStatus.NoSwapNeeded));
+        assertEq(q.effectiveBps, 10_000);
     }
 
     function test_quoteSwap_executable_case2() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         nfpm.setLiquidityForTesting(tokenId, 0);
-        nfpm.accrueFeesForTesting(tokenId, 900, 900); // q<floor, b>B
-
+        nfpm.accrueFeesForTesting(tokenId, 900, 900);
         SwapQuote memory q = vault.quoteSwap();
         assertEq(uint256(q.status), uint256(SwapStatus.Executable));
-        assertEq(q.tokenIn, address(tokenA)); // quote
-        assertEq(q.tokenOut, address(tokenB)); // base
+        assertEq(q.tokenIn, address(tokenA));
+        assertEq(q.tokenOut, address(tokenB));
         assertEq(q.minAmountIn, 200);
         assertEq(q.amountOut, 100);
+        assertEq(q.effectiveBps, 10_000);
     }
 
     function test_quoteSwap_executable_case3() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         nfpm.setLiquidityForTesting(tokenId, 0);
-        nfpm.accrueFeesForTesting(tokenId, 1_300, 700); // q>floor, b<B
-
+        nfpm.accrueFeesForTesting(tokenId, 1_300, 700);
         SwapQuote memory q = vault.quoteSwap();
         assertEq(uint256(q.status), uint256(SwapStatus.Executable));
-        assertEq(q.tokenIn, address(tokenB)); // base
-        assertEq(q.tokenOut, address(tokenA)); // quote
+        assertEq(q.tokenIn, address(tokenB));
+        assertEq(q.tokenOut, address(tokenA));
         assertEq(q.minAmountIn, 100);
         assertEq(q.amountOut, 200);
     }
@@ -731,176 +1203,104 @@ contract UniswapV3StakingVaultTest is Test {
     function test_quoteSwap_underwater_case4() public {
         uint256 tokenId = _stake(1_000, 800, 500, true, 100);
         nfpm.setLiquidityForTesting(tokenId, 0);
-        nfpm.accrueFeesForTesting(tokenId, 500, 500); // both deficit
-
+        nfpm.accrueFeesForTesting(tokenId, 500, 500);
         SwapQuote memory q = vault.quoteSwap();
         assertEq(uint256(q.status), uint256(SwapStatus.Underwater));
     }
 
+    function test_quoteSwap_partial_reflectsPendingBps() public {
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(5_000);
+        // With L=0 + owed fees, principal = 0 regardless of bps; fees not pro-rated.
+        nfpm.setLiquidityForTesting(tokenId, 0);
+        nfpm.accrueFeesForTesting(tokenId, 600, 500); // q=600, b=500
+        // Targets at 5000 bps: tB=400, tQ=550. Case 1 (both surplus).
+        SwapQuote memory q = vault.quoteSwap();
+        assertEq(uint256(q.status), uint256(SwapStatus.NoSwapNeeded));
+        assertEq(q.effectiveBps, 5_000);
+    }
+
     // ============ quoteSwap — live (unsnapshotted) fees ============
 
-    /// @notice Without the live-fee component, an unattended NFT (no decreaseLiquidity /
-    ///         collect calls between stake() and settlement) would always classify as
-    ///         Underwater while fees actually exist in the pool. This test asserts the
-    ///         live-fee path flips classification once feeGrowthInside delta is added.
     function test_quoteSwap_liveFees_flipsCaseFromUnderwaterToExecutable() public {
-        // L = 1 keeps principal contribution effectively zero relative to the staked
-        // amounts (B = 10_000, Q = 10_000), so the fee component is the only swing
-        // variable in the case classification.
         uint256 tokenId = _stake(10_000, 10_000, 1, true, 100);
-
-        // Phase 1: no live fees → both b, q ≈ 0 → Case 4.
         SwapQuote memory q0 = vault.quoteSwap();
         assertEq(uint256(q0.status), uint256(SwapStatus.Underwater));
 
-        // Phase 2: pump live fees on the quote side only.
-        // Library does: fees = (inside - inside_last) * L / Q128. With L = 1, set
-        // inside_delta = 10_300 * Q128 → fees_quote = 10_300 (pushes q over Q+T = 10_100).
         uint256 Q128 = 1 << 128;
         pool.setTickData(TICK_LOWER, 0, 0);
         pool.setTickData(TICK_UPPER, 0, 0);
         nfpm.setFeeGrowthInsideLastForTesting(tokenId, 0, 0);
-        // isToken0Quote = true → token0 is quote; pump global0 only.
         pool.setFeeGrowthGlobal(10_300 * Q128, 0);
 
         SwapQuote memory q1 = vault.quoteSwap();
-        // q ≈ 10_300 > Q+T = 10_100 (surplus quote)
-        // b ≈ 0 < B = 10_000 (deficit base) → Case 3
         assertEq(uint256(q1.status), uint256(SwapStatus.Executable));
-        assertEq(q1.tokenIn, address(tokenB)); // base
-        assertEq(q1.tokenOut, address(tokenA)); // quote
-        // amountOut ≈ q - (Q+T) = 10_300 - 10_100 = 200 (± principal)
+        assertEq(q1.tokenIn, address(tokenB));
+        assertEq(q1.tokenOut, address(tokenA));
         assertApproxEqAbs(q1.amountOut, 200, 5);
-        // requiredMin ≈ B - b = 10_000 - 0 = 10_000 (± principal)
         assertApproxEqAbs(q1.minAmountIn, 10_000, 5);
     }
 
-    /// @notice Live fees can also lift the vault out of Case 4 onto Case 1 (no swap).
     function test_quoteSwap_liveFees_reachNoSwapNeeded() public {
         uint256 tokenId = _stake(10_000, 10_000, 1, true, 100);
         uint256 Q128 = 1 << 128;
         pool.setTickData(TICK_LOWER, 0, 0);
         pool.setTickData(TICK_UPPER, 0, 0);
         nfpm.setFeeGrowthInsideLastForTesting(tokenId, 0, 0);
-        // Push BOTH sides over their floors: quote >= 10_100 AND base >= 10_000.
         pool.setFeeGrowthGlobal(11_000 * Q128, 11_000 * Q128);
 
         SwapQuote memory q = vault.quoteSwap();
         assertEq(uint256(q.status), uint256(SwapStatus.NoSwapNeeded));
     }
 
-    // ============ flashClose — Cases 2, 3, 4 (callback bridges deficit) ============
+    // ============ Multicall ============
 
-    /// @notice flashClose on a Case 2 close: vault has surplus base + deficit quote.
-    ///         Helper "flash-loans" the missing quote in to satisfy expectedQuote.
-    function test_flashClose_case2_callbackBridgesQuoteDeficit() public {
-        uint256 tokenId = _stake(1_000, 800, 500, true, 100); // Q=1000, B=800, T=100
-        // Case 2: b=900>B, q=900<Q+T=1100. Vault pushes 900 base + 900 quote to callback.
-        _arrangeClose(tokenId, 900, 900);
-
-        MockFlashCloseCallback cb = _setupFlashCallback();
-        // Callback needs to return (B=800 base, Q+T=1100 quote). It already has 900
-        // base and 900 quote post-push. Pre-fund 200 quote so it can return 1100.
-        tokenA.mint(address(cb), 200);
-        cb.setMode(MockFlashCloseCallback.Mode.Exact);
-
-        uint256 baseBefore = tokenB.balanceOf(alice);
-        uint256 quoteBefore = tokenA.balanceOf(alice);
-
-        vm.prank(alice);
-        vault.flashClose(address(cb), "");
-
-        // baseReward = finalBase - stakedBase = 800 - 800 = 0
-        // quoteReward = finalQuote - stakedQuote = 1100 - 1000 = 100
-        assertEq(vault.baseReward(), 0);
-        assertEq(vault.quoteReward(), 100);
-        assertEq(uint256(vault.state()), uint256(UniswapV3StakingVault.State.Settled));
-        assertEq(tokenB.balanceOf(alice), baseBefore + 800);
-        assertEq(tokenA.balanceOf(alice), quoteBefore + 1_100);
-    }
-
-    /// @notice flashClose on a Case 3 close: vault has deficit base + surplus quote.
-    function test_flashClose_case3_callbackBridgesBaseDeficit() public {
-        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        // Case 3: b=700<B, q=1300>Q+T. Vault pushes 700 base + 1300 quote to callback.
-        _arrangeClose(tokenId, 1_300, 700);
-
-        MockFlashCloseCallback cb = _setupFlashCallback();
-        // Pre-fund 100 base so callback can return (800 base, 1100 quote).
-        tokenB.mint(address(cb), 100);
-        cb.setMode(MockFlashCloseCallback.Mode.Exact);
-
-        uint256 baseBefore = tokenB.balanceOf(alice);
-        uint256 quoteBefore = tokenA.balanceOf(alice);
-
-        vm.prank(alice);
-        vault.flashClose(address(cb), "");
-
-        assertEq(vault.baseReward(), 0);
-        assertEq(vault.quoteReward(), 100);
-        assertEq(tokenB.balanceOf(alice), baseBefore + 800);
-        assertEq(tokenA.balanceOf(alice), quoteBefore + 1_100);
-    }
-
-    /// @notice flashClose on a Case 4 close: deficit on BOTH sides. Helper must
-    ///         externally fund both — only path out for the owner.
-    function test_flashClose_case4_callbackBridgesBothDeficits() public {
-        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
-        // Case 4: b=500<B, q=500<Q+T. Vault pushes 500 base + 500 quote to callback.
-        _arrangeClose(tokenId, 500, 500);
-
-        MockFlashCloseCallback cb = _setupFlashCallback();
-        // Pre-fund: 300 base + 600 quote so callback can return (800, 1100).
-        tokenB.mint(address(cb), 300);
-        tokenA.mint(address(cb), 600);
-        cb.setMode(MockFlashCloseCallback.Mode.Exact);
-
-        uint256 baseBefore = tokenB.balanceOf(alice);
-        uint256 quoteBefore = tokenA.balanceOf(alice);
-
-        vm.prank(alice);
-        vault.flashClose(address(cb), "");
-
-        assertEq(vault.baseReward(), 0);
-        assertEq(vault.quoteReward(), 100);
-        assertEq(tokenB.balanceOf(alice), baseBefore + 800);
-        assertEq(tokenA.balanceOf(alice), quoteBefore + 1_100);
-    }
-
-    // ============ Multicall (OZ mixin) ============
-
-    /// @notice OZ Multicall composes inner state-changing calls via delegatecall;
-    ///         each inner call's state checks must still fire normally.
     function test_multicall_composes_setYieldTarget() public {
         _stake(1_000, 800, 500, true, 100);
-
         bytes[] memory calls = new bytes[](2);
         calls[0] = abi.encodeWithSelector(UniswapV3StakingVault.setYieldTarget.selector, 250);
         calls[1] = abi.encodeWithSelector(UniswapV3StakingVault.setYieldTarget.selector, 500);
-
         vm.prank(alice);
         vault.multicall(calls);
-
         assertEq(vault.yieldTarget(), 500);
     }
 
     function test_multicall_revertsIfInnerCallReverts() public {
         _stake(1_000, 800, 500, true, 100);
-
         bytes[] memory calls = new bytes[](1);
-        // setYieldTarget from non-owner inside a multicall — inner call's onlyOwner reverts.
         calls[0] = abi.encodeWithSelector(UniswapV3StakingVault.setYieldTarget.selector, 250);
-
         vm.prank(bob);
         vm.expectRevert(UniswapV3StakingVault.NotOwner.selector);
         vault.multicall(calls);
     }
 
-    // ============ ERC-777 / fee-on-transfer reentrancy on stake() and swap() ============
+    function test_multicall_setPartialThenUnstake_atomic() public {
+        // Pre-fill unstake buffer via a partial swap.
+        uint256 tokenId = _stake(1_000, 800, 500, true, 100);
+        vm.prank(alice);
+        vault.setPartialUnstakeBps(3_000);
+        _arrangeClose(tokenId, 400, 400);
+        vm.prank(executor);
+        vault.swap(address(0), 0, address(0), 0);
+        // Buffers populated, state Staked.
 
-    /// @dev Stake `mal`-as-quote into a fresh clone. Returns vault `v` ready for the
-    ///      reentrancy probe — `mal.armAttack()` will trigger reentry on the next
-    ///      transferFrom called against `mal`.
+        // Now atomic: setPartialUnstakeBps(2000) + unstake() in one tx.
+        bytes[] memory calls = new bytes[](2);
+        calls[0] = abi.encodeWithSelector(
+            UniswapV3StakingVault.setPartialUnstakeBps.selector, uint16(2_000)
+        );
+        calls[1] = abi.encodeWithSelector(UniswapV3StakingVault.unstake.selector);
+        vm.prank(alice);
+        vault.multicall(calls);
+
+        assertEq(vault.partialUnstakeBps(), 2_000);
+        assertEq(vault.unstakeBufferBase(), 0);
+        assertEq(vault.unstakeBufferQuote(), 0);
+    }
+
+    // ============ Reentrancy probes ============
+
     function _setupMaliciousVault()
         internal
         returns (UniswapV3StakingVault v, ReentrantToken mal, MockERC20 plainBase, uint256 tid)
@@ -914,17 +1314,16 @@ contract UniswapV3StakingVaultTest is Test {
         bool malIsToken0 = address(mal) < address(plainBase);
         address t0 = malIsToken0 ? address(mal) : address(plainBase);
         address t1 = malIsToken0 ? address(plainBase) : address(mal);
-        bool isQ0 = malIsToken0; // quote = mal
+        bool isQ0 = malIsToken0;
 
         MockUniPool poolNew = new MockUniPool(SQRT_PRICE_X96, 0);
         uniFactory.setPool(t0, t1, FEE, address(poolNew));
 
-        // Stake B=800 base + Q=1000 quote, T=100. desired == used.
         uint256 desired0 = isQ0 ? 1_000 : 800;
         uint256 desired1 = isQ0 ? 800 : 1_000;
         nfpm.setNextMintResult(500, desired0, desired1);
 
-        mal.mintForTest(alice, desired0 + desired1); // generous
+        mal.mintForTest(alice, desired0 + desired1);
         plainBase.mint(alice, desired0 + desired1);
 
         vm.startPrank(alice);
@@ -945,8 +1344,7 @@ contract UniswapV3StakingVaultTest is Test {
         tid = v.stake(sp, isQ0, 100);
         vm.stopPrank();
 
-        // Arrange Case 2 close: vault holds (b=900, q=900) after _closePosition.
-        nfpm.setLiquidityForTesting(tid, 1);
+        nfpm.setLiquidityForTesting(tid, L_BIG);
         nfpm.setNextDecreaseResult(tid, 900, 900);
         mal.mintForTest(address(nfpm), 900);
         plainBase.mint(address(nfpm), 900);
@@ -955,8 +1353,6 @@ contract UniswapV3StakingVaultTest is Test {
     }
 
     function test_stake_reentrancy_isBlocked() public {
-        // Build a fresh vault but DON'T stake yet; arm the malicious token first
-        // so it reenters during the very first stake() call.
         UniswapV3StakingVault v = UniswapV3StakingVault(Clones.clone(address(implementation)));
         v.initialize(alice);
 
@@ -975,7 +1371,6 @@ contract UniswapV3StakingVaultTest is Test {
         mal.mintForTest(alice, 2_000);
         plainBase.mint(alice, 2_000);
 
-        // Arm: malicious quote token reenters swap() during its transferFrom.
         mal.setTarget(address(v));
         mal.armAttack();
 
@@ -994,9 +1389,6 @@ contract UniswapV3StakingVaultTest is Test {
             amount1Min: 0,
             deadline: DEADLINE
         });
-        // The malicious token's reentry into v.swap() inside its transferFrom must
-        // be caught by `nonReentrant` (outer stake set _status = ENTERED), bubbling
-        // up to revert the outer stake.
         vm.expectRevert();
         v.stake(sp, isQ0, 100);
         vm.stopPrank();
@@ -1005,15 +1397,10 @@ contract UniswapV3StakingVaultTest is Test {
     function test_swap_reentrancy_isBlocked() public {
         (UniswapV3StakingVault v, ReentrantToken mal, MockERC20 plainBase,) =
             _setupMaliciousVault();
-
         mal.armAttack();
-
-        // Executor pays 250 quote (mal) → vault calls mal.transferFrom which
-        // reenters v.swap() — must revert via nonReentrant.
         mal.mintForTest(executor, 250);
         vm.prank(executor);
         IERC20(address(mal)).approve(address(v), 250);
-
         vm.prank(executor);
         vm.expectRevert();
         v.swap(address(mal), 250, address(plainBase), 0);
@@ -1022,7 +1409,7 @@ contract UniswapV3StakingVaultTest is Test {
 
 /// @notice Minimal ERC-20 with a `transferFrom` hook that re-enters a target
 ///         vault's `swap()` once. Models the ERC-777 / fee-on-transfer
-///         reentrancy threat called out in spec §19.
+///         reentrancy threat.
 contract ReentrantToken is ERC20 {
     address public target;
     bool public attack;
@@ -1048,11 +1435,9 @@ contract ReentrantToken is ERC20 {
     {
         bool ok = super.transferFrom(from, to, amount);
         if (attack && target != address(0)) {
-            attack = false; // single-shot; avoid recursion
-            // Try to reenter swap() — vault's nonReentrant guard MUST revert.
+            attack = false;
             UniswapV3StakingVault(target).swap(address(0), 0, address(0), 0);
         }
         return ok;
     }
 }
-

--- a/apps/midcurve-contracts/test/staking-vault/mocks/MockStakingNFPM.sol
+++ b/apps/midcurve-contracts/test/staking-vault/mocks/MockStakingNFPM.sol
@@ -38,6 +38,11 @@ contract MockStakingNFPM {
     mapping(uint256 => uint256) public nextDecrease0;
     mapping(uint256 => uint256) public nextDecrease1;
 
+    // Controllable increaseLiquidity() result, keyed per tokenId.
+    mapping(uint256 => uint128) public nextIncreaseLiquidity;
+    mapping(uint256 => uint256) public nextIncrease0;
+    mapping(uint256 => uint256) public nextIncrease1;
+
     constructor(address factory_) {
         factory = factory_;
     }
@@ -55,6 +60,17 @@ contract MockStakingNFPM {
     function setNextDecreaseResult(uint256 tokenId_, uint256 amount0_, uint256 amount1_) external {
         nextDecrease0[tokenId_] = amount0_;
         nextDecrease1[tokenId_] = amount1_;
+    }
+
+    function setNextIncreaseResult(
+        uint256 tokenId_,
+        uint128 liquidity_,
+        uint256 amount0Used_,
+        uint256 amount1Used_
+    ) external {
+        nextIncreaseLiquidity[tokenId_] = liquidity_;
+        nextIncrease0[tokenId_] = amount0Used_;
+        nextIncrease1[tokenId_] = amount1Used_;
     }
 
     function setLiquidityForTesting(uint256 tokenId_, uint128 liquidity_) external {
@@ -144,12 +160,29 @@ contract MockStakingNFPM {
         _owners[tokenId_] = params.recipient;
     }
 
-    function increaseLiquidity(INonfungiblePositionManagerMinimal.IncreaseLiquidityParams calldata)
+    function increaseLiquidity(INonfungiblePositionManagerMinimal.IncreaseLiquidityParams calldata params)
         external
         payable
-        returns (uint128, uint256, uint256)
+        returns (uint128 liquidity_, uint256 amount0, uint256 amount1)
     {
-        revert("not implemented");
+        Position storage p = _positions[params.tokenId];
+        liquidity_ = nextIncreaseLiquidity[params.tokenId];
+        amount0 = nextIncrease0[params.tokenId];
+        amount1 = nextIncrease1[params.tokenId];
+
+        if (amount0 > 0) {
+            IERC20(p.token0).transferFrom(msg.sender, address(this), amount0);
+        }
+        if (amount1 > 0) {
+            IERC20(p.token1).transferFrom(msg.sender, address(this), amount1);
+        }
+
+        p.liquidity += liquidity_;
+
+        // Reset so a follow-up increase without setup yields zero (no accidental reuse).
+        nextIncreaseLiquidity[params.tokenId] = 0;
+        nextIncrease0[params.tokenId] = 0;
+        nextIncrease1[params.tokenId] = 0;
     }
 
     function decreaseLiquidity(INonfungiblePositionManagerMinimal.DecreaseLiquidityParams calldata params)


### PR DESCRIPTION
## Summary
Extends the one-shot `UniswapV3StakingVault` into the multi-cycle design from SPEC-0003a (issue #61). Three feature axes plus a buffer-based settlement model:
- **Top-up:** `stakeTopUp(TopUpParams)` callable in `Staked`; ceil-divided `yieldTarget` rescaling preserves the implicit yield rate.
- **Partial unstake:** new `pendingBps` slot with `setPartialUnstakeBps` / `increasePartialUnstakeBps`; defaults to full close when zero.
- **Fractional flashClose:** `flashClose(uint16 bps, ...)` accepts 1..10000 and returns to `Staked` for `bps < 10000`. `pendingBps` is intentionally untouched.
- **Settlement buffers:** `unstakeBuffer{Base,Quote}` + `rewardBuffer{Base,Quote}` replace the one-shot `baseReward` / `quoteReward` / `principalUnstaked` / `rewardsClaimed` slots. `unstake()` / `claimRewards()` drain on demand and are callable in `Staked` AND `Settled`.

`swap()` snapshots pre/post balances to isolate the freed delta from prior buffers (per spec §12 NOTE — see issue clarification), classifies Cases 1–4 against partial targets, and accumulates buffers proportionally. `flashClose()` pushes only the freed delta to the callback and auto-drains every buffer (including pre-existing partial-swap balances) to the owner before returning. Both paths are guarded by OZ `nonReentrant`; `flashClose` is additionally locked by the `FlashCloseInProgress` state.

## Test plan
- [x] `forge test --match-path 'test/staking-vault/**'` — 92 / 92 pass (was 56)
- [x] `forge test` (full repo) — 192 / 192 pass
- [x] New coverage:
  - top-up happy path / refund / T-scaling (ceil rounding, `Q == 0` no-op) / state guards
  - `setPartialUnstakeBps` + `increasePartialUnstakeBps` boundaries (0, 10000, 10001 reverts, overflow on +)
  - partial swap Cases 1–4 at `pendingBps = 5000`; explicit-full via `pendingBps = 10000`
  - sequential partials (30% + 30%) — buffer accumulation + `(B, Q, T)` reduction
  - `unstake` / `claimRewards` callable in `Staked`; multi-cycle drain across two settlements
  - `flashClose(bps < 10000)` returns to `Staked`, `pendingBps` untouched, auto-drains pre-existing buffers
  - `flashClose(0)` / `flashClose(10001)` revert with `InvalidBps`
- [x] Existing tests preserved: state machine, slippage, overpayment, reentrancy, multicall composition, live-fees `quoteSwap` paths.

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)