### PR TITLE
feat: add UniswapV3 staking-vault ledger service (SPEC-0003b PR1)

### DIFF
--- a/apps/midcurve-contracts/deployments/arbitrum.json
+++ b/apps/midcurve-contracts/deployments/arbitrum.json
@@ -1,13 +1,15 @@
 {
   "chainId": 42161,
   "network": "arbitrum",
-  "deployedAt": "2026-03-12T00:00:00Z",
+  "deployedAt": "2026-05-04T00:00:00Z",
   "contracts": {
     "UniswapV3PositionCloser": "0xA28ec2Bd1b24B6DB85550854Cc326857e2D30C2D",
     "MidcurveSwapRouter": "0x5aE412a2105345f770FC6862Be7e8Fb90245C50a",
     "UniswapV3Vault": "0xD85A1ECB2F8515D8f542B1efcb10409E47be643c",
     "AllowlistedUniswapV3Vault": "0xFf266AA88BD2B1496eb354116b70D845d8a896c6",
     "UniswapV3VaultFactory": "0xB9605C30d5e68D535d45E663cfA06A429AA83A3b",
-    "UniswapV3VaultPositionCloser": "0x13d13B15BbE9b06C0279a7aB5f0a898EA3f25A40"
+    "UniswapV3VaultPositionCloser": "0x13d13B15BbE9b06C0279a7aB5f0a898EA3f25A40",
+    "UniswapV3StakingVault": "0x7f8b35eafF873Dabb70aFe027949e79884b2dB88",
+    "UniswapV3StakingVaultFactory": "0x2Cc277Cd2CF5d78F18f0627a1DA2aA48b7C57EB1"
   }
 }

--- a/apps/midcurve-contracts/package.json
+++ b/apps/midcurve-contracts/package.json
@@ -21,6 +21,7 @@
     "deploy:diamond": "tsx scripts/deploy-diamond.ts",
     "deploy:vault-diamond": "tsx scripts/deploy-vault-diamond.ts",
     "deploy:swap-router": "tsx scripts/deploy-swap-router.ts",
+    "deploy:staking-vault": "tsx scripts/deploy-staking-vault.ts",
     "db:reset-local": "tsx scripts/reset-local-chain-db.ts",
     "db:upsert-contract": "tsx scripts/upsert-shared-contract.ts"
   },

--- a/apps/midcurve-contracts/scripts/deploy-staking-vault.ts
+++ b/apps/midcurve-contracts/scripts/deploy-staking-vault.ts
@@ -1,0 +1,191 @@
+/**
+ * Deploy UniswapV3StakingVault + Factory
+ *
+ * Wraps the DeployStakingVault.s.sol Forge script and prints the
+ * pnpm db:upsert-contract invocation needed to register the factory in
+ * the shared_contracts table.
+ *
+ * Usage:
+ *   CHAIN=arbitrum pnpm deploy:staking-vault
+ *
+ * Add --broadcast to actually deploy (default is dry-run):
+ *   CHAIN=arbitrum pnpm deploy:staking-vault -- --broadcast --verify
+ *
+ * Environment variables:
+ *   CHAIN  - RPC endpoint name from foundry.toml: arbitrum, base, mainnet (required)
+ */
+
+import { spawn } from 'child_process';
+import { readFileSync, existsSync } from 'fs';
+import { resolve } from 'path';
+
+const CHAIN_IDS: Record<string, number> = {
+  mainnet: 1,
+  arbitrum: 42161,
+  base: 8453,
+};
+
+const POSITION_MANAGER: Record<string, `0x${string}`> = {
+  mainnet: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
+  arbitrum: '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
+  base: '0x03a520b32C04BF3bEEf7BEb72E919cf822Ed34f1',
+};
+
+function loadEnv(): void {
+  const envPath = resolve(process.cwd(), '.env');
+  if (!existsSync(envPath)) {
+    return;
+  }
+
+  const content = readFileSync(envPath, 'utf-8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) {
+      continue;
+    }
+    const key = trimmed.substring(0, eqIndex).trim();
+    let value = trimmed.substring(eqIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function runForge(args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let output = '';
+
+    const proc = spawn('forge', args, {
+      cwd: process.cwd(),
+      env: process.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    proc.stdin?.end();
+
+    proc.stdout?.on('data', (data) => {
+      const text = data.toString();
+      output += text;
+      process.stdout.write(text);
+    });
+
+    proc.stderr?.on('data', (data) => {
+      const text = data.toString();
+      output += text;
+      process.stderr.write(text);
+    });
+
+    proc.on('error', (err) => {
+      reject(new Error(`Failed to start forge: ${err.message}`));
+    });
+
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve(output);
+      } else {
+        reject(new Error(`forge exited with code ${code}`));
+      }
+    });
+  });
+}
+
+async function main(): Promise<void> {
+  loadEnv();
+
+  const chain = process.env.CHAIN;
+
+  if (!chain) {
+    console.error('Missing required environment variables.');
+    console.error('');
+    console.error('Usage:');
+    console.error('  CHAIN=arbitrum pnpm deploy:staking-vault');
+    console.error('');
+    console.error('Add extra forge flags after --:');
+    console.error('  CHAIN=arbitrum pnpm deploy:staking-vault -- --broadcast --verify');
+    process.exit(1);
+  }
+
+  const chainId = CHAIN_IDS[chain];
+  if (!chainId) {
+    console.error(`Unknown chain "${chain}". Supported: ${Object.keys(CHAIN_IDS).join(', ')}`);
+    process.exit(1);
+  }
+
+  const positionManager = POSITION_MANAGER[chain];
+  if (!positionManager) {
+    console.error(`No NonfungiblePositionManager address configured for chain "${chain}".`);
+    process.exit(1);
+  }
+
+  // Extra flags passed after -- (e.g., --broadcast --verify)
+  const extraArgs = process.argv.slice(2).filter((arg) => arg !== '--');
+
+  console.log('=== Deploy UniswapV3StakingVaultFactory ===');
+  console.log('  Chain:           ', chain, `(${chainId})`);
+  console.log('  Position Manager:', positionManager);
+  console.log('  Extra flags:     ', extraArgs.length > 0 ? extraArgs.join(' ') : '(dry-run)');
+  console.log('');
+
+  const forgeArgs = [
+    'script',
+    'script/DeployStakingVault.s.sol',
+    '--sig',
+    'run(address)',
+    positionManager,
+    '--rpc-url',
+    chain,
+    '-vvvv',
+    ...extraArgs,
+  ];
+
+  const output = await runForge(forgeArgs);
+
+  const implMatch = output.match(/UniswapV3StakingVault \(impl\):\s*(0x[0-9a-fA-F]{40})/);
+  const factoryMatch = output.match(/UniswapV3StakingVaultFactory:\s*(0x[0-9a-fA-F]{40})/);
+
+  console.log('');
+  console.log('='.repeat(60));
+
+  if (implMatch && factoryMatch) {
+    const implAddress = implMatch[1];
+    const factoryAddress = factoryMatch[1];
+
+    console.log('');
+    console.log('Deployed addresses:');
+    console.log(`  UniswapV3StakingVault (impl): ${implAddress}`);
+    console.log(`  UniswapV3StakingVaultFactory: ${factoryAddress}`);
+    console.log('');
+    console.log(`Add both addresses to apps/midcurve-contracts/deployments/${chain}.json`);
+    console.log('under the "contracts" key. Bump "deployedAt" to the current UTC timestamp.');
+    console.log('');
+    console.log('To register the factory in the shared_contracts DB, run:');
+    console.log('');
+    console.log(
+      `  CONTRACT_ADDRESS=${factoryAddress} CHAIN_ID=${chainId} CONTRACT_NAME=UniswapV3StakingVaultFactory pnpm db:upsert-contract`,
+    );
+    console.log('');
+    console.log('Or export for later use:');
+    console.log('');
+    console.log(`  export CONTRACT_ADDRESS=${factoryAddress}`);
+    console.log(`  export CHAIN_ID=${chainId}`);
+  } else {
+    console.log('');
+    console.log('Could not extract deployed addresses from forge output.');
+    console.log('Check the forge output above for the deployed addresses.');
+  }
+}
+
+main().catch((error) => {
+  console.error('Deployment failed:', error.message);
+  process.exit(1);
+});

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -1,0 +1,352 @@
+# Midcurve Finance - UI Reference (Positions)
+
+This document is a structural reference for the position-related surface of the [`apps/midcurve-ui/`](../apps/midcurve-ui/) Vite SPA. It covers the positions list, position detail page, and the "Add Position" entry points — what is shown, which actions are available, and which features are common to all position types versus specific to one.
+
+For the data model behind the UI, see [positions.md](./positions.md). For the overall app architecture, routing, and tech stack, see [architecture.md](./architecture.md) and [`apps/midcurve-ui/CLAUDE.md`](../apps/midcurve-ui/CLAUDE.md).
+
+The two position types currently rendered by the UI are:
+
+- **UniswapV3 NFT position** — `protocol: 'uniswapv3'`, route segment `uniswapv3/{chain}/{nftId}`
+- **UniswapV3 Vault Share position** — `protocol: 'uniswapv3-vault'`, route segment `uniswapv3-vault/{chain}/{vaultAddress}/{ownerAddress}`
+
+---
+
+## a) Positions List
+
+The list lives on the dashboard at [`/dashboard`](../apps/midcurve-ui/src/pages/DashboardPage.tsx) under the **Positions** tab. The page header shows the app title, a notification bell, and a user dropdown; the section header carries the **Add Position** dropdown (described in section [c](#c-add-position-menu)). Below it sits a tab switcher for **Positions** / **Accounting**; the latter is a separate dashboard summary, not position-specific.
+
+The list itself is implemented in [`PositionList`](../apps/midcurve-ui/src/components/positions/position-list.tsx) and renders one row per position via protocol-specific card components.
+
+### Filter and sort controls
+
+All filter/sort state lives in URL search params, so the view is shareable and back/forward-navigable.
+
+| Control | Param | Values | Default |
+|---|---|---|---|
+| Status filter | `status` | `all` · `active` · `archived` | `active` |
+| Protocol filter | `protocol` | `all` · `uniswapv3` · `uniswapv3-vault` | `all` |
+| Sort by | `sortBy` | `positionOpenedAt` · `totalApr` · `currentValue` | `positionOpenedAt` |
+| Sort direction | `sortDirection` | `asc` · `desc` (icon toggle) | `desc` |
+| Pagination offset | `offset` | integer, page size **20** | `0` |
+
+There is no free-text search, no fee-tier or token filter, and no per-column sorting — sort options are limited to the three above.
+
+A **refresh** icon button next to the sort controls is shown only when `status=active`. It just refetches the current page; for finding *new* positions on chain, use the **Scan Wallet** option in the Add Position dropdown (section [c](#c-add-position-menu)).
+
+### Per-card layout
+
+Every card has a uniform three-region layout, with a per-protocol action row beneath it.
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│ [icons] PAIR + status badges  │   metrics block   │  view  refresh  ⋮   │
+│         protocol-line badges  │                   │                     │
+├──────────────────────────────────────────────────────────────────────────┤
+│ protocol-specific action buttons row (Increase / Withdraw / Collect …)  │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+**Left — header** ([`PositionCardHeader`](../apps/midcurve-ui/src/components/positions/position-card-header.tsx)):
+- Token logo pair (base + quote, overlapping circles)
+- Pair name + position-opened timestamp
+- Status-line badges:
+  - `Burned` (red) — UniswapV3 NFT only, when the NFT has been burned on-chain
+  - Range status: `In Range` (green) · `Out of Range` (red) · `Closed` (grey)
+- Protocol-line badges: chain badge, identifier (`#nftId` or truncated vault address), owner badge / share-owner badge
+
+**Middle — metrics** ([`PositionCardMetrics`](../apps/midcurve-ui/src/components/positions/position-card-metrics.tsx), protocol-agnostic):
+- **Current Value** in quote token
+- **PnL Curve** — small SVG sparkline of position value vs base price (mini PnL curve, type-specific component)
+- **Total PnL** in quote token, with up/down arrow and red/green tinting (`realizedPnl + unrealizedPnl`)
+- **Unclaimed Fees** in quote token (amber when > 0)
+- **est. APR** — `totalApr` from the backend; renders `–` with a clock icon when below the noise threshold (~5 minutes of history)
+
+**Right — common buttons:**
+- **View Details** (search icon) — navigates to the protocol-specific detail page; stores the current dashboard URL so the detail page's "back" navigates correctly
+- **Refresh** (rotate icon) — POSTs to the position's `/refresh` endpoint to re-read on-chain state; spins while pending. The card also auto-refreshes on-chain every 60s, polls the DB every 3s, and patches live pool price every 5s in the background.
+- **Three-dot menu** ([`PositionActionsMenu`](../apps/midcurve-ui/src/components/positions/position-actions-menu.tsx)) with three entries:
+  - **Reload History** — opens a confirmation modal; re-imports all ledger events from chain/subgraph and rebuilds cumulatives
+  - **Switch Quote Token** — opens a confirmation modal; flips `isToken0Quote` and recomputes every quote-denominated field
+  - **Delete Position** (destructive, red) — opens a confirmation modal; removes the tracking row (and ledger/journal cascades)
+
+**Bottom — protocol-specific action row.** See [Action button rows](#action-button-rows) below.
+
+### Action button rows
+
+The row beneath each card mixes position-management buttons with automation buttons. Visibility depends on (1) connected wallet vs. on-chain owner, (2) on-chain liquidity / shares / fees state.
+
+#### UniswapV3 NFT — [`UniswapV3Actions`](../apps/midcurve-ui/src/components/positions/protocol/uniswapv3/uniswapv3-actions.tsx)
+
+| Button | Visibility | Action |
+|---|---|---|
+| **Increase Deposit** / **Reopen Position** | Always (label flips when `liquidity == 0`) | Navigates to `/positions/increase/uniswapv3/{chain}/{nftId}` |
+| **Withdraw** | Only when `liquidity > 0` | Navigates to `/positions/withdraw/uniswapv3/{chain}/{nftId}` |
+| **Collect Fees** | When `liquidity > 0` OR has unclaimed fees; disabled (grey) when no fees | Opens `UniswapV3CollectFeesModal` |
+| **Burn NFT** | Only when `liquidity == 0` AND `tokensOwed{0,1} == 0` AND no unclaimed fees | Opens `UniswapV3BurnNftModal` |
+| **Archive Position** | When `liquidity == 0` AND no unclaimed fees | Toggles `isArchived` via `useArchivePosition` |
+| ◇ divider ◇ | | |
+| **Stop-Loss (SL)** | Always shown; disabled with reason when burned / no liquidity / chain unsupported | Opens close-order modal (LOWER trigger) |
+| **Current Price label** | Always | Live-updating flashing price between SL and TP |
+| **Take-Profit (TP)** | Same as SL | Opens close-order modal (UPPER trigger) |
+| ◇ divider ◇ | | |
+| **Tokenize** | Only when `liquidity > 0` | Opens `UniswapV3TokenizePositionModal` (NFT → vault conversion) |
+
+When the connected wallet is **not** the NFT owner *or* the position is archived, the entire row collapses to a single **Archive Position** / **Unarchive Position** button (so the user can hide it from their dashboard).
+
+#### UniswapV3 Vault — [`UniswapV3VaultActions`](../apps/midcurve-ui/src/components/positions/protocol/uniswapv3-vault/uniswapv3-vault-actions.tsx)
+
+| Button | Visibility | Action |
+|---|---|---|
+| **Increase Deposit** / **Reopen Position** | Always (label flips when `sharesBalance == 0`) | Navigates to `/positions/increase/uniswapv3-vault/{chain}/{vaultAddress}/{ownerAddress}` |
+| **Withdraw** | Only when `sharesBalance > 0` | Navigates to `/positions/withdraw/uniswapv3-vault/...` |
+| **Collect Fees** | When has shares OR has unclaimed fees | Opens `UniswapV3VaultCollectFeesModal` |
+| **Archive Position** | When no shares AND no unclaimed fees | Toggles `isArchived` |
+| ◇ divider ◇ | | |
+| **Stop-Loss (SL)** | Always shown; disabled when no shares | Opens vault close-order modal |
+| **Current Price label** | Always | |
+| **Take-Profit (TP)** | Same as SL | Opens vault close-order modal |
+
+There is **no Burn NFT** (vaults are share-based — empty share balances are not destroyed) and **no Tokenize** (it is already tokenized).
+
+The connected wallet must equal the position's `ownerAddress` (the share-holder) to see the full row; otherwise it collapses to the same single **Archive / Unarchive** button.
+
+### Empty state
+
+When the list is empty, [`EmptyStateActions`](../apps/midcurve-ui/src/components/positions/empty-state-actions.tsx) shows a 3-card grid:
+
+1. **Create Position** → opens the wizard at [`/positions/create`](../apps/midcurve-ui/src/pages/CreatePositionPage.tsx)
+2. **Import by NFT ID** → inline form (chain dropdown + NFT ID input) using `useImportPositionByNftId`
+3. **Scan for Positions** → opens [`ScanPositionsModal`](../apps/midcurve-ui/src/components/positions/scan-positions-modal.tsx)
+
+The empty state intentionally omits **Import Tokenized Position by Address** — that option is only available from the Add Position dropdown when the list is non-empty.
+
+### Pagination
+
+Below the grid: a **Load More (N remaining)** button when `hasMore`, plus a status line `Showing X of Y positions`. The page size is fixed at 20.
+
+---
+
+## b) Position Detail Page
+
+Routes:
+
+- NFT: `/positions/uniswapv3/:chain/:nftId` → [`PositionDetailPage`](../apps/midcurve-ui/src/pages/PositionDetailPage.tsx) → [`UniswapV3PositionDetail`](../apps/midcurve-ui/src/components/positions/protocol/uniswapv3/uniswapv3-position-detail.tsx)
+- Vault: `/positions/uniswapv3-vault/:chain/:vaultAddress/:ownerAddress` → [`VaultPositionDetailPage`](../apps/midcurve-ui/src/pages/VaultPositionDetailPage.tsx) → [`UniswapV3VaultPositionDetail`](../apps/midcurve-ui/src/components/positions/protocol/uniswapv3-vault/uniswapv3-vault-position-detail.tsx)
+
+Both pages share the same skeleton: a [`PositionDetailHeader`](../apps/midcurve-ui/src/components/positions/position-detail-header.tsx) on top and a tab strip with **seven** tabs (defined in [`PositionDetailTabs`](../apps/midcurve-ui/src/components/positions/position-detail-tabs.tsx) for NFT and inlined in vault detail). The active tab is in the URL (`?tab=...`); `overview` is the default.
+
+### Detail header (common)
+
+- Token icon pair + pair name
+- Status badge: `Active` / `Archived`
+- In-range badge
+- Chain badge (chain name + colour)
+- Fee-tier display (`%`), identifier (`#nftId` or truncated vault address) with explorer link
+- "Last updated" timestamp
+- Refresh button (manual on-chain sync via the `/refresh` endpoint)
+- **Vault adds:** a `Tokenized` badge and a `XX.XX% Shares` badge (`sharesBalance / totalSupply`)
+
+### Tabs (common to both types)
+
+| # | Tab | Icon | Contents | Actions enabled |
+|---|---|---|---|---|
+| 1 | **Overview** | `BarChart3` | Range status line. Big metric cards: Current Value · Total PnL · Unclaimed Fees · Break-Even Price. **Position States** section: three cards (Current / Lower Range / Upper Range), each with token amounts, pool price, position value, PnL excluding fees, and a mini PnL curve at that tick. | **Simulation** toggle button — replaces the three states with a [`PortfolioSimulator`](../apps/midcurve-ui/src/components/positions/portfolio-simulator.tsx) where the user can drag a price slider to see hypothetical states |
+| 2 | **PnL Analysis** | `Clock` | [`PnLBreakdown`](../apps/midcurve-ui/src/components/positions/pnl-breakdown.tsx) (realized vs. unrealized) + [`LedgerEventTable`](../apps/midcurve-ui/src/components/positions/ledger/ledger-event-table.tsx) (full chronological event list). | Read-only |
+| 3 | **APR Analysis** | `TrendingUp` | [`AprBreakdown`](../apps/midcurve-ui/src/components/positions/apr-breakdown.tsx) (time-weighted summary) + [`AprPeriodsTable`](../apps/midcurve-ui/src/components/positions/apr-periods-table.tsx) (per-`PositionAprPeriod` row). | Read-only |
+| 4 | **Conversion** | `Repeat` | [`ConversionSummary`](../apps/midcurve-ui/src/components/positions/protocol/uniswapv3/conversion-summary.tsx) (net deposits/withdrawals/holdings, average rebalancing direction, fee premium) + [`RebalancingHistoryTable`](../apps/midcurve-ui/src/components/positions/protocol/uniswapv3/rebalancing-history-table.tsx). | Read-only |
+| 5 | **Automation** | `Shield` | [`PositionCloseOrdersPanel`](../apps/midcurve-ui/src/components/positions/automation/PositionCloseOrdersPanel.tsx) / [`VaultCloseOrdersPanel`](../apps/midcurve-ui/src/components/positions/automation/VaultCloseOrdersPanel.tsx) listing existing close orders, plus the [`AutomationLogList`](../apps/midcurve-ui/src/components/positions/automation/AutomationLogList.tsx). | **Create / Edit / Cancel** close orders. Edit a close order via [`CloseOrderModal`](../apps/midcurve-ui/src/components/positions/automation/CloseOrderModal.tsx) (4-step wizard: Configure → Review → Processing → Success). Cancel via [`CancelOrderConfirmModal`](../apps/midcurve-ui/src/components/positions/automation/CancelOrderConfirmModal.tsx). |
+| 6 | **Accounting** | `BookOpen` | [`PositionAccountingTab`](../apps/midcurve-ui/src/components/positions/accounting/position-accounting-tab.tsx) (shared between protocols): balance sheet section, P&L section, journal entries audit trail. | Read-only |
+| 7 | **Technical Details** | `Settings` | Raw position config/state, on-chain references, copy-to-clipboard fields for addresses, NFPM/vault links to block explorer. | Read-only |
+
+### Tab actions versus card actions
+
+The card-row actions (Increase / Withdraw / Collect / Burn / Tokenize / Archive) are **not** repeated on the detail page header — those are reached only from the list. The detail page's only state-mutating actions are the **header Refresh** button and the **close-order management** inside the Automation tab. To increase, withdraw, etc., the user goes back to the list (or navigates to the dedicated wizard pages directly).
+
+---
+
+## c) Add Position Menu
+
+The **Add Position** button in the dashboard header opens a dropdown ([`CreatePositionDropdown`](../apps/midcurve-ui/src/components/positions/create-position-dropdown.tsx)) with **four** options. The first two and the fourth are also available from the empty state (option 3 is intentionally not in the empty state).
+
+### Option 1 — Create New Position (wizard)
+
+Navigates to [`/positions/create`](../apps/midcurve-ui/src/pages/CreatePositionPage.tsx) → [`CreatePositionWizard`](../apps/midcurve-ui/src/components/positions/wizard/create-position/uniswapv3/CreatePositionWizard.tsx). Steps:
+
+1. **Pool Selection** — search a token-pair, see candidate pools sorted by APR/TVL/volume
+2. **Position Config** — quote-token assignment, fee tier review
+3. **Range** — interactive price-range picker
+4. **Swap** — optional pre-deposit token swap to balance amounts
+5. **Risk Triggers** — optional initial close-order configuration
+6. **Summary** — review all settings
+7. **Transaction** — approval(s) → mint NFT → register close order(s)
+8. **Autowallet** — optional handoff so closes execute without user signing
+
+This is **UniswapV3 NFT only** today — there is no parallel "Create Vault Position" wizard (vaults are deployed by an operator separately, then users *join* an existing vault via Option 3).
+
+### Option 2 — Import NFT by ID
+
+Inline form inside the dropdown (chain dropdown + NFT ID text input). Uses [`useImportPositionByNftId`](../apps/midcurve-ui/src/hooks/positions/uniswapv3/useImportPositionByNftId.ts) → `POST /api/v1/positions/uniswapv3/import`. Imports the on-chain NFT into the user's tracked set; the user does **not** need to own the NFT to track it (read-only watching is allowed).
+
+### Option 3 — Import Tokenized Position by Address
+
+Inline form inside the dropdown (chain dropdown + vault contract address input). Uses [`useImportVaultPosition`](../apps/midcurve-ui/src/hooks/positions/uniswapv3/vault/useImportVaultPosition.ts). The connected wallet is automatically used as the share-holder address — so the user must have a wallet connected and that wallet's share balance in the named vault is what gets tracked.
+
+This is the only path to add a **vault share** position to the dashboard.
+
+### Option 4 — Scan Wallet (modal)
+
+Opens [`ScanPositionsModal`](../apps/midcurve-ui/src/components/positions/scan-positions-modal.tsx). Lets the user pick which production chains to scan (checkboxes, "select all" shortcut), then `POST /api/v1/positions/discover` for the connected wallet's address. Returns a result summary; new positions show up on the next list refetch. Currently scans **UniswapV3 NFT** positions only — vault scanning is separate (`POST /api/v1/positions/uniswapv3-vault/discover`) and not surfaced from this modal.
+
+---
+
+## Common UI features (apply to every position type)
+
+- **Routing pattern**: `/positions/{protocol}/{...identity}` for detail; `/positions/{action}/{protocol}/{...identity}` for actions. URLs carry chain *slugs* (e.g. `arbitrum`), not numeric chain IDs.
+- **Filters and sort** in URL search params (shareable, back-button-friendly).
+- **Card layout**: header / metrics / right-side common actions / protocol-specific action row.
+- **Common metrics block** (`PositionCardMetrics`): Current Value, PnL Curve sparkline slot, Total PnL, Unclaimed Fees, est. APR.
+- **Right-side icon buttons**: View Details, Refresh, Three-dot menu (Reload History · Switch Quote Token · Delete Position).
+- **Auto-refresh stack**: 60s on-chain refresh + 3s DB polling + 5s live pool-price patch — applies to both card and detail page.
+- **Quote/base swap**: every quote-denominated metric flips when the user switches quote token; the underlying field is `isToken0Quote`.
+- **Archive lifecycle**: archive when empty, unarchive any time; archived positions only show the Archive button.
+- **Detail page skeleton**: 7-tab strip (Overview · PnL Analysis · APR Analysis · Conversion · Automation · Accounting · Technical Details), URL-driven active tab, shared header with Refresh.
+- **Accounting tab is fully shared** (`PositionAccountingTab`) — protocol-agnostic.
+- **Close orders UI**: SL/TP buttons in the card row, full close-order panel + 4-step wizard modal in the Automation tab, automation log feed.
+- **Connected-wallet gating**: the action row collapses to "Archive only" when the connected wallet does not match the on-chain owner.
+
+## Type-specific UI features
+
+| Feature | UniswapV3 NFT | UniswapV3 Vault |
+|---|---|---|
+| Add-via-wizard | ✅ Full create wizard | ❌ (vaults are joined via Option 3) |
+| Add-via-NFT-ID | ✅ | ❌ |
+| Add-via-address | ❌ | ✅ (vault contract address + connected wallet as share owner) |
+| Add-via-scan | ✅ (`/positions/discover`) | ❌ in this UI (separate endpoint exists) |
+| Identifier on card | `#nftId` | Truncated vault address |
+| Owner badge | NFT owner address | Share-owner address |
+| `Burned` badge | ✅ when NFT burned | n/a |
+| `Tokenized` badge | ❌ | ✅ |
+| `XX.XX% Shares` badge | n/a | ✅ in detail header |
+| **Burn NFT** action | ✅ when fully empty | n/a |
+| **Tokenize** action | ✅ when has liquidity | n/a (already tokenized) |
+| **Withdraw** | Liquidity → tokens | Shares → underlying liquidity |
+| Liquidity check | `state.liquidity > 0` | `state.sharesBalance > 0` |
+| Close-order contract | `UniswapV3PositionCloser` Diamond | `UniswapV3VaultPositionCloser` Diamond |
+| SL/TP button components | `StopLossButton` / `TakeProfitButton` | `VaultStopLossButton` / `VaultTakeProfitButton` |
+| Detail-page wrapper | `UniswapV3PositionDetail` | `UniswapV3VaultPositionDetail` |
+| Per-tab components | `uniswapv3-{overview,history,apr,conversion,automation,technical}-tab.tsx` | `uniswapv3-vault-{overview,history,apr,conversion,automation,technical}-tab.tsx` |
+
+The two implementations are deliberately parallel — same tab order, same metric headings, same detail-page skeleton — diverging only where the underlying primitive differs (NFT vs. ERC-20 share, on-chain owner vs. share-owner).
+
+---
+
+## Implementation checklist for a new position type
+
+When introducing a new `protocol` discriminator (e.g. `aerodrome`, `orca-clmm`, `hyperliquid-perp`), the UI work below is required to bring it to feature parity with the existing two. File paths use `{proto}` as a placeholder for the new protocol's directory name (kebab-case, e.g. `aerodrome` or `hyperliquid-perp`).
+
+### 1. Routing (in [`App.tsx`](../apps/midcurve-ui/src/App.tsx))
+- [ ] Add `<Route path="/positions/{proto}/.../*" element={<{Proto}PositionDetailPage />}>`
+- [ ] Add increase/withdraw/triggers routes mirroring the UniswapV3 set
+- [ ] Update `parsePositionHash` in `@midcurve/shared` for the new protocol
+
+### 2. Position Card (rendered by [`PositionList`](../apps/midcurve-ui/src/components/positions/position-list.tsx))
+- [ ] Add the protocol value to `VALID_PROTOCOL_VALUES` and the protocol filter dropdown
+- [ ] Add a `case '{proto}':` in the `parsePositionHash` switch returning the new card component
+- [ ] Implement `{Proto}PositionCard` — fetches detail via the protocol's data hook, shows skeleton during load, renders the common header/metrics layout, and embeds the protocol-specific action row
+
+### 3. Card sub-components (one each, under `components/positions/protocol/{proto}/`)
+- [ ] `{proto}-position-card.tsx` (the entry point above)
+- [ ] `{proto}-actions.tsx` (action button row — see [Action button rows](#action-button-rows))
+- [ ] `{proto}-mini-pnl-curve.tsx` (sparkline used in the metrics slot and on the detail page)
+- [ ] `{proto}-identifier.tsx` (the `#…` / `0x…` chip)
+- [ ] `{proto}-chain-badge.tsx` (or reuse a shared one if chain semantics match)
+- [ ] `{proto}-owner-badge.tsx` (or `{proto}-share-owner-badge.tsx` if applicable)
+- [ ] `{proto}-range-status.tsx` (compact range badge for the card)
+- [ ] `{proto}-range-status-line.tsx` (extended status line for the overview tab)
+
+### 4. Card modals
+- [ ] `{proto}-collect-fees-modal.tsx` + form
+- [ ] `{proto}-delete-position-modal.tsx`
+- [ ] `{proto}-reload-history-modal.tsx`
+- [ ] `{proto}-switch-quote-token-modal.tsx`
+- [ ] Lifecycle-cleanup modal if the protocol has one (e.g. NFT-style `Burn`)
+- [ ] Tokenization / wrap modal if applicable
+
+### 5. Detail page
+- [ ] `{Proto}PositionDetailPage` page wrapper (parses URL params, fetches position, renders the detail component)
+- [ ] `{Proto}PositionDetail` component with the seven-tab strip
+- [ ] Per-tab components:
+  - [ ] `{proto}-overview-tab.tsx` — three position-state cards + optional `PortfolioSimulator` integration
+  - [ ] `{proto}-history-tab.tsx` — PnL breakdown + ledger event table (reuse the protocol-agnostic `PnLBreakdown` and `LedgerEventTable` if event shapes match)
+  - [ ] `{proto}-apr-tab.tsx` — APR breakdown + periods table (`AprBreakdown` and `AprPeriodsTable` are reusable)
+  - [ ] `{proto}-conversion-tab.tsx` — protocol-specific conversion summary + history (or omit if conversion is meaningless for the protocol)
+  - [ ] `{proto}-automation-tab.tsx` — close-orders panel + automation logs
+  - [ ] `{proto}-technical-tab.tsx` — raw config/state with explorer links
+- [ ] **Accounting tab is shared** ([`PositionAccountingTab`](../apps/midcurve-ui/src/components/positions/accounting/position-accounting-tab.tsx)) — just wire up a `use{Proto}PositionAccounting` hook
+
+### 6. Wizards
+- [ ] Increase deposit wizard at `components/positions/wizard/increase-deposit/{proto}/` (4 steps: Configure → Swap → Transaction)
+- [ ] Withdraw wizard at `wizard/withdraw/{proto}/`
+- [ ] Risk triggers wizard at `wizard/risk-triggers/{proto}/`
+- [ ] Page wrappers: `{Proto}IncreaseDepositPage`, `{Proto}WithdrawPage`, `{Proto}RiskTriggersPage`
+
+### 7. Automation buttons & flows
+- [ ] `{Proto}StopLossButton` and `{Proto}TakeProfitButton` (or reuse the existing ones if the close-order data shape is identical)
+- [ ] `{Proto}CloseOrdersPanel` (or reuse `PositionCloseOrdersPanel` if the close-order shape matches)
+- [ ] Wire `useSharedContract` to the new chain's deployed closer contract; gate disabled state with the same reasons (`burned`, `no liquidity`, `chain unsupported`)
+
+### 8. Hooks (under `hooks/positions/{proto}/`)
+- [ ] `use{Proto}Position(...)` — returns position detail; 3s DB polling
+- [ ] `use{Proto}AutoRefresh(...)` — fires `/refresh` on mount + every 60s
+- [ ] `use{Proto}LiveMetrics(position)` — patches live pool price every 5s
+- [ ] `use{Proto}RefreshPosition` — manual refresh mutation
+- [ ] `use{Proto}Ledger`, `use{Proto}AprPeriods`, `use{Proto}Conversion`, `use{Proto}PositionAccounting`
+- [ ] `useImport{Proto}Position` (mutation) and `useDiscover{Proto}Positions` if scanning is supported
+
+### 9. Add Position dropdown
+- [ ] Decide which entry points the new protocol supports (wizard / import-by-id / import-by-address / scan)
+- [ ] Add the option(s) to [`CreatePositionDropdown`](../apps/midcurve-ui/src/components/positions/create-position-dropdown.tsx)
+- [ ] Add an entry to [`EmptyStateActions`](../apps/midcurve-ui/src/components/positions/empty-state-actions.tsx) for the most common option
+- [ ] If scanning is supported, extend [`ScanPositionsModal`](../apps/midcurve-ui/src/components/positions/scan-positions-modal.tsx) (or add a parallel modal)
+
+### 10. Per-protocol config
+- [ ] Chain list under `config/protocols/{proto}/` (chain slug ↔ chain id mapping, contract addresses)
+- [ ] Contract ABIs under `abis/` (NFT-manager-equivalent, vault-equivalent, etc.)
+
+### 11. Visual & copy review
+- [ ] Token logos resolve via the existing helper (CoinGecko / fallback)
+- [ ] Range status semantics match the underlying primitive (some protocols don't have ranges — adapt or hide the range badges)
+- [ ] All quote/base flips work; mini PnL curve renders correctly with `isToken0Quote = true` and `false`
+- [ ] Action buttons collapse to Archive-only when the connected wallet is not the on-chain owner
+
+---
+
+## Out of scope — non-position UI pages
+
+The pages below exist in the SPA but are **not** about positions and are deliberately omitted from this document. Each is listed here so a future doc can cover them.
+
+| Page | Route | Purpose | Future doc |
+|---|---|---|---|
+| [`HomePage`](../apps/midcurve-ui/src/pages/HomePage.tsx) | `/` | Landing page, sign-in entry, marketing copy | `auth-and-onboarding.md` |
+| [`SetupWizardPage`](../apps/midcurve-ui/src/pages/SetupWizardPage.tsx) | `/setup` (or auto-served when `configured == false`) | First-run admin wizard: WalletConnect project ID, operator address, allowlist | `auth-and-onboarding.md` |
+| [`SystemConfigPage`](../apps/midcurve-ui/src/pages/SystemConfigPage.tsx) | `/system-config` | Admin: edit system config post-setup | `admin.md` |
+| [`WalletManagementPage`](../apps/midcurve-ui/src/pages/WalletManagementPage.tsx) | `/wallets` | User-side: link/unlink wallets to the account, set primary wallet | `auth-and-onboarding.md` |
+| [`ApiKeysPage`](../apps/midcurve-ui/src/pages/ApiKeysPage.tsx) | `/api-keys` | Create/revoke `mck_…` API keys for the MCP server and other clients | `mcp-and-api-keys.md` |
+| [`NotificationsPage`](../apps/midcurve-ui/src/pages/NotificationsPage.tsx) | `/notifications` | In-app notification feed (range exits, close-order executions); webhook configuration | `notifications.md` |
+| [Notification bell](../apps/midcurve-ui/src/components/notifications/notification-bell.tsx) | (header) | Compact unread-count badge on the dashboard header | `notifications.md` |
+| [Accounting tab on dashboard](../apps/midcurve-ui/src/components/accounting/accounting-summary.tsx) | `/dashboard?tab=accounting` | Cross-position accounting summary (not the per-position Accounting tab — that one *is* covered here) | `accounting.md` |
+| [`WizardExamplePage`](../apps/midcurve-ui/src/pages/WizardExamplePage.tsx) | `/wizard-example` | Internal example/playground for the wizard primitives | (developer-only, no user doc planned) |
+
+The **swap** UI (under [`components/swap/`](../apps/midcurve-ui/src/components/swap/)) is also out of scope here — it is a standalone token-swap surface, not a position-management view.
+
+---
+
+## See also
+
+- [positions.md](./positions.md) — Data model: position types, metric fields, ledger events, automation lifecycle
+- [architecture.md](./architecture.md) — Monorepo layout, services, deployment
+- [philosophy.md](./philosophy.md) — Quote/base paradigm, risk definition
+- [`apps/midcurve-ui/CLAUDE.md`](../apps/midcurve-ui/CLAUDE.md) — UI tech stack, providers, query patterns
+- [`.claude/rules/cursor-pointer.md`](../.claude/rules/cursor-pointer.md) — Every interactive element gets `cursor-pointer`
+- [`.claude/rules/frontend-no-rpc.md`](../.claude/rules/frontend-no-rpc.md) — Why every blockchain read goes through the API, not wagmi
+- [`.claude/rules/platform-agnostic-design.md`](../.claude/rules/platform-agnostic-design.md) — Why every protocol-specific file lives under a platform-named subdirectory

--- a/packages/midcurve-database/prisma/migrations/20260504155248_add_staking_token_lot_events/migration.sql
+++ b/packages/midcurve-database/prisma/migrations/20260504155248_add_staking_token_lot_events/migration.sql
@@ -1,0 +1,10 @@
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "accounting"."TokenLotTransferEvent" ADD VALUE 'STAKING_DEPOSIT';
+ALTER TYPE "accounting"."TokenLotTransferEvent" ADD VALUE 'STAKING_DISPOSE';

--- a/packages/midcurve-database/prisma/schema.prisma
+++ b/packages/midcurve-database/prisma/schema.prisma
@@ -919,6 +919,8 @@ enum TokenLotTransferEvent {
   VAULT_BURN
   DEPOSIT_TO_PROTOCOL
   WITHDRAWAL_FROM_PROTOCOL
+  STAKING_DEPOSIT
+  STAKING_DISPOSE
 
   @@schema("accounting")
 }

--- a/packages/midcurve-database/prisma/seed-contracts.ts
+++ b/packages/midcurve-database/prisma/seed-contracts.ts
@@ -25,6 +25,7 @@ const CONTRACT_NAME_TO_KEBAB: Record<string, string> = {
   AllowlistedUniswapV3Vault: 'allowlisted-uniswap-v3-vault',
   UniswapV3VaultFactory: 'uniswap-v3-vault-factory',
   UniswapV3VaultPositionCloser: 'uniswap-v3-vault-position-closer',
+  UniswapV3StakingVaultFactory: 'uniswap-v3-staking-vault-factory',
 };
 
 interface DeploymentFile {

--- a/packages/midcurve-services/src/services/position-ledger/index.ts
+++ b/packages/midcurve-services/src/services/position-ledger/index.ts
@@ -39,5 +39,24 @@ export {
   type DecodedVaultLogData,
 } from './uniswapv3-vault-ledger-service.js';
 
+export {
+  UniswapV3StakingLedgerService,
+  type UniswapV3StakingLedgerServiceConfig,
+  type UniswapV3StakingLedgerServiceDependencies,
+  type CreateStakingLedgerEventInput,
+  type StakingRawLogInput,
+  type StakingLogChainContext,
+  type StakingLedgerAggregates,
+  type StakingSingleLogResult,
+  type StakingImportLogsResult,
+  // Staking event validation and decoding
+  STAKING_VAULT_EVENT_SIGNATURES,
+  validateStakingEvent,
+  decodeStakingLogData,
+  type ValidStakingEventType,
+  type ValidateStakingEventResult,
+  type DecodedStakingLogData,
+} from './uniswapv3-staking-ledger-service.js';
+
 // Re-export APR types for backward compatibility
 export type { AprPeriodData } from '../types/position-apr/index.js';

--- a/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.test.ts
+++ b/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.test.ts
@@ -1,0 +1,924 @@
+/**
+ * UniswapV3StakingLedgerService — unit tests
+ *
+ * Synthetic-fixture tests covering SPEC-0003b PR1 acceptance:
+ *  - Stake (initial) → STAKING_DEPOSIT
+ *  - Stake (top-up) → second STAKING_DEPOSIT, exercises non-Empty vaultStateBefore
+ *  - Swap (50% partial) → STAKING_DISPOSE, principal/yield split, Model A semantics
+ *  - FlashClose composition → single synthesized STAKING_DISPOSE
+ *  - Marker events (YieldTargetSet / PartialUnstakeBpsSet)
+ *  - Standalone Unstake / ClaimRewards suppression
+ *  - Validation: wrong contract / wrong owner / unknown topic0
+ *  - Idempotency: rerun produces same row count
+ *  - Reorg: deleteAllByBlockHash cascades
+ *  - Model A invariant: yield-only flat-principal vs. principal-floor gain
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { encodeAbiParameters, keccak256, toBytes, pad } from 'viem';
+import type { PrismaClient } from '@midcurve/database';
+import {
+    UniswapV3StakingLedgerService,
+    STAKING_VAULT_EVENT_SIGNATURES,
+    type StakingRawLogInput,
+    type StakingLogChainContext,
+} from './uniswapv3-staking-ledger-service.js';
+
+// ============================================================================
+// FIXTURES
+// ============================================================================
+
+const POSITION_ID = 'pos_staking_test';
+const CHAIN_ID = 42161;
+const VAULT_ADDRESS = '0xA1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1';
+const OWNER_ADDRESS = '0xB2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2B2';
+const POOL_ADDRESS = '0xC3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3';
+const EXECUTOR_ADDRESS = '0xD4D4D4D4D4D4D4D4D4D4D4D4D4D4D4D4D4D4D4D4';
+const TOKEN0 = '0x0000000000000000000000000000000000000001';
+const TOKEN1 = '0x0000000000000000000000000000000000000002';
+
+const SQRT_PRICE_1_TO_1 = 2n ** 96n;
+const BASE_TIMESTAMP = new Date('2026-04-01T00:00:00Z');
+
+const POSITION_CONTEXT = {
+    typedConfig: {
+        isToken0Quote: false, // base = token0, quote = token1
+        vaultAddress: VAULT_ADDRESS,
+        poolAddress: POOL_ADDRESS,
+    },
+};
+
+// ============================================================================
+// IN-MEMORY PRISMA MOCK
+// ============================================================================
+
+interface StoredEvent {
+    id: string;
+    createdAt: Date;
+    updatedAt: Date;
+    positionId: string;
+    protocol: string;
+    previousId: string | null;
+    timestamp: Date;
+    eventType: string;
+    inputHash: string;
+    tokenValue: string;
+    rewards: unknown;
+    deltaCostBasis: string;
+    costBasisAfter: string;
+    deltaPnl: string;
+    pnlAfter: string;
+    deltaCollectedYield: string;
+    collectedYieldAfter: string;
+    deltaRealizedCashflow: string;
+    realizedCashflowAfter: string;
+    isIgnored: boolean;
+    ignoredReason: string | null;
+    config: Record<string, unknown>;
+    state: Record<string, unknown>;
+}
+
+class FakePrisma {
+    public store: StoredEvent[] = [];
+    private nextId = 1;
+
+    positionLedgerEvent = {
+        create: vi.fn(async ({ data }: { data: any }) => {
+            const row: StoredEvent = {
+                id: `evt_${this.nextId++}`,
+                createdAt: new Date(),
+                updatedAt: new Date(),
+                ...data,
+                rewards: data.rewards ?? [],
+                isIgnored: data.isIgnored ?? false,
+                ignoredReason: data.ignoredReason ?? null,
+                previousId: data.previousId ?? null,
+            };
+            this.store.push(row);
+            return row;
+        }),
+        findFirst: vi.fn(async ({ where }: any) => {
+            const inputHash = where?.inputHash;
+            if (inputHash !== undefined) {
+                const found = this.store.find(
+                    (e) =>
+                        e.positionId === where.positionId &&
+                        e.inputHash === inputHash,
+                );
+                return found ?? null;
+            }
+            return this.store.find((e) => e.positionId === where.positionId) ?? null;
+        }),
+        findMany: vi.fn(async ({ where }: any) => {
+            const path = where?.config?.path?.[0];
+            const equals = where?.config?.equals;
+            if (path === 'txHash') {
+                return this.store.filter(
+                    (e) =>
+                        e.positionId === where.positionId &&
+                        (e.config as any).txHash === equals,
+                );
+            }
+            if (path === 'blockHash') {
+                return this.store.filter(
+                    (e) =>
+                        e.positionId === where.positionId &&
+                        (e.config as any).blockHash === equals,
+                );
+            }
+            const ids = where?.id?.in;
+            if (Array.isArray(ids)) {
+                return this.store.filter((e) => ids.includes(e.id));
+            }
+            return this.store.filter((e) => e.positionId === where.positionId);
+        }),
+        update: vi.fn(async ({ where, data }: any) => {
+            const idx = this.store.findIndex((e) => e.id === where.id);
+            if (idx < 0) throw new Error(`update: id ${where.id} not found`);
+            this.store[idx] = { ...this.store[idx], ...data, updatedAt: new Date() } as StoredEvent;
+            return this.store[idx];
+        }),
+        deleteMany: vi.fn(async ({ where }: any) => {
+            const ids = where?.id?.in;
+            if (Array.isArray(ids)) {
+                const before = this.store.length;
+                this.store = this.store.filter((e) => !ids.includes(e.id));
+                return { count: before - this.store.length };
+            }
+            const before = this.store.length;
+            this.store = this.store.filter((e) => e.positionId !== where.positionId);
+            return { count: before - this.store.length };
+        }),
+    };
+
+    // Tagged template literal handler for ORDER BY (blockNumber DESC, logIndex DESC).
+    $queryRaw = vi.fn(async (_strings: TemplateStringsArray, ..._values: unknown[]) => {
+        const sorted = [...this.store]
+            .filter((e) => e.positionId === POSITION_ID)
+            .sort((a, b) => {
+                const aBn = BigInt((a.config as any).blockNumber);
+                const bBn = BigInt((b.config as any).blockNumber);
+                if (aBn !== bBn) return aBn < bBn ? 1 : -1;
+                return (b.config as any).logIndex - (a.config as any).logIndex;
+            });
+        // findLast uses LIMIT 1 — we can't easily detect that from a tagged
+        // template, but the service handles results.length===0 fine. The
+        // service only ever asks for full-list or LIMIT 1; it slices the array
+        // itself, so always returning the full sorted list is safe.
+        return sorted as unknown[];
+    });
+}
+
+function makePrismaMock(): { fake: FakePrisma; client: PrismaClient } {
+    const fake = new FakePrisma();
+    return { fake, client: fake as unknown as PrismaClient };
+}
+
+// ============================================================================
+// POOL PRICE SERVICE MOCK
+// ============================================================================
+
+function makePoolPriceServiceMock(sqrtPriceX96 = SQRT_PRICE_1_TO_1) {
+    return {
+        discover: vi.fn(async (_pool: any, opts: any) => ({
+            sqrtPriceX96,
+            timestamp: new Date(BASE_TIMESTAMP.getTime() + (opts?.blockNumber ?? 0) * 1000),
+        })),
+    } as any;
+}
+
+// ============================================================================
+// LOG BUILDERS
+// ============================================================================
+
+function paddedAddress(address: string): `0x${string}` {
+    return pad(address.toLowerCase() as `0x${string}`, { size: 32 });
+}
+
+function makeBaseLog(
+    sigHex: string,
+    blockNumber: bigint,
+    txHash: string,
+    blockHash: string,
+    logIndex: number,
+    extras: { topics?: string[]; data?: `0x${string}`; chainContext?: StakingLogChainContext } = {},
+): StakingRawLogInput {
+    return {
+        address: VAULT_ADDRESS,
+        topics: [sigHex, ...(extras.topics ?? [])],
+        data: extras.data ?? '0x',
+        blockNumber,
+        blockHash,
+        transactionHash: txHash,
+        transactionIndex: 0,
+        logIndex,
+        removed: false,
+        chainContext: extras.chainContext,
+    };
+}
+
+function makeStakeLog(
+    blockNumber: bigint,
+    txHash: string,
+    blockHash: string,
+    logIndex: number,
+    args: {
+        base: bigint;
+        quote: bigint;
+        yieldTarget: bigint;
+        tokenId: bigint;
+        chainContext: StakingLogChainContext;
+        ownerOverride?: string;
+    },
+): StakingRawLogInput {
+    const owner = args.ownerOverride ?? OWNER_ADDRESS;
+    const data = encodeAbiParameters(
+        [
+            { name: 'base', type: 'uint256' },
+            { name: 'quote', type: 'uint256' },
+            { name: 'yieldTarget', type: 'uint256' },
+            { name: 'tokenId', type: 'uint256' },
+        ],
+        [args.base, args.quote, args.yieldTarget, args.tokenId],
+    );
+    return makeBaseLog(
+        STAKING_VAULT_EVENT_SIGNATURES.STAKE,
+        blockNumber, txHash, blockHash, logIndex,
+        { topics: [paddedAddress(owner)], data, chainContext: args.chainContext },
+    );
+}
+
+function makeSwapLog(
+    blockNumber: bigint,
+    txHash: string,
+    blockHash: string,
+    logIndex: number,
+    args: {
+        executor?: string;
+        tokenIn: string;
+        amountIn: bigint;
+        tokenOut: string;
+        amountOut: bigint;
+        effectiveBps: number;
+        chainContext: StakingLogChainContext;
+    },
+): StakingRawLogInput {
+    const executor = args.executor ?? EXECUTOR_ADDRESS;
+    const data = encodeAbiParameters(
+        [
+            { name: 'tokenIn', type: 'address' },
+            { name: 'amountIn', type: 'uint256' },
+            { name: 'tokenOut', type: 'address' },
+            { name: 'amountOut', type: 'uint256' },
+            { name: 'effectiveBps', type: 'uint16' },
+        ],
+        [args.tokenIn as `0x${string}`, args.amountIn, args.tokenOut as `0x${string}`, args.amountOut, args.effectiveBps],
+    );
+    return makeBaseLog(
+        STAKING_VAULT_EVENT_SIGNATURES.SWAP,
+        blockNumber, txHash, blockHash, logIndex,
+        { topics: [paddedAddress(executor)], data, chainContext: args.chainContext },
+    );
+}
+
+function makeFlashCloseInitiatedLog(
+    blockNumber: bigint,
+    txHash: string,
+    blockHash: string,
+    logIndex: number,
+    args: {
+        bps: number;
+        callbackTarget: string;
+        chainContext: StakingLogChainContext;
+    },
+): StakingRawLogInput {
+    const data = encodeAbiParameters(
+        [
+            { name: 'bps', type: 'uint16' },
+            { name: 'data', type: 'bytes' },
+        ],
+        [args.bps, '0x'],
+    );
+    return makeBaseLog(
+        STAKING_VAULT_EVENT_SIGNATURES.FLASH_CLOSE_INITIATED,
+        blockNumber, txHash, blockHash, logIndex,
+        { topics: [paddedAddress(OWNER_ADDRESS), paddedAddress(args.callbackTarget)], data, chainContext: args.chainContext },
+    );
+}
+
+function makeUnstakeLog(
+    blockNumber: bigint,
+    txHash: string,
+    blockHash: string,
+    logIndex: number,
+    args: { base: bigint; quote: bigint },
+): StakingRawLogInput {
+    const data = encodeAbiParameters(
+        [
+            { name: 'base', type: 'uint256' },
+            { name: 'quote', type: 'uint256' },
+        ],
+        [args.base, args.quote],
+    );
+    return makeBaseLog(
+        STAKING_VAULT_EVENT_SIGNATURES.UNSTAKE,
+        blockNumber, txHash, blockHash, logIndex,
+        { topics: [paddedAddress(OWNER_ADDRESS)], data },
+    );
+}
+
+function makeClaimRewardsLog(
+    blockNumber: bigint,
+    txHash: string,
+    blockHash: string,
+    logIndex: number,
+    args: { base: bigint; quote: bigint },
+): StakingRawLogInput {
+    const data = encodeAbiParameters(
+        [
+            { name: 'baseAmount', type: 'uint256' },
+            { name: 'quoteAmount', type: 'uint256' },
+        ],
+        [args.base, args.quote],
+    );
+    return makeBaseLog(
+        STAKING_VAULT_EVENT_SIGNATURES.CLAIM_REWARDS,
+        blockNumber, txHash, blockHash, logIndex,
+        { topics: [paddedAddress(OWNER_ADDRESS)], data },
+    );
+}
+
+function makeYieldTargetSetLog(
+    blockNumber: bigint,
+    txHash: string,
+    blockHash: string,
+    logIndex: number,
+    args: { oldTarget: bigint; newTarget: bigint },
+): StakingRawLogInput {
+    const data = encodeAbiParameters(
+        [
+            { name: 'oldTarget', type: 'uint256' },
+            { name: 'newTarget', type: 'uint256' },
+        ],
+        [args.oldTarget, args.newTarget],
+    );
+    return makeBaseLog(
+        STAKING_VAULT_EVENT_SIGNATURES.YIELD_TARGET_SET,
+        blockNumber, txHash, blockHash, logIndex,
+        { topics: [paddedAddress(OWNER_ADDRESS)], data },
+    );
+}
+
+function makePartialUnstakeBpsSetLog(
+    blockNumber: bigint,
+    txHash: string,
+    blockHash: string,
+    logIndex: number,
+    args: { oldBps: number; newBps: number },
+): StakingRawLogInput {
+    const data = encodeAbiParameters(
+        [
+            { name: 'oldBps', type: 'uint16' },
+            { name: 'newBps', type: 'uint16' },
+        ],
+        [args.oldBps, args.newBps],
+    );
+    return makeBaseLog(
+        STAKING_VAULT_EVENT_SIGNATURES.PARTIAL_UNSTAKE_BPS_SET,
+        blockNumber, txHash, blockHash, logIndex,
+        { topics: [paddedAddress(OWNER_ADDRESS)], data },
+    );
+}
+
+// ============================================================================
+// TESTS
+// ============================================================================
+
+describe('UniswapV3StakingLedgerService', () => {
+    let fake: FakePrisma;
+    let service: UniswapV3StakingLedgerService;
+    let poolPriceService: ReturnType<typeof makePoolPriceServiceMock>;
+
+    beforeEach(() => {
+        const { fake: f, client } = makePrismaMock();
+        fake = f;
+        service = new UniswapV3StakingLedgerService(
+            { positionId: POSITION_ID },
+            { prisma: client },
+        );
+        poolPriceService = makePoolPriceServiceMock();
+    });
+
+    // ============================================================================
+    // STATIC HASH
+    // ============================================================================
+
+    describe('createHash', () => {
+        it('produces uniswapv3-staking/{chainId}/{txHash}/{blockHash}/{logIndex}', () => {
+            const hash = UniswapV3StakingLedgerService.createHash(
+                42161, '0xtx', '0xblk', 7,
+            );
+            expect(hash).toBe('uniswapv3-staking/42161/0xtx/0xblk/7');
+        });
+    });
+
+    // ============================================================================
+    // STAKE — INITIAL
+    // ============================================================================
+
+    describe('Stake (initial)', () => {
+        it('inserts STAKING_DEPOSIT with correct cost basis and zero PnL', async () => {
+            const log = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n,
+                quote: 500n,
+                yieldTarget: 100n,
+                tokenId: 42n,
+                chainContext: {
+                    vaultStateBefore: 'Empty',
+                    liquidityAfter: 1_000_000n,
+                },
+            });
+
+            const result = await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [log], poolPriceService,
+            );
+
+            expect(fake.store.length).toBe(1);
+            const row = fake.store[0]!;
+            expect(row.eventType).toBe('STAKING_DEPOSIT');
+            // tokenValue = base*P + quote = 1000*1 + 500 = 1500 (sqrtPrice 1:1, isToken0Quote=false)
+            expect(row.tokenValue).toBe('1500');
+            expect(row.deltaCostBasis).toBe('1500');
+            expect(row.costBasisAfter).toBe('1500');
+            expect(row.pnlAfter).toBe('0');
+            expect(row.collectedYieldAfter).toBe('0');
+            const cfg = row.config as any;
+            expect(cfg.deltaL).toBe('1000000');
+            expect(cfg.liquidityAfter).toBe('1000000');
+            expect(cfg.effectiveBps).toBe(10000);
+            const state = row.state as any;
+            expect(state.eventType).toBe('STAKING_DEPOSIT');
+            expect(state.isInitial).toBe(true);
+            expect(state.baseAmount).toBe('1000');
+            expect(state.quoteAmount).toBe('500');
+            expect(result.postImportAggregates.costBasisAfter).toBe(1500n);
+            expect(result.postImportAggregates.liquidityAfter).toBe(1_000_000n);
+        });
+    });
+
+    // ============================================================================
+    // STAKE — TOP-UP
+    // ============================================================================
+
+    describe('Stake (top-up) — vaultStateBefore=Staked precondition', () => {
+        it('chains liquidityBefore from prior STAKING_DEPOSIT and accumulates cost basis', async () => {
+            const initial = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n,
+                quote: 500n,
+                yieldTarget: 100n,
+                tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const topUp = makeStakeLog(200n, '0xtx2', '0xblk2', 0, {
+                base: 2000n,
+                quote: 1000n,
+                yieldTarget: 100n,
+                tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Staked', liquidityAfter: 3_000_000n },
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [initial, topUp], poolPriceService,
+            );
+
+            expect(fake.store.length).toBe(2);
+            const events = [...fake.store].sort(
+                (a, b) => Number((a.config as any).blockNumber) - Number((b.config as any).blockNumber),
+            );
+            const initialRow = events[0]!;
+            const topUpRow = events[1]!;
+
+            expect(initialRow.eventType).toBe('STAKING_DEPOSIT');
+            expect((initialRow.state as any).isInitial).toBe(true);
+
+            expect(topUpRow.eventType).toBe('STAKING_DEPOSIT');
+            expect((topUpRow.state as any).isInitial).toBe(false);
+            // deltaL = 3_000_000 - 1_000_000 = 2_000_000 (chain-from-previous, no RPC for top-up)
+            expect((topUpRow.config as any).deltaL).toBe('2000000');
+            expect((topUpRow.config as any).liquidityAfter).toBe('3000000');
+            // tokenValue = 2000*1 + 1000 = 3000
+            expect(topUpRow.tokenValue).toBe('3000');
+            // costBasisAfter accumulates: 1500 + 3000 = 4500
+            expect(topUpRow.costBasisAfter).toBe('4500');
+            expect(topUpRow.pnlAfter).toBe('0');
+        });
+    });
+
+    // ============================================================================
+    // SWAP — 50% PARTIAL DISPOSE
+    // ============================================================================
+
+    describe('Swap (50% partial)', () => {
+        it('emits STAKING_DISPOSE with principal/yield split and Model A semantics', async () => {
+            const stake = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n,
+                quote: 500n,
+                yieldTarget: 100n,
+                tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const swap = makeSwapLog(200n, '0xtx2', '0xblk2', 0, {
+                tokenIn: TOKEN1,
+                amountIn: 250n,
+                tokenOut: TOKEN0,
+                amountOut: 250n,
+                effectiveBps: 5000,
+                chainContext: {
+                    stakedBaseBefore: 1000n,
+                    stakedQuoteBefore: 500n,
+                    rewardBufferBaseDelta: 50n, // yield base
+                    rewardBufferQuoteDelta: 25n, // yield quote
+                    liquidityAfter: 500_000n, // halved
+                },
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake, swap], poolPriceService,
+            );
+
+            const events = [...fake.store].sort(
+                (a, b) => Number((a.config as any).blockNumber) - Number((b.config as any).blockNumber),
+            );
+            const swapRow = events[1]!;
+            expect(swapRow.eventType).toBe('STAKING_DISPOSE');
+
+            // principal = stakedBefore × bps / 10000:
+            //   principalBase  = 1000 × 5000 / 10000 = 500
+            //   principalQuote =  500 × 5000 / 10000 = 250
+            // principalQuoteValue = principalBase*1 + principalQuote = 500 + 250 = 750
+            // yieldQuoteValue     = yieldBase*1 + yieldQuote         =  50 +  25 =  75
+            // tokenValue = 750 + 75 = 825
+            expect(swapRow.tokenValue).toBe('825');
+
+            const cfg = swapRow.config as any;
+            expect(cfg.principalBaseDelta).toBe('500');
+            expect(cfg.principalQuoteDelta).toBe('250');
+            expect(cfg.yieldBaseDelta).toBe('50');
+            expect(cfg.yieldQuoteDelta).toBe('25');
+            expect(cfg.principalQuoteValue).toBe('750');
+            expect(cfg.yieldQuoteValue).toBe('75');
+            expect(cfg.source).toBe('swap');
+            expect(cfg.effectiveBps).toBe(5000);
+            expect(cfg.deltaL).toBe('-500000');
+
+            // Aggregate recalculation (Model A):
+            //   proportionalCostBasis = |deltaL| × prevCostBasis / prevLiquidity
+            //                         = 500_000 × 1500 / 1_000_000 = 750
+            //   deltaCostBasis = -750
+            //   costBasisAfter = 1500 - 750 = 750
+            //   deltaPnl = principalQuoteValue - proportionalCostBasis = 750 - 750 = 0
+            //   pnlAfter = 0
+            //   deltaCollectedYield = yieldQuoteValue = 75
+            //   collectedYieldAfter = 75
+            expect(swapRow.deltaCostBasis).toBe('-750');
+            expect(swapRow.costBasisAfter).toBe('750');
+            expect(swapRow.deltaPnl).toBe('0');
+            expect(swapRow.pnlAfter).toBe('0');
+            expect(swapRow.deltaCollectedYield).toBe('75');
+            expect(swapRow.collectedYieldAfter).toBe('75');
+        });
+    });
+
+    // ============================================================================
+    // FLASHCLOSE COMPOSITION
+    // ============================================================================
+
+    describe('FlashClose composition', () => {
+        it('folds FlashCloseInitiated + same-tx Unstake + ClaimRewards into a single STAKING_DISPOSE', async () => {
+            const stake = makeStakeLog(100n, '0xtxA', '0xblkA', 0, {
+                base: 1000n,
+                quote: 500n,
+                yieldTarget: 100n,
+                tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const fci = makeFlashCloseInitiatedLog(200n, '0xtxFC', '0xblkFC', 0, {
+                bps: 10000,
+                callbackTarget: '0xE5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5',
+                chainContext: { liquidityAfter: 0n },
+            });
+            const unstake = makeUnstakeLog(200n, '0xtxFC', '0xblkFC', 1, {
+                base: 1000n, quote: 500n,
+            });
+            const claim = makeClaimRewardsLog(200n, '0xtxFC', '0xblkFC', 2, {
+                base: 100n, quote: 50n,
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake, fci, unstake, claim], poolPriceService,
+            );
+
+            // Expect 2 events: stake + 1 synthesized dispose. Standalone Unstake/Claim are folded.
+            expect(fake.store.length).toBe(2);
+            const dispose = fake.store.find((e) => e.eventType === 'STAKING_DISPOSE')!;
+            expect(dispose).toBeDefined();
+            const state = dispose.state as any;
+            expect(state.source).toBe('flashClose');
+            expect(state.principalBase).toBe('1000');
+            expect(state.principalQuote).toBe('500');
+            expect(state.yieldBase).toBe('100');
+            expect(state.yieldQuote).toBe('50');
+            // tokenValue = (1000+500) + (100+50) = 1500 + 150 = 1650
+            expect(dispose.tokenValue).toBe('1650');
+            // proportionalCostBasis = 1_000_000 × 1500 / 1_000_000 = 1500
+            // deltaPnl = principalQuoteValue - proportionalCostBasis = 1500 - 1500 = 0
+            expect(dispose.deltaPnl).toBe('0');
+            // deltaCollectedYield = yieldQuoteValue = 150
+            expect(dispose.collectedYieldAfter).toBe('150');
+        });
+    });
+
+    // ============================================================================
+    // MARKER EVENTS
+    // ============================================================================
+
+    describe('Marker events', () => {
+        it('YieldTargetSet → STAKING_YIELD_TARGET_SET with no aggregate change', async () => {
+            const stake = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n,
+                quote: 500n,
+                yieldTarget: 100n,
+                tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const yt = makeYieldTargetSetLog(110n, '0xtx2', '0xblk2', 0, {
+                oldTarget: 100n, newTarget: 200n,
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake, yt], poolPriceService,
+            );
+
+            const ytRow = fake.store.find((e) => e.eventType === 'STAKING_YIELD_TARGET_SET')!;
+            expect(ytRow).toBeDefined();
+            expect(ytRow.tokenValue).toBe('0');
+            expect(ytRow.deltaCostBasis).toBe('0');
+            expect(ytRow.deltaPnl).toBe('0');
+            expect(ytRow.deltaCollectedYield).toBe('0');
+            expect(ytRow.costBasisAfter).toBe('1500');
+        });
+
+        it('PartialUnstakeBpsSet → STAKING_PENDING_BPS_SET with no aggregate change', async () => {
+            const stake = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n,
+                quote: 500n,
+                yieldTarget: 100n,
+                tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const bps = makePartialUnstakeBpsSetLog(110n, '0xtx2', '0xblk2', 0, {
+                oldBps: 0, newBps: 5000,
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake, bps], poolPriceService,
+            );
+
+            const bpsRow = fake.store.find((e) => e.eventType === 'STAKING_PENDING_BPS_SET')!;
+            expect(bpsRow).toBeDefined();
+            expect(bpsRow.deltaCostBasis).toBe('0');
+            expect((bpsRow.state as any).newBps).toBe(5000);
+        });
+    });
+
+    // ============================================================================
+    // STANDALONE DRAINS (NOT IN FLASHCLOSE TX) — SUPPRESSED
+    // ============================================================================
+
+    describe('standalone Unstake / ClaimRewards', () => {
+        it('are suppressed (no ledger event created)', async () => {
+            const stake = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n,
+                quote: 500n,
+                yieldTarget: 100n,
+                tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const unstake = makeUnstakeLog(150n, '0xtxStandalone1', '0xblkS1', 0, {
+                base: 200n, quote: 100n,
+            });
+            const claim = makeClaimRewardsLog(160n, '0xtxStandalone2', '0xblkS2', 0, {
+                base: 50n, quote: 25n,
+            });
+
+            const result = await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake, unstake, claim], poolPriceService,
+            );
+
+            // Only the Stake → STAKING_DEPOSIT event is persisted.
+            expect(fake.store.length).toBe(1);
+            const skipped = result.perLogResults.filter((r) => r.action === 'skipped');
+            expect(skipped.length).toBe(2);
+            expect(skipped.every((r) => r.action === 'skipped' && r.reason === 'standalone_drain'))
+                .toBe(true);
+        });
+    });
+
+    // ============================================================================
+    // VALIDATION
+    // ============================================================================
+
+    describe('Validation', () => {
+        it('rejects logs from a different contract (wrong_contract)', async () => {
+            const wrongAddr = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1n },
+            });
+            wrongAddr.address = '0xFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFEFE';
+
+            const result = await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [wrongAddr], poolPriceService,
+            );
+            expect(fake.store.length).toBe(0);
+            expect(result.perLogResults[0]).toEqual({ action: 'skipped', reason: 'invalid_event' });
+        });
+
+        it('rejects owner-indexed events with a different owner topic (wrong_owner)', async () => {
+            const wrongOwner = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1n },
+                ownerOverride: '0xCAFECAFECAFECAFECAFECAFECAFECAFECAFECAFE',
+            });
+
+            const result = await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [wrongOwner], poolPriceService,
+            );
+            expect(fake.store.length).toBe(0);
+            expect(result.perLogResults[0]).toEqual({ action: 'skipped', reason: 'invalid_event' });
+        });
+
+        it('rejects unknown topic0', async () => {
+            const unknown: StakingRawLogInput = {
+                address: VAULT_ADDRESS,
+                topics: [keccak256(toBytes('UnrelatedEvent()')), paddedAddress(OWNER_ADDRESS)],
+                data: '0x',
+                blockNumber: 100n,
+                blockHash: '0xblk1',
+                transactionHash: '0xtx1',
+                transactionIndex: 0,
+                logIndex: 0,
+            };
+
+            const result = await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [unknown], poolPriceService,
+            );
+            expect(fake.store.length).toBe(0);
+            expect(result.perLogResults[0]).toEqual({ action: 'skipped', reason: 'invalid_event' });
+        });
+    });
+
+    // ============================================================================
+    // IDEMPOTENCY
+    // ============================================================================
+
+    describe('Idempotency', () => {
+        it('rerunning import with the same logs produces the same row count', async () => {
+            const log = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [log], poolPriceService,
+            );
+            const after1 = fake.store.length;
+            const cb1 = fake.store[0]!.costBasisAfter;
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [log], poolPriceService,
+            );
+            const after2 = fake.store.length;
+            const cb2 = fake.store[0]!.costBasisAfter;
+
+            expect(after1).toBe(1);
+            expect(after2).toBe(1);
+            expect(cb1).toBe(cb2);
+        });
+    });
+
+    // ============================================================================
+    // REORG
+    // ============================================================================
+
+    describe('Reorg handling', () => {
+        it('deleteAllByBlockHash removes events with matching blockHash', async () => {
+            const log = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [log], poolPriceService,
+            );
+            expect(fake.store.length).toBe(1);
+
+            const deleted = await service.deleteAllByBlockHash('0xblk1');
+            expect(deleted.length).toBe(1);
+            expect(fake.store.length).toBe(0);
+        });
+
+        it('removed:true triggers blockHash deletion', async () => {
+            const stake = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake], poolPriceService,
+            );
+            expect(fake.store.length).toBe(1);
+
+            const removalLog = { ...stake, removed: true };
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [removalLog], poolPriceService,
+            );
+            expect(fake.store.length).toBe(0);
+        });
+    });
+
+    // ============================================================================
+    // MODEL A INVARIANT — §12.4
+    // ============================================================================
+
+    describe('Model A invariant', () => {
+        it('flat-principal yield-only swap → pnlAfter=0, collectedYieldAfter=yieldQuoteValue', async () => {
+            const stake = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            // 100% dispose at the same price (no principal P&L), with 200 yield in quote terms
+            const swap = makeSwapLog(200n, '0xtx2', '0xblk2', 0, {
+                tokenIn: TOKEN1,
+                amountIn: 0n,
+                tokenOut: TOKEN0,
+                amountOut: 0n,
+                effectiveBps: 10000,
+                chainContext: {
+                    stakedBaseBefore: 1000n,
+                    stakedQuoteBefore: 500n,
+                    rewardBufferBaseDelta: 100n,
+                    rewardBufferQuoteDelta: 100n, // yieldQuoteValue = 100*1 + 100 = 200
+                    liquidityAfter: 0n,
+                },
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake, swap], poolPriceService,
+            );
+
+            const dispose = fake.store.find((e) => e.eventType === 'STAKING_DISPOSE')!;
+            // principalQuoteValue = 1000+500 = 1500
+            // proportionalCostBasis = full disposal = 1500 (whole position)
+            // deltaPnl = 1500 - 1500 = 0  ← Model A: principal break-even
+            expect(dispose.deltaPnl).toBe('0');
+            expect(dispose.pnlAfter).toBe('0');
+            expect(dispose.deltaCollectedYield).toBe('200');
+            expect(dispose.collectedYieldAfter).toBe('200');
+        });
+
+        it('positive principal-floor gain → pnlAfter > 0 independent of yield', async () => {
+            // Initial stake at 1:1, then dispose 100% at price 2:1 (price higher).
+            // Track simulated 2:1 price by injecting a different sqrtPrice for the swap block.
+            const SQRT_PRICE_2_TO_1 = 2n ** 96n * 2n; // sqrtPrice^2 / 2^192 = 4
+            const ppMock = {
+                discover: vi.fn(async (_pool: any, opts: any) => ({
+                    sqrtPriceX96: opts.blockNumber === 200 ? SQRT_PRICE_2_TO_1 : SQRT_PRICE_1_TO_1,
+                    timestamp: BASE_TIMESTAMP,
+                })),
+            } as any;
+
+            const stake = makeStakeLog(100n, '0xtx1', '0xblk1', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const swap = makeSwapLog(200n, '0xtx2', '0xblk2', 0, {
+                tokenIn: TOKEN1, amountIn: 0n, tokenOut: TOKEN0, amountOut: 0n,
+                effectiveBps: 10000,
+                chainContext: {
+                    stakedBaseBefore: 1000n, stakedQuoteBefore: 500n,
+                    rewardBufferBaseDelta: 0n, rewardBufferQuoteDelta: 0n, // zero yield
+                    liquidityAfter: 0n,
+                },
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake, swap], ppMock,
+            );
+
+            const dispose = fake.store.find((e) => e.eventType === 'STAKING_DISPOSE')!;
+            // principalQuoteValue at price=4 (token0→token1): base*4 + quote = 1000*4 + 500 = 4500
+            // proportionalCostBasis = 1500 (full disposal at original cost basis)
+            // deltaPnl = 4500 - 1500 = 3000 (purely principal-floor gain)
+            expect(BigInt(dispose.deltaPnl)).toBeGreaterThan(0n);
+            expect(dispose.deltaCollectedYield).toBe('0');
+        });
+    });
+});

--- a/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.ts
+++ b/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.ts
@@ -1,0 +1,1341 @@
+/**
+ * UniswapV3 Staking Ledger Service
+ *
+ * Manages ledger events for UniswapV3StakingVault positions.
+ *
+ * Event mapping (per SPEC-0003b §6.3):
+ * - Stake (initial or top-up) → STAKING_DEPOSIT
+ * - Swap → STAKING_DISPOSE (executor settlement)
+ * - FlashCloseInitiated + same-tx auto-drained Unstake + ClaimRewards →
+ *   single synthesized STAKING_DISPOSE (source='flashClose')
+ * - YieldTargetSet → STAKING_YIELD_TARGET_SET (marker, no financial impact)
+ * - PartialUnstakeBpsSet → STAKING_PENDING_BPS_SET (marker, no financial impact)
+ * - Standalone Unstake / ClaimRewards (owner-driven drain, NOT in a flashClose tx)
+ *   → suppressed (buffers don't affect cost basis directly)
+ *
+ * Recalculation follows Model A (per philosophy.md):
+ * - Yield is NEVER added to deltaPnl; it goes to deltaCollectedYield only.
+ * - deltaPnl on disposal = principalQuoteValue − proportionalCostBasis.
+ *   This differs from UniswapV3LedgerService where COLLECT events add fees to PnL.
+ */
+
+import { decodeAbiParameters } from 'viem';
+import { prisma as prismaClient, PrismaClient } from '@midcurve/database';
+import {
+    UniswapV3StakingPositionLedgerEvent,
+    stakingLedgerEventConfigToJSON,
+    stakingLedgerEventStateToJSON,
+    valueOfToken0AmountInToken1,
+    valueOfToken1AmountInToken0,
+} from '@midcurve/shared';
+import type {
+    UniswapV3StakingPositionLedgerEventRow,
+    UniswapV3StakingLedgerEventConfig,
+    UniswapV3StakingLedgerEventState,
+    StakingState,
+    EventType,
+    Reward,
+} from '@midcurve/shared';
+import { createServiceLogger } from '../../logging/index.js';
+import type { ServiceLogger } from '../../logging/index.js';
+import type { PrismaTransactionClient } from '../../clients/prisma/index.js';
+import type { UniswapV3PoolPriceService } from '../pool-price/uniswapv3-pool-price-service.js';
+
+// ============================================================================
+// EVENT SIGNATURES
+// ============================================================================
+
+/**
+ * Topic0 (event signature hash) for each UniswapV3StakingVault event.
+ * Computed once via `keccak256(toBytes(<solidity-signature>))`.
+ */
+export const STAKING_VAULT_EVENT_SIGNATURES = {
+    STAKE:                   '0x2720efa4b2dd4f3f8a347da3cbd290a522e9432da9072c5b8e6300496fdde282',
+    YIELD_TARGET_SET:        '0x8157141975dedf58854297da6355d32a1aa83c4167c66664dac07c9a74c2d27a',
+    PARTIAL_UNSTAKE_BPS_SET: '0x991a39dd3212a3790cc04f8694ea6724f3053f36e0b3949c3f1d694a6b0de739',
+    SWAP:                    '0xa1f9d84f8238f8ae4b568ee1ae8a42dbaf3aad54ca2fc6e6b50d4b9a75b259c7',
+    UNSTAKE:                 '0xf960dbf9e5d0682f7a298ed974e33a28b4464914b7a2bfac12ae419a9afeb280',
+    CLAIM_REWARDS:           '0x674a8930d4166ce2352c3dc1e9ff633595db479f71f3741270a0a73a52cb7b0f',
+    FLASH_CLOSE_INITIATED:   '0x9d0df5b0f16aa34c89a9e410e837bcf07e564658481be063a50b847654b62382',
+} as const;
+
+export type ValidStakingEventType = keyof typeof STAKING_VAULT_EVENT_SIGNATURES;
+
+// ============================================================================
+// RAW LOG TYPES
+// ============================================================================
+
+/**
+ * Optional pre-fetched chain state for events that need it.
+ *
+ * Subscribers (PR2) populate these via NFPM/vault contract reads.
+ * Unit tests inject them directly into fixtures.
+ *
+ * Required fields by event type:
+ * - Stake: `vaultStateBefore`, `liquidityAfter` (all fields below required for top-up disambiguation)
+ * - Swap: `stakedBaseBefore`, `stakedQuoteBefore`, `rewardBufferBaseDelta`,
+ *         `rewardBufferQuoteDelta`, `liquidityAfter`
+ * - FlashCloseInitiated: `liquidityAfter` (principal/yield are derived from
+ *   the same-tx Unstake/ClaimRewards events)
+ * - All marker events / standalone Unstake / ClaimRewards: none
+ */
+export interface StakingLogChainContext {
+    /** vault.state() at blockNumber - 1 (for Stake disambiguation) */
+    vaultStateBefore?: StakingState;
+    /** NFPM.positions(tokenId).liquidity at blockNumber - 1 (initial-stake anchor only) */
+    liquidityBefore?: bigint;
+    /** NFPM.positions(tokenId).liquidity at blockNumber (post-event) */
+    liquidityAfter?: bigint;
+    /** vault.stakedBase() at blockNumber - 1 */
+    stakedBaseBefore?: bigint;
+    /** vault.stakedQuote() at blockNumber - 1 */
+    stakedQuoteBefore?: bigint;
+    /** rewardBuffer base delta (after - before, for Swap events) */
+    rewardBufferBaseDelta?: bigint;
+    /** rewardBuffer quote delta (after - before, for Swap events) */
+    rewardBufferQuoteDelta?: bigint;
+}
+
+/**
+ * Raw log + optional pre-fetched chain context.
+ * Compatible with viem Log shape; chainContext is filled in by the subscriber.
+ */
+export interface StakingRawLogInput {
+    address: string;
+    topics: readonly string[];
+    data: string;
+    blockNumber: string | bigint;
+    blockHash: string;
+    transactionHash: string;
+    transactionIndex: string | number;
+    logIndex: string | number;
+    removed?: boolean;
+    chainContext?: StakingLogChainContext;
+}
+
+// ============================================================================
+// VALIDATION
+// ============================================================================
+
+export type ValidateStakingEventResult =
+    | { valid: true; eventType: ValidStakingEventType }
+    | { valid: false; reason: 'wrong_contract' | 'unknown_event' | 'missing_topics' | 'wrong_owner' };
+
+/**
+ * Validate a raw staking-vault event log against the expected vault and owner.
+ *
+ * Owner-indexed events (Stake / YieldTargetSet / PartialUnstakeBpsSet / Unstake /
+ * ClaimRewards / FlashCloseInitiated) check `topics[1] === ownerAddress`.
+ * The Swap event has the executor in topics[1], so no owner check is performed.
+ */
+export function validateStakingEvent(
+    vaultAddress: string,
+    ownerAddress: string,
+    log: StakingRawLogInput,
+): ValidateStakingEventResult {
+    if (log.address.toLowerCase() !== vaultAddress.toLowerCase()) {
+        return { valid: false, reason: 'wrong_contract' };
+    }
+
+    if (!log.topics || log.topics.length < 1) {
+        return { valid: false, reason: 'missing_topics' };
+    }
+
+    const topic0 = log.topics[0]?.toLowerCase();
+    let eventType: ValidStakingEventType | null = null;
+    for (const [type, signature] of Object.entries(STAKING_VAULT_EVENT_SIGNATURES)) {
+        if (topic0 === signature.toLowerCase()) {
+            eventType = type as ValidStakingEventType;
+            break;
+        }
+    }
+    if (!eventType) {
+        return { valid: false, reason: 'unknown_event' };
+    }
+
+    if (eventType === 'SWAP') {
+        // Executor-indexed; no owner check.
+        if (log.topics.length < 2) return { valid: false, reason: 'missing_topics' };
+        return { valid: true, eventType };
+    }
+
+    // Owner-indexed events: topic[1] must match ownerAddress.
+    if (log.topics.length < 2) return { valid: false, reason: 'missing_topics' };
+    const ownerHex = '0x' + ownerAddress.toLowerCase().slice(2).padStart(64, '0');
+    if (log.topics[1]?.toLowerCase() !== ownerHex) {
+        return { valid: false, reason: 'wrong_owner' };
+    }
+
+    return { valid: true, eventType };
+}
+
+// ============================================================================
+// DECODING
+// ============================================================================
+
+export interface DecodedStakeData {
+    eventType: 'STAKE';
+    owner: string;
+    base: bigint;
+    quote: bigint;
+    yieldTarget: bigint;
+    tokenId: bigint;
+}
+
+export interface DecodedYieldTargetSetData {
+    eventType: 'YIELD_TARGET_SET';
+    owner: string;
+    oldTarget: bigint;
+    newTarget: bigint;
+}
+
+export interface DecodedPartialUnstakeBpsSetData {
+    eventType: 'PARTIAL_UNSTAKE_BPS_SET';
+    owner: string;
+    oldBps: number;
+    newBps: number;
+}
+
+export interface DecodedSwapData {
+    eventType: 'SWAP';
+    executor: string;
+    tokenIn: string;
+    amountIn: bigint;
+    tokenOut: string;
+    amountOut: bigint;
+    effectiveBps: number;
+}
+
+export interface DecodedUnstakeData {
+    eventType: 'UNSTAKE';
+    owner: string;
+    base: bigint;
+    quote: bigint;
+}
+
+export interface DecodedClaimRewardsData {
+    eventType: 'CLAIM_REWARDS';
+    owner: string;
+    baseAmount: bigint;
+    quoteAmount: bigint;
+}
+
+export interface DecodedFlashCloseInitiatedData {
+    eventType: 'FLASH_CLOSE_INITIATED';
+    owner: string;
+    bps: number;
+    callbackTarget: string;
+    data: string;
+}
+
+export type DecodedStakingLogData =
+    | DecodedStakeData
+    | DecodedYieldTargetSetData
+    | DecodedPartialUnstakeBpsSetData
+    | DecodedSwapData
+    | DecodedUnstakeData
+    | DecodedClaimRewardsData
+    | DecodedFlashCloseInitiatedData;
+
+function topicToAddress(topic: string | undefined): string {
+    return '0x' + (topic?.slice(26) ?? '');
+}
+
+/**
+ * Decode the ABI-encoded data + indexed topics for a staking-vault event.
+ */
+export function decodeStakingLogData(
+    eventType: ValidStakingEventType,
+    data: string,
+    topics: readonly string[],
+): DecodedStakingLogData {
+    const dataHex = (data.startsWith('0x') ? data.slice(2) : data);
+    switch (eventType) {
+        case 'STAKE': {
+            // Stake(address indexed owner, uint256 base, uint256 quote, uint256 yieldTarget, uint256 tokenId)
+            const owner = topicToAddress(topics[1]);
+            const decoded = decodeAbiParameters(
+                [
+                    { name: 'base', type: 'uint256' },
+                    { name: 'quote', type: 'uint256' },
+                    { name: 'yieldTarget', type: 'uint256' },
+                    { name: 'tokenId', type: 'uint256' },
+                ],
+                `0x${dataHex}` as `0x${string}`,
+            );
+            return {
+                eventType: 'STAKE',
+                owner,
+                base: decoded[0],
+                quote: decoded[1],
+                yieldTarget: decoded[2],
+                tokenId: decoded[3],
+            };
+        }
+        case 'YIELD_TARGET_SET': {
+            // YieldTargetSet(address indexed owner, uint256 oldTarget, uint256 newTarget)
+            const owner = topicToAddress(topics[1]);
+            const decoded = decodeAbiParameters(
+                [
+                    { name: 'oldTarget', type: 'uint256' },
+                    { name: 'newTarget', type: 'uint256' },
+                ],
+                `0x${dataHex}` as `0x${string}`,
+            );
+            return {
+                eventType: 'YIELD_TARGET_SET',
+                owner,
+                oldTarget: decoded[0],
+                newTarget: decoded[1],
+            };
+        }
+        case 'PARTIAL_UNSTAKE_BPS_SET': {
+            // PartialUnstakeBpsSet(address indexed owner, uint16 oldBps, uint16 newBps)
+            const owner = topicToAddress(topics[1]);
+            const decoded = decodeAbiParameters(
+                [
+                    { name: 'oldBps', type: 'uint16' },
+                    { name: 'newBps', type: 'uint16' },
+                ],
+                `0x${dataHex}` as `0x${string}`,
+            );
+            return {
+                eventType: 'PARTIAL_UNSTAKE_BPS_SET',
+                owner,
+                oldBps: Number(decoded[0]),
+                newBps: Number(decoded[1]),
+            };
+        }
+        case 'SWAP': {
+            // Swap(address indexed executor, address tokenIn, uint256 amountIn, address tokenOut, uint256 amountOut, uint16 effectiveBps)
+            const executor = topicToAddress(topics[1]);
+            const decoded = decodeAbiParameters(
+                [
+                    { name: 'tokenIn', type: 'address' },
+                    { name: 'amountIn', type: 'uint256' },
+                    { name: 'tokenOut', type: 'address' },
+                    { name: 'amountOut', type: 'uint256' },
+                    { name: 'effectiveBps', type: 'uint16' },
+                ],
+                `0x${dataHex}` as `0x${string}`,
+            );
+            return {
+                eventType: 'SWAP',
+                executor,
+                tokenIn: decoded[0],
+                amountIn: decoded[1],
+                tokenOut: decoded[2],
+                amountOut: decoded[3],
+                effectiveBps: Number(decoded[4]),
+            };
+        }
+        case 'UNSTAKE': {
+            // Unstake(address indexed owner, uint256 base, uint256 quote)
+            const owner = topicToAddress(topics[1]);
+            const decoded = decodeAbiParameters(
+                [
+                    { name: 'base', type: 'uint256' },
+                    { name: 'quote', type: 'uint256' },
+                ],
+                `0x${dataHex}` as `0x${string}`,
+            );
+            return {
+                eventType: 'UNSTAKE',
+                owner,
+                base: decoded[0],
+                quote: decoded[1],
+            };
+        }
+        case 'CLAIM_REWARDS': {
+            // ClaimRewards(address indexed owner, uint256 baseAmount, uint256 quoteAmount)
+            const owner = topicToAddress(topics[1]);
+            const decoded = decodeAbiParameters(
+                [
+                    { name: 'baseAmount', type: 'uint256' },
+                    { name: 'quoteAmount', type: 'uint256' },
+                ],
+                `0x${dataHex}` as `0x${string}`,
+            );
+            return {
+                eventType: 'CLAIM_REWARDS',
+                owner,
+                baseAmount: decoded[0],
+                quoteAmount: decoded[1],
+            };
+        }
+        case 'FLASH_CLOSE_INITIATED': {
+            // FlashCloseInitiated(address indexed owner, uint16 bps, address indexed callbackTarget, bytes data)
+            const owner = topicToAddress(topics[1]);
+            const callbackTarget = topicToAddress(topics[2]);
+            const decoded = decodeAbiParameters(
+                [
+                    { name: 'bps', type: 'uint16' },
+                    { name: 'data', type: 'bytes' },
+                ],
+                `0x${dataHex}` as `0x${string}`,
+            );
+            return {
+                eventType: 'FLASH_CLOSE_INITIATED',
+                owner,
+                bps: Number(decoded[0]),
+                callbackTarget,
+                data: decoded[1],
+            };
+        }
+    }
+}
+
+// ============================================================================
+// CREATE INPUT
+// ============================================================================
+
+export interface CreateStakingLedgerEventInput {
+    previousId: string | null;
+    timestamp: Date;
+    eventType: EventType;
+    inputHash: string;
+    tokenValue: bigint;
+    rewards: Reward[];
+    deltaCostBasis: bigint;
+    costBasisAfter: bigint;
+    deltaPnl: bigint;
+    pnlAfter: bigint;
+    deltaCollectedYield: bigint;
+    collectedYieldAfter: bigint;
+    deltaRealizedCashflow: bigint;
+    realizedCashflowAfter: bigint;
+    config: UniswapV3StakingLedgerEventConfig;
+    state: UniswapV3StakingLedgerEventState;
+}
+
+// ============================================================================
+// AGGREGATES
+// ============================================================================
+
+export interface StakingLedgerAggregates {
+    liquidityAfter: bigint;
+    costBasisAfter: bigint;
+    realizedPnlAfter: bigint;
+    collectedYieldAfter: bigint;
+    realizedCashflowAfter: bigint;
+}
+
+// ============================================================================
+// IMPORT RESULT
+// ============================================================================
+
+export type StakingSingleLogResult =
+    | {
+          action: 'inserted';
+          inputHash: string;
+          eventDetail: {
+              eventType: EventType;
+              tokenValue: bigint;
+              blockTimestamp: Date;
+          };
+          reorgDeletedEvents?: UniswapV3StakingPositionLedgerEvent[];
+      }
+    | { action: 'removed'; inputHash: string; deletedEvents: UniswapV3StakingPositionLedgerEvent[]; blockHash: string }
+    | { action: 'skipped'; reason: 'already_exists' | 'invalid_event' | 'folded_into_flash_close' | 'standalone_drain' };
+
+export interface StakingImportLogsResult {
+    perLogResults: StakingSingleLogResult[];
+    allDeletedEvents: UniswapV3StakingPositionLedgerEvent[];
+    preImportAggregates: StakingLedgerAggregates;
+    postImportAggregates: StakingLedgerAggregates;
+}
+
+// ============================================================================
+// UPDATE AGGREGATES INPUT
+// ============================================================================
+
+interface UpdateStakingEventAggregatesInput {
+    previousId: string | null;
+    deltaCostBasis: bigint;
+    costBasisAfter: bigint;
+    deltaPnl: bigint;
+    pnlAfter: bigint;
+    deltaCollectedYield: bigint;
+    collectedYieldAfter: bigint;
+}
+
+// ============================================================================
+// SERVICE CONFIG
+// ============================================================================
+
+export interface UniswapV3StakingLedgerServiceConfig {
+    positionId: string;
+}
+
+export interface UniswapV3StakingLedgerServiceDependencies {
+    prisma?: PrismaClient;
+}
+
+// ============================================================================
+// SERVICE
+// ============================================================================
+
+export class UniswapV3StakingLedgerService {
+    private readonly prisma: PrismaClient;
+    private readonly positionId: string;
+    private readonly protocol = 'uniswapv3-staking' as const;
+    private readonly logger: ServiceLogger;
+
+    constructor(
+        config: UniswapV3StakingLedgerServiceConfig,
+        deps: UniswapV3StakingLedgerServiceDependencies = {},
+    ) {
+        this.positionId = config.positionId;
+        this.prisma = deps.prisma ?? prismaClient;
+        this.logger = createServiceLogger('uniswapv3-staking-ledger');
+    }
+
+    // ============================================================================
+    // STATIC HELPERS
+    // ============================================================================
+
+    /**
+     * Deterministic, reorg-safe inputHash for dedup.
+     * Format: `uniswapv3-staking/{chainId}/{txHash}/{blockHash}/{logIndex}`
+     */
+    static createHash(
+        chainId: number,
+        txHash: string,
+        blockHash: string,
+        logIndex: number,
+    ): string {
+        return `uniswapv3-staking/${chainId}/${txHash}/${blockHash}/${logIndex}`;
+    }
+
+    /**
+     * Sort events by blockchain coordinates (blockNumber ASC, logIndex ASC).
+     */
+    private static sortByBlockchainCoordinates<
+        T extends { typedConfig: { blockNumber: bigint; logIndex: number } },
+    >(events: T[]): T[] {
+        return events.sort((a, b) => {
+            const aConfig = a.typedConfig;
+            const bConfig = b.typedConfig;
+            if (aConfig.blockNumber !== bConfig.blockNumber) {
+                return aConfig.blockNumber < bConfig.blockNumber ? -1 : 1;
+            }
+            return aConfig.logIndex - bConfig.logIndex;
+        });
+    }
+
+    // ============================================================================
+    // QUERY METHODS
+    // ============================================================================
+
+    async findIdByHash(
+        inputHash: string,
+        tx?: PrismaTransactionClient,
+    ): Promise<string | null> {
+        const db = tx ?? this.prisma;
+        const result = await db.positionLedgerEvent.findFirst({
+            where: { positionId: this.positionId, inputHash },
+            select: { id: true },
+        });
+        return result?.id ?? null;
+    }
+
+    async findByTxHash(
+        txHash: string,
+        tx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPositionLedgerEvent[]> {
+        const db = tx ?? this.prisma;
+        const results = await db.positionLedgerEvent.findMany({
+            where: {
+                positionId: this.positionId,
+                config: { path: ['txHash'], equals: txHash },
+            },
+        });
+        return results.map((r) =>
+            UniswapV3StakingPositionLedgerEvent.fromDB(
+                r as unknown as UniswapV3StakingPositionLedgerEventRow,
+            ),
+        );
+    }
+
+    async findAll(tx?: PrismaTransactionClient): Promise<UniswapV3StakingPositionLedgerEvent[]> {
+        const db = tx ?? this.prisma;
+        const results = await db.$queryRaw<unknown[]>`
+            SELECT * FROM position_ledger_events
+            WHERE "positionId" = ${this.positionId}
+            ORDER BY (config->>'blockNumber')::BIGINT DESC,
+                     (config->>'logIndex')::INTEGER DESC
+        `;
+        return results.map((r) =>
+            UniswapV3StakingPositionLedgerEvent.fromDB(
+                r as unknown as UniswapV3StakingPositionLedgerEventRow,
+            ),
+        );
+    }
+
+    async findLast(tx?: PrismaTransactionClient): Promise<UniswapV3StakingPositionLedgerEvent | null> {
+        const db = tx ?? this.prisma;
+        const results = await db.$queryRaw<unknown[]>`
+            SELECT * FROM position_ledger_events
+            WHERE "positionId" = ${this.positionId}
+            ORDER BY (config->>'blockNumber')::BIGINT DESC,
+                     (config->>'logIndex')::INTEGER DESC
+            LIMIT 1
+        `;
+        if (results.length === 0) return null;
+        return UniswapV3StakingPositionLedgerEvent.fromDB(
+            results[0] as unknown as UniswapV3StakingPositionLedgerEventRow,
+        );
+    }
+
+    // ============================================================================
+    // CRUD METHODS
+    // ============================================================================
+
+    async create(
+        input: CreateStakingLedgerEventInput,
+        tx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPositionLedgerEvent> {
+        const db = tx ?? this.prisma;
+        const result = await db.positionLedgerEvent.create({
+            data: {
+                positionId: this.positionId,
+                protocol: this.protocol,
+                previousId: input.previousId,
+                timestamp: input.timestamp,
+                eventType: input.eventType,
+                inputHash: input.inputHash,
+                tokenValue: input.tokenValue.toString(),
+                rewards: input.rewards.map((r) => ({
+                    tokenId: r.tokenId,
+                    tokenAmount: r.tokenAmount.toString(),
+                    tokenValue: r.tokenValue.toString(),
+                })),
+                deltaCostBasis: input.deltaCostBasis.toString(),
+                costBasisAfter: input.costBasisAfter.toString(),
+                deltaPnl: input.deltaPnl.toString(),
+                pnlAfter: input.pnlAfter.toString(),
+                deltaCollectedYield: input.deltaCollectedYield.toString(),
+                collectedYieldAfter: input.collectedYieldAfter.toString(),
+                deltaRealizedCashflow: input.deltaRealizedCashflow.toString(),
+                realizedCashflowAfter: input.realizedCashflowAfter.toString(),
+                config: stakingLedgerEventConfigToJSON(input.config) as object,
+                state: stakingLedgerEventStateToJSON(input.state) as object,
+            },
+        });
+        return UniswapV3StakingPositionLedgerEvent.fromDB(
+            result as unknown as UniswapV3StakingPositionLedgerEventRow,
+        );
+    }
+
+    async deleteAll(tx?: PrismaTransactionClient): Promise<void> {
+        const db = tx ?? this.prisma;
+        await db.positionLedgerEvent.deleteMany({
+            where: { positionId: this.positionId },
+        });
+    }
+
+    async deleteAllByBlockHash(
+        blockHash: string,
+        tx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPositionLedgerEvent[]> {
+        const db = tx ?? this.prisma;
+        const toDelete = await db.positionLedgerEvent.findMany({
+            where: {
+                positionId: this.positionId,
+                config: { path: ['blockHash'], equals: blockHash },
+            },
+        });
+
+        if (toDelete.length > 0) {
+            await db.positionLedgerEvent.deleteMany({
+                where: { id: { in: toDelete.map((e) => e.id) } },
+            });
+        }
+
+        return toDelete.map((r) =>
+            UniswapV3StakingPositionLedgerEvent.fromDB(
+                r as unknown as UniswapV3StakingPositionLedgerEventRow,
+            ),
+        );
+    }
+
+    // ============================================================================
+    // IMPORT ORCHESTRATOR
+    // ============================================================================
+
+    /**
+     * Import raw blockchain logs and recalculate all aggregates.
+     *
+     * Two-pass:
+     * 1. Insert events with placeholder zeros for running totals.
+     * 2. `recalculateAggregates` rebuilds all running totals chronologically.
+     *
+     * FlashClose composition is handled here: same-tx
+     * `FlashCloseInitiated + Unstake + ClaimRewards` are folded into a single
+     * synthesized `STAKING_DISPOSE` event keyed on the FlashCloseInitiated log.
+     */
+    async importLogsForPosition(
+        position: { typedConfig: { isToken0Quote: boolean; vaultAddress: string; poolAddress: string } },
+        chainId: number,
+        ownerAddress: string,
+        logs: StakingRawLogInput[],
+        poolPriceService: UniswapV3PoolPriceService,
+        tx?: PrismaTransactionClient,
+    ): Promise<StakingImportLogsResult> {
+        const preImportAggregates = await this.recalculateAggregates(
+            position.typedConfig.isToken0Quote,
+            tx,
+        );
+
+        const vaultAddrLower = position.typedConfig.vaultAddress.toLowerCase();
+
+        // Collect FlashClose-tx companion events keyed by txHash for composition.
+        const flashCloseTxHashes = new Set<string>();
+        const unstakeByTx = new Map<string, StakingRawLogInput>();
+        const claimRewardsByTx = new Map<string, StakingRawLogInput>();
+        for (const log of logs) {
+            if (log.address.toLowerCase() !== vaultAddrLower) continue;
+            const topic0 = log.topics[0]?.toLowerCase();
+            const txHash = log.transactionHash.toLowerCase();
+            if (topic0 === STAKING_VAULT_EVENT_SIGNATURES.FLASH_CLOSE_INITIATED.toLowerCase()) {
+                flashCloseTxHashes.add(txHash);
+            } else if (topic0 === STAKING_VAULT_EVENT_SIGNATURES.UNSTAKE.toLowerCase()) {
+                unstakeByTx.set(txHash, log);
+            } else if (topic0 === STAKING_VAULT_EVENT_SIGNATURES.CLAIM_REWARDS.toLowerCase()) {
+                claimRewardsByTx.set(txHash, log);
+            }
+        }
+
+        const perLogResults: StakingSingleLogResult[] = [];
+        const allDeletedEvents: UniswapV3StakingPositionLedgerEvent[] = [];
+
+        for (const log of logs) {
+            const result = await this.processSingleLog(
+                position, chainId, ownerAddress, log, poolPriceService,
+                flashCloseTxHashes, unstakeByTx, claimRewardsByTx,
+                tx,
+            );
+            perLogResults.push(result);
+            if (result.action === 'removed') {
+                allDeletedEvents.push(...result.deletedEvents);
+            } else if (result.action === 'inserted' && result.reorgDeletedEvents) {
+                allDeletedEvents.push(...result.reorgDeletedEvents);
+            }
+        }
+
+        const postImportAggregates = await this.recalculateAggregates(
+            position.typedConfig.isToken0Quote,
+            tx,
+        );
+
+        return { perLogResults, allDeletedEvents, preImportAggregates, postImportAggregates };
+    }
+
+    // ============================================================================
+    // SINGLE LOG PROCESSOR
+    // ============================================================================
+
+    private async processSingleLog(
+        position: { typedConfig: { isToken0Quote: boolean; vaultAddress: string; poolAddress: string } },
+        chainId: number,
+        ownerAddress: string,
+        log: StakingRawLogInput,
+        poolPriceService: UniswapV3PoolPriceService,
+        flashCloseTxHashes: Set<string>,
+        unstakeByTx: Map<string, StakingRawLogInput>,
+        claimRewardsByTx: Map<string, StakingRawLogInput>,
+        tx?: PrismaTransactionClient,
+    ): Promise<StakingSingleLogResult> {
+        // 1. Validate
+        const validation = validateStakingEvent(
+            position.typedConfig.vaultAddress, ownerAddress, log,
+        );
+        if (!validation.valid) {
+            this.logger.debug({ reason: validation.reason }, 'Invalid staking event skipped');
+            return { action: 'skipped', reason: 'invalid_event' };
+        }
+
+        const txHash = log.transactionHash.toLowerCase();
+        const txIsFlashClose = flashCloseTxHashes.has(txHash);
+
+        // 2. Suppress UNSTAKE / CLAIM_REWARDS:
+        //    - In flashClose tx: folded into the FlashCloseInitiated -> STAKING_DISPOSE event.
+        //    - Standalone (owner-driven drain): no ledger impact (cost-basis was already
+        //      booked at the prior Swap/FlashClose event; drains only move buffer balances
+        //      to the owner wallet).
+        if (validation.eventType === 'UNSTAKE' || validation.eventType === 'CLAIM_REWARDS') {
+            return {
+                action: 'skipped',
+                reason: txIsFlashClose ? 'folded_into_flash_close' : 'standalone_drain',
+            };
+        }
+
+        // 3. Parse numeric coordinates
+        const logIndex = typeof log.logIndex === 'string'
+            ? parseInt(log.logIndex, log.logIndex.startsWith('0x') ? 16 : 10)
+            : log.logIndex;
+        const txIndex = typeof log.transactionIndex === 'string'
+            ? parseInt(log.transactionIndex, log.transactionIndex.startsWith('0x') ? 16 : 10)
+            : log.transactionIndex;
+        const blockNumber = typeof log.blockNumber === 'string'
+            ? BigInt(log.blockNumber)
+            : log.blockNumber;
+
+        // 4. inputHash
+        const inputHash = UniswapV3StakingLedgerService.createHash(
+            chainId, log.transactionHash, log.blockHash, logIndex,
+        );
+
+        // 5. Active reorg
+        if (log.removed) {
+            const deletedEvents = await this.deleteAllByBlockHash(log.blockHash, tx);
+            if (deletedEvents.length > 0) {
+                this.logger.info(
+                    { blockHash: log.blockHash, deletedCount: deletedEvents.length },
+                    'Staking events removed due to reorg',
+                );
+            }
+            return { action: 'removed', inputHash, deletedEvents, blockHash: log.blockHash };
+        }
+
+        // 6. Dedup
+        const existingId = await this.findIdByHash(inputHash, tx);
+        if (existingId) {
+            return { action: 'skipped', reason: 'already_exists' };
+        }
+
+        // 7. Catch-up reorg
+        let reorgDeletedEvents: UniswapV3StakingPositionLedgerEvent[] | undefined;
+        const eventsWithSameTxHash = await this.findByTxHash(log.transactionHash, tx);
+        for (const existing of eventsWithSameTxHash) {
+            const existingBlockHash = existing.typedConfig.blockHash;
+            if (existingBlockHash !== log.blockHash) {
+                this.logger.debug(
+                    { txHash: log.transactionHash, orphanedBlockHash: existingBlockHash, canonicalBlockHash: log.blockHash },
+                    'Catch-up reorg detected for staking event',
+                );
+                reorgDeletedEvents = await this.deleteAllByBlockHash(existingBlockHash, tx);
+                break;
+            }
+        }
+
+        // 8. Pool price at event block
+        const poolPrice = await poolPriceService.discover(
+            { chainId, poolAddress: position.typedConfig.poolAddress },
+            { blockNumber: Number(blockNumber), blockHash: log.blockHash },
+        );
+        const sqrtPriceX96 = poolPrice.sqrtPriceX96;
+        const blockTimestamp = poolPrice.timestamp;
+
+        // 9. Decode + branch on event type
+        const decoded = decodeStakingLogData(validation.eventType, log.data, log.topics);
+
+        let eventType: EventType;
+        let tokenValue: bigint;
+        let ledgerState: UniswapV3StakingLedgerEventState;
+        let ledgerConfig: UniswapV3StakingLedgerEventConfig;
+        const isToken0Quote = position.typedConfig.isToken0Quote;
+
+        switch (decoded.eventType) {
+            case 'STAKE': {
+                const ctx = log.chainContext ?? {};
+                if (ctx.liquidityAfter === undefined) {
+                    throw new Error(
+                        `Missing chainContext.liquidityAfter for STAKE log at ${log.transactionHash}:${logIndex}`,
+                    );
+                }
+
+                // Disambiguate initial vs top-up:
+                //  - If a prior STAKING_DEPOSIT exists for this position → top-up.
+                //  - Else if vault.state() at block-1 was Empty → initial.
+                //  - Else if vault.state() at block-1 was Staked → top-up.
+                const last = await this.findLast(tx);
+                const hasPriorDeposit = last !== null;
+                let isInitial: boolean;
+                if (hasPriorDeposit) {
+                    isInitial = false;
+                } else if (ctx.vaultStateBefore === 'Empty') {
+                    isInitial = true;
+                } else if (ctx.vaultStateBefore === 'Staked') {
+                    isInitial = false;
+                } else if (ctx.vaultStateBefore === undefined) {
+                    // Conservative default: no prior event → treat as initial.
+                    isInitial = true;
+                } else {
+                    throw new Error(
+                        `Stake event in unexpected vaultStateBefore=${ctx.vaultStateBefore} (tx=${log.transactionHash})`,
+                    );
+                }
+
+                const liquidityBefore = isInitial
+                    ? 0n
+                    : (last?.typedConfig.liquidityAfter ?? ctx.liquidityBefore ?? 0n);
+                const deltaL = ctx.liquidityAfter - liquidityBefore;
+
+                eventType = 'STAKING_DEPOSIT';
+                tokenValue = this.valueOfBaseAndQuote(
+                    decoded.base, decoded.quote, sqrtPriceX96, isToken0Quote,
+                );
+
+                ledgerState = {
+                    eventType: 'STAKING_DEPOSIT',
+                    isInitial,
+                    owner: decoded.owner,
+                    baseAmount: decoded.base,
+                    quoteAmount: decoded.quote,
+                    yieldTarget: decoded.yieldTarget,
+                    underlyingTokenId: Number(decoded.tokenId),
+                    poolPrice: sqrtPriceX96,
+                    tokenAmounts: this.tokenAmountsForBaseQuote(
+                        decoded.base, decoded.quote, isToken0Quote,
+                    ),
+                };
+                ledgerConfig = this.buildBaseConfig(
+                    chainId, position.typedConfig.vaultAddress,
+                    blockNumber, txIndex, logIndex,
+                    log.transactionHash, log.blockHash,
+                    deltaL, ctx.liquidityAfter,
+                    /* effectiveBps */ 10000, sqrtPriceX96,
+                    /* dispose split */ 0n, 0n, 0n, 0n, 0n, 0n,
+                    /* source */ null,
+                );
+                break;
+            }
+
+            case 'YIELD_TARGET_SET': {
+                eventType = 'STAKING_YIELD_TARGET_SET';
+                tokenValue = 0n;
+                const last = await this.findLast(tx);
+                const liquidityAfter = last?.typedConfig.liquidityAfter ?? 0n;
+                ledgerState = {
+                    eventType: 'STAKING_YIELD_TARGET_SET',
+                    owner: decoded.owner,
+                    oldTarget: decoded.oldTarget,
+                    newTarget: decoded.newTarget,
+                    poolPrice: sqrtPriceX96,
+                    tokenAmounts: [0n, 0n],
+                };
+                ledgerConfig = this.buildBaseConfig(
+                    chainId, position.typedConfig.vaultAddress,
+                    blockNumber, txIndex, logIndex,
+                    log.transactionHash, log.blockHash,
+                    /* deltaL */ 0n, liquidityAfter,
+                    /* effectiveBps */ 0, sqrtPriceX96,
+                    0n, 0n, 0n, 0n, 0n, 0n,
+                    null,
+                );
+                break;
+            }
+
+            case 'PARTIAL_UNSTAKE_BPS_SET': {
+                eventType = 'STAKING_PENDING_BPS_SET';
+                tokenValue = 0n;
+                const last = await this.findLast(tx);
+                const liquidityAfter = last?.typedConfig.liquidityAfter ?? 0n;
+                ledgerState = {
+                    eventType: 'STAKING_PENDING_BPS_SET',
+                    owner: decoded.owner,
+                    oldBps: decoded.oldBps,
+                    newBps: decoded.newBps,
+                    poolPrice: sqrtPriceX96,
+                    tokenAmounts: [0n, 0n],
+                };
+                ledgerConfig = this.buildBaseConfig(
+                    chainId, position.typedConfig.vaultAddress,
+                    blockNumber, txIndex, logIndex,
+                    log.transactionHash, log.blockHash,
+                    0n, liquidityAfter,
+                    0, sqrtPriceX96,
+                    0n, 0n, 0n, 0n, 0n, 0n,
+                    null,
+                );
+                break;
+            }
+
+            case 'SWAP': {
+                const ctx = log.chainContext ?? {};
+                if (
+                    ctx.liquidityAfter === undefined ||
+                    ctx.stakedBaseBefore === undefined ||
+                    ctx.stakedQuoteBefore === undefined ||
+                    ctx.rewardBufferBaseDelta === undefined ||
+                    ctx.rewardBufferQuoteDelta === undefined
+                ) {
+                    throw new Error(
+                        `Missing chainContext fields for SWAP log at ${log.transactionHash}:${logIndex}`,
+                    );
+                }
+                const bps = BigInt(decoded.effectiveBps);
+                const principalBase = (ctx.stakedBaseBefore * bps) / 10000n;
+                const principalQuote = (ctx.stakedQuoteBefore * bps) / 10000n;
+                const yieldBase = ctx.rewardBufferBaseDelta;
+                const yieldQuote = ctx.rewardBufferQuoteDelta;
+
+                const principalQuoteValue = this.valueOfBaseAndQuote(
+                    principalBase, principalQuote, sqrtPriceX96, isToken0Quote,
+                );
+                const yieldQuoteValue = this.valueOfBaseAndQuote(
+                    yieldBase, yieldQuote, sqrtPriceX96, isToken0Quote,
+                );
+
+                const last = await this.findLast(tx);
+                const liquidityBefore = last?.typedConfig.liquidityAfter ?? 0n;
+                const deltaL = ctx.liquidityAfter - liquidityBefore;
+
+                eventType = 'STAKING_DISPOSE';
+                tokenValue = principalQuoteValue + yieldQuoteValue;
+
+                const totalBase = principalBase + yieldBase;
+                const totalQuote = principalQuote + yieldQuote;
+                ledgerState = {
+                    eventType: 'STAKING_DISPOSE',
+                    source: 'swap',
+                    effectiveBps: decoded.effectiveBps,
+                    initiator: decoded.executor,
+                    principalBase, principalQuote, yieldBase, yieldQuote,
+                    tokenIn: decoded.tokenIn,
+                    tokenOut: decoded.tokenOut,
+                    amountIn: decoded.amountIn,
+                    amountOut: decoded.amountOut,
+                    poolPrice: sqrtPriceX96,
+                    tokenAmounts: this.tokenAmountsForBaseQuote(
+                        totalBase, totalQuote, isToken0Quote,
+                    ),
+                };
+                ledgerConfig = this.buildBaseConfig(
+                    chainId, position.typedConfig.vaultAddress,
+                    blockNumber, txIndex, logIndex,
+                    log.transactionHash, log.blockHash,
+                    deltaL, ctx.liquidityAfter,
+                    decoded.effectiveBps, sqrtPriceX96,
+                    principalBase, principalQuote, yieldBase, yieldQuote,
+                    principalQuoteValue, yieldQuoteValue,
+                    'swap',
+                );
+                break;
+            }
+
+            case 'FLASH_CLOSE_INITIATED': {
+                const ctx = log.chainContext ?? {};
+                if (ctx.liquidityAfter === undefined) {
+                    throw new Error(
+                        `Missing chainContext.liquidityAfter for FLASH_CLOSE_INITIATED log at ${log.transactionHash}:${logIndex}`,
+                    );
+                }
+                const unstakeLog = unstakeByTx.get(txHash);
+                const claimLog = claimRewardsByTx.get(txHash);
+                if (!unstakeLog || !claimLog) {
+                    throw new Error(
+                        `Missing companion Unstake/ClaimRewards for FlashClose tx ${log.transactionHash}`,
+                    );
+                }
+                const decodedUnstake = decodeStakingLogData(
+                    'UNSTAKE', unstakeLog.data, unstakeLog.topics,
+                ) as DecodedUnstakeData;
+                const decodedClaim = decodeStakingLogData(
+                    'CLAIM_REWARDS', claimLog.data, claimLog.topics,
+                ) as DecodedClaimRewardsData;
+
+                const principalBase = decodedUnstake.base;
+                const principalQuote = decodedUnstake.quote;
+                const yieldBase = decodedClaim.baseAmount;
+                const yieldQuote = decodedClaim.quoteAmount;
+
+                const principalQuoteValue = this.valueOfBaseAndQuote(
+                    principalBase, principalQuote, sqrtPriceX96, isToken0Quote,
+                );
+                const yieldQuoteValue = this.valueOfBaseAndQuote(
+                    yieldBase, yieldQuote, sqrtPriceX96, isToken0Quote,
+                );
+
+                const last = await this.findLast(tx);
+                const liquidityBefore = last?.typedConfig.liquidityAfter ?? 0n;
+                const deltaL = ctx.liquidityAfter - liquidityBefore;
+
+                eventType = 'STAKING_DISPOSE';
+                tokenValue = principalQuoteValue + yieldQuoteValue;
+
+                const totalBase = principalBase + yieldBase;
+                const totalQuote = principalQuote + yieldQuote;
+                ledgerState = {
+                    eventType: 'STAKING_DISPOSE',
+                    source: 'flashClose',
+                    effectiveBps: decoded.bps,
+                    initiator: decoded.owner,
+                    principalBase, principalQuote, yieldBase, yieldQuote,
+                    tokenIn: '0x0000000000000000000000000000000000000000',
+                    tokenOut: '0x0000000000000000000000000000000000000000',
+                    amountIn: 0n,
+                    amountOut: 0n,
+                    poolPrice: sqrtPriceX96,
+                    tokenAmounts: this.tokenAmountsForBaseQuote(
+                        totalBase, totalQuote, isToken0Quote,
+                    ),
+                };
+                ledgerConfig = this.buildBaseConfig(
+                    chainId, position.typedConfig.vaultAddress,
+                    blockNumber, txIndex, logIndex,
+                    log.transactionHash, log.blockHash,
+                    deltaL, ctx.liquidityAfter,
+                    decoded.bps, sqrtPriceX96,
+                    principalBase, principalQuote, yieldBase, yieldQuote,
+                    principalQuoteValue, yieldQuoteValue,
+                    'flashClose',
+                );
+                break;
+            }
+
+            // UNSTAKE / CLAIM_REWARDS handled above in step 2; cannot reach here.
+            case 'UNSTAKE':
+            case 'CLAIM_REWARDS':
+                throw new Error(
+                    `${decoded.eventType} reached the dispatch branch (should have been suppressed): ${log.transactionHash}:${logIndex}`,
+                );
+        }
+
+        const createInput: CreateStakingLedgerEventInput = {
+            previousId: null,
+            timestamp: blockTimestamp,
+            eventType,
+            inputHash,
+            tokenValue,
+            rewards: [],
+            // Placeholder zeros — recalculateAggregates rebuilds these.
+            deltaCostBasis: 0n,
+            costBasisAfter: 0n,
+            deltaPnl: 0n,
+            pnlAfter: 0n,
+            deltaCollectedYield: 0n,
+            collectedYieldAfter: 0n,
+            deltaRealizedCashflow: 0n,
+            realizedCashflowAfter: 0n,
+            config: ledgerConfig,
+            state: ledgerState,
+        };
+
+        await this.create(createInput, tx);
+
+        return {
+            action: 'inserted',
+            inputHash,
+            eventDetail: { eventType, tokenValue, blockTimestamp },
+            ...(reorgDeletedEvents !== undefined && { reorgDeletedEvents }),
+        };
+    }
+
+    // ============================================================================
+    // PNL ENGINE — MODEL A SEMANTICS
+    // ============================================================================
+
+    /**
+     * Recalculate all running totals by replaying events chronologically.
+     *
+     * Model A divergence from UniswapV3LedgerService:
+     * - STAKING_DISPOSE.deltaPnl = principalQuoteValue − proportionalCostBasis
+     *   (yield is NOT in PnL; it goes to deltaCollectedYield only)
+     *
+     * The `_isToken0Quote` parameter is unused at this layer because the
+     * principal/yield split is pre-computed in quote units at insert time
+     * (see `processSingleLog`). It is retained for signature parity with
+     * UniswapV3VaultLedgerService.recalculateAggregates.
+     */
+    async recalculateAggregates(
+        _isToken0Quote: boolean,
+        tx?: PrismaTransactionClient,
+    ): Promise<StakingLedgerAggregates> {
+        const events = await this.findAll(tx);
+
+        if (events.length === 0) {
+            return {
+                liquidityAfter: 0n,
+                costBasisAfter: 0n,
+                realizedPnlAfter: 0n,
+                collectedYieldAfter: 0n,
+                realizedCashflowAfter: 0n,
+            };
+        }
+
+        UniswapV3StakingLedgerService.sortByBlockchainCoordinates(events);
+
+        let liquidityAfter = 0n;
+        let costBasisAfter = 0n;
+        let pnlAfter = 0n;
+        let collectedYieldAfter = 0n;
+        let previousEventId: string | null = null;
+
+        for (const event of events) {
+            const state = event.typedState;
+            const config = event.typedConfig;
+
+            const previousLiquidity = liquidityAfter;
+            const previousCostBasis = costBasisAfter;
+            const previousPnl = pnlAfter;
+            const previousCollectedYield = collectedYieldAfter;
+
+            let deltaCostBasis = 0n;
+            let deltaPnl = 0n;
+            let deltaCollectedYield = 0n;
+
+            switch (state.eventType) {
+                case 'STAKING_DEPOSIT': {
+                    deltaCostBasis = event.tokenValue;
+                    costBasisAfter = previousCostBasis + deltaCostBasis;
+                    pnlAfter = previousPnl;
+                    collectedYieldAfter = previousCollectedYield;
+                    liquidityAfter = config.liquidityAfter;
+                    break;
+                }
+                case 'STAKING_DISPOSE': {
+                    const absDeltaL = config.deltaL < 0n ? -config.deltaL : config.deltaL;
+                    let proportionalCostBasis = 0n;
+                    if (previousLiquidity > 0n && absDeltaL > 0n) {
+                        proportionalCostBasis = (absDeltaL * previousCostBasis) / previousLiquidity;
+                    }
+                    deltaCostBasis = -proportionalCostBasis;
+                    costBasisAfter = previousCostBasis + deltaCostBasis;
+                    // Model A: yield excluded from PnL.
+                    deltaPnl = config.principalQuoteValue - proportionalCostBasis;
+                    pnlAfter = previousPnl + deltaPnl;
+                    deltaCollectedYield = config.yieldQuoteValue;
+                    collectedYieldAfter = previousCollectedYield + deltaCollectedYield;
+                    liquidityAfter = config.liquidityAfter;
+                    break;
+                }
+                case 'STAKING_YIELD_TARGET_SET':
+                case 'STAKING_PENDING_BPS_SET': {
+                    // Markers — no aggregate change.
+                    costBasisAfter = previousCostBasis;
+                    pnlAfter = previousPnl;
+                    collectedYieldAfter = previousCollectedYield;
+                    liquidityAfter = previousLiquidity;
+                    break;
+                }
+            }
+
+            await this.updateEventAggregates(
+                event.id,
+                {
+                    previousId: previousEventId,
+                    deltaCostBasis,
+                    costBasisAfter,
+                    deltaPnl,
+                    pnlAfter,
+                    deltaCollectedYield,
+                    collectedYieldAfter,
+                },
+                tx,
+            );
+
+            previousEventId = event.id;
+        }
+
+        return {
+            liquidityAfter,
+            costBasisAfter,
+            realizedPnlAfter: pnlAfter,
+            collectedYieldAfter,
+            realizedCashflowAfter: 0n,
+        };
+    }
+
+    // ============================================================================
+    // PRIVATE HELPERS
+    // ============================================================================
+
+    private async updateEventAggregates(
+        eventId: string,
+        updates: UpdateStakingEventAggregatesInput,
+        tx?: PrismaTransactionClient,
+    ): Promise<void> {
+        const db = tx ?? this.prisma;
+        await db.positionLedgerEvent.update({
+            where: { id: eventId },
+            data: {
+                previousId: updates.previousId,
+                deltaCostBasis: updates.deltaCostBasis.toString(),
+                costBasisAfter: updates.costBasisAfter.toString(),
+                deltaPnl: updates.deltaPnl.toString(),
+                pnlAfter: updates.pnlAfter.toString(),
+                deltaCollectedYield: updates.deltaCollectedYield.toString(),
+                collectedYieldAfter: updates.collectedYieldAfter.toString(),
+            },
+        });
+    }
+
+    /**
+     * Total quote-units value of (baseAmount × P + quoteAmount).
+     * Direction depends on isToken0Quote.
+     */
+    private valueOfBaseAndQuote(
+        baseAmount: bigint,
+        quoteAmount: bigint,
+        sqrtPriceX96: bigint,
+        isToken0Quote: boolean,
+    ): bigint {
+        if (isToken0Quote) {
+            // base = token1, quote = token0.
+            // valueOfToken1AmountInToken0 returns base value in quote units.
+            return valueOfToken1AmountInToken0(baseAmount, sqrtPriceX96) + quoteAmount;
+        } else {
+            // base = token0, quote = token1.
+            return valueOfToken0AmountInToken1(baseAmount, sqrtPriceX96) + quoteAmount;
+        }
+    }
+
+    /**
+     * Map (baseAmount, quoteAmount) → [token0Amount, token1Amount] for ledger state.
+     */
+    private tokenAmountsForBaseQuote(
+        baseAmount: bigint,
+        quoteAmount: bigint,
+        isToken0Quote: boolean,
+    ): bigint[] {
+        return isToken0Quote ? [quoteAmount, baseAmount] : [baseAmount, quoteAmount];
+    }
+
+    /**
+     * Build a base UniswapV3StakingLedgerEventConfig with all dispose-only
+     * fields zeroed when not applicable.
+     */
+    private buildBaseConfig(
+        chainId: number,
+        vaultAddress: string,
+        blockNumber: bigint,
+        txIndex: number,
+        logIndex: number,
+        txHash: string,
+        blockHash: string,
+        deltaL: bigint,
+        liquidityAfter: bigint,
+        effectiveBps: number,
+        sqrtPriceX96: bigint,
+        principalBaseDelta: bigint,
+        principalQuoteDelta: bigint,
+        yieldBaseDelta: bigint,
+        yieldQuoteDelta: bigint,
+        principalQuoteValue: bigint,
+        yieldQuoteValue: bigint,
+        source: 'swap' | 'flashClose' | null,
+    ): UniswapV3StakingLedgerEventConfig {
+        return {
+            chainId,
+            vaultAddress,
+            blockNumber,
+            txIndex,
+            logIndex,
+            txHash,
+            blockHash,
+            deltaL,
+            liquidityAfter,
+            effectiveBps,
+            sqrtPriceX96,
+            principalBaseDelta,
+            principalQuoteDelta,
+            yieldBaseDelta,
+            yieldQuoteDelta,
+            principalQuoteValue,
+            yieldQuoteValue,
+            source,
+        };
+    }
+}

--- a/packages/midcurve-shared/src/types/index.ts
+++ b/packages/midcurve-shared/src/types/index.ts
@@ -126,6 +126,11 @@ export {
   UniswapV3VaultPositionConfig,
   vaultPositionStateToJSON,
   vaultPositionStateFromJSON,
+  // Staking position
+  UniswapV3StakingPosition,
+  UniswapV3StakingPositionConfig,
+  stakingPositionStateToJSON,
+  stakingPositionStateFromJSON,
 } from './position/index.js';
 export type {
   PnLScenario,
@@ -140,6 +145,14 @@ export type {
   UniswapV3VaultPositionConfigJSON,
   UniswapV3VaultPositionState,
   UniswapV3VaultPositionStateJSON,
+  // Staking position types
+  UniswapV3StakingPositionParams,
+  UniswapV3StakingPositionRow,
+  UniswapV3StakingPositionConfigData,
+  UniswapV3StakingPositionConfigJSON,
+  UniswapV3StakingPositionState,
+  UniswapV3StakingPositionStateJSON,
+  StakingState,
 } from './position/index.js';
 
 // ============================================================================
@@ -247,6 +260,12 @@ export {
   vaultLedgerEventConfigFromJSON,
   vaultLedgerEventStateToJSON,
   vaultLedgerEventStateFromJSON,
+  // Staking ledger events
+  UniswapV3StakingPositionLedgerEvent,
+  stakingLedgerEventConfigToJSON,
+  stakingLedgerEventConfigFromJSON,
+  stakingLedgerEventStateToJSON,
+  stakingLedgerEventStateFromJSON,
 } from './position-ledger-event/index.js';
 export type {
   UniswapV3VaultLedgerEventConfig,
@@ -260,6 +279,18 @@ export type {
   UniswapV3VaultTransferOutEvent,
   UniswapV3VaultPositionLedgerEventParams,
   UniswapV3VaultPositionLedgerEventRow,
+  // Staking ledger event types
+  UniswapV3StakingLedgerEventConfig,
+  UniswapV3StakingLedgerEventConfigJSON,
+  UniswapV3StakingLedgerEventState,
+  UniswapV3StakingLedgerEventStateJSON,
+  UniswapV3StakingDepositEvent,
+  UniswapV3StakingDisposeEvent,
+  UniswapV3StakingYieldTargetSetEvent,
+  UniswapV3StakingPendingBpsSetEvent,
+  UniswapV3StakingPositionLedgerEventParams,
+  UniswapV3StakingPositionLedgerEventRow,
+  StakingDisposeSource,
 } from './position-ledger-event/index.js';
 
 // ============================================================================

--- a/packages/midcurve-shared/src/types/position-ledger-event/factory.ts
+++ b/packages/midcurve-shared/src/types/position-ledger-event/factory.ts
@@ -18,6 +18,10 @@ import {
   UniswapV3VaultPositionLedgerEvent,
   type UniswapV3VaultPositionLedgerEventRow,
 } from './uniswapv3-vault/uniswapv3-vault-position-ledger-event.js';
+import {
+  UniswapV3StakingPositionLedgerEvent,
+  type UniswapV3StakingPositionLedgerEventRow,
+} from './uniswapv3-staking/uniswapv3-staking-position-ledger-event.js';
 
 /**
  * PositionLedgerEventFactory
@@ -57,6 +61,11 @@ export class PositionLedgerEventFactory {
           row as UniswapV3VaultPositionLedgerEventRow
         );
 
+      case 'uniswapv3-staking':
+        return UniswapV3StakingPositionLedgerEvent.fromDB(
+          row as UniswapV3StakingPositionLedgerEventRow
+        );
+
       default:
         throw new Error(`Unknown ledger event protocol: ${row.protocol}`);
     }
@@ -69,6 +78,6 @@ export class PositionLedgerEventFactory {
    * @returns true if protocol is supported
    */
   static isSupported(protocol: string): protocol is LedgerEventProtocol {
-    return ['uniswapv3', 'uniswapv3-vault'].includes(protocol);
+    return ['uniswapv3', 'uniswapv3-vault', 'uniswapv3-staking'].includes(protocol);
   }
 }

--- a/packages/midcurve-shared/src/types/position-ledger-event/index.ts
+++ b/packages/midcurve-shared/src/types/position-ledger-event/index.ts
@@ -21,3 +21,6 @@ export * from './uniswapv3/index.js';
 
 // UniswapV3 Vault
 export * from './uniswapv3-vault/index.js';
+
+// UniswapV3 Staking
+export * from './uniswapv3-staking/index.js';

--- a/packages/midcurve-shared/src/types/position-ledger-event/position-ledger-event.types.ts
+++ b/packages/midcurve-shared/src/types/position-ledger-event/position-ledger-event.types.ts
@@ -11,7 +11,7 @@
 /**
  * Supported protocols for ledger events
  */
-export type LedgerEventProtocol = 'uniswapv3' | 'uniswapv3-vault';
+export type LedgerEventProtocol = 'uniswapv3' | 'uniswapv3-vault' | 'uniswapv3-staking';
 
 // ============================================================================
 // EVENT TYPES
@@ -42,7 +42,12 @@ export type EventType =
   | 'VAULT_COLLECT_YIELD'
   | 'VAULT_TRANSFER_IN'
   | 'VAULT_TRANSFER_OUT'
-  | 'VAULT_CLOSE_ORDER_EXECUTED';
+  | 'VAULT_CLOSE_ORDER_EXECUTED'
+  // Staking-vault events (SPEC-0003b)
+  | 'STAKING_DEPOSIT'
+  | 'STAKING_DISPOSE'
+  | 'STAKING_YIELD_TARGET_SET'
+  | 'STAKING_PENDING_BPS_SET';
 
 // ============================================================================
 // REWARD STRUCTURE

--- a/packages/midcurve-shared/src/types/position-ledger-event/uniswapv3-staking/index.ts
+++ b/packages/midcurve-shared/src/types/position-ledger-event/uniswapv3-staking/index.ts
@@ -1,0 +1,28 @@
+/**
+ * UniswapV3 Staking Ledger Event Exports
+ */
+
+export {
+  UniswapV3StakingPositionLedgerEvent,
+  type UniswapV3StakingPositionLedgerEventParams,
+  type UniswapV3StakingPositionLedgerEventRow,
+} from './uniswapv3-staking-position-ledger-event.js';
+
+export {
+  type UniswapV3StakingLedgerEventConfig,
+  type UniswapV3StakingLedgerEventConfigJSON,
+  type StakingDisposeSource,
+  stakingLedgerEventConfigToJSON,
+  stakingLedgerEventConfigFromJSON,
+} from './uniswapv3-staking-ledger-event-config.js';
+
+export {
+  type UniswapV3StakingLedgerEventState,
+  type UniswapV3StakingLedgerEventStateJSON,
+  type UniswapV3StakingDepositEvent,
+  type UniswapV3StakingDisposeEvent,
+  type UniswapV3StakingYieldTargetSetEvent,
+  type UniswapV3StakingPendingBpsSetEvent,
+  stakingLedgerEventStateToJSON,
+  stakingLedgerEventStateFromJSON,
+} from './uniswapv3-staking-ledger-event-state.js';

--- a/packages/midcurve-shared/src/types/position-ledger-event/uniswapv3-staking/uniswapv3-staking-ledger-event-config.ts
+++ b/packages/midcurve-shared/src/types/position-ledger-event/uniswapv3-staking/uniswapv3-staking-ledger-event-config.ts
@@ -1,0 +1,160 @@
+/**
+ * UniswapV3 Staking Ledger Event Configuration
+ *
+ * Immutable metadata for a UniswapV3StakingVault position event.
+ * Beyond the common blockchain coordinates, persists the principal/yield
+ * split for STAKING_DISPOSE events (per SPEC-0003b §6.4) so the journal-posting
+ * rule can post Model A entries without re-reading chain state.
+ *
+ * For STAKING_DEPOSIT events, the dispose-related fields are zero.
+ */
+
+// ============================================================================
+// CONFIG INTERFACE
+// ============================================================================
+
+/**
+ * Source of a STAKING_DISPOSE event.
+ * - 'swap': permissionless executor settlement via vault.swap()
+ * - 'flashClose': owner-driven exit via vault.flashClose()
+ *   (synthesized from FlashCloseInitiated + auto-drained Unstake/ClaimRewards
+ *    in the same transaction)
+ */
+export type StakingDisposeSource = 'swap' | 'flashClose';
+
+export interface UniswapV3StakingLedgerEventConfig {
+  /** EVM chain ID where event occurred */
+  chainId: number;
+
+  /** Vault contract address (EIP-55 checksummed) */
+  vaultAddress: string;
+
+  /** Block number where event occurred */
+  blockNumber: bigint;
+
+  /** Transaction index within the block */
+  txIndex: number;
+
+  /** Log index within the transaction */
+  logIndex: number;
+
+  /** Transaction hash */
+  txHash: string;
+
+  /** Block hash (for reorg detection) */
+  blockHash: string;
+
+  /** Liquidity delta from the event (positive for STAKING_DEPOSIT, negative for STAKING_DISPOSE, 0 for markers) */
+  deltaL: bigint;
+
+  /** Underlying NFT liquidity AFTER the event */
+  liquidityAfter: bigint;
+
+  /**
+   * Effective bps used by the contract for this event.
+   * - 10000 for full STAKING_DEPOSIT (initial / top-up)
+   * - 1..10000 for STAKING_DISPOSE (the bps that was actually applied)
+   * - 0 for marker events
+   */
+  effectiveBps: number;
+
+  /** Pool sqrt price (Q64.96) at event block */
+  sqrtPriceX96: bigint;
+
+  // ---- Component split (populated for STAKING_DISPOSE only; 0 otherwise) ----
+
+  /** Base-token portion of disposed principal (= unstakeBuffer base delta) */
+  principalBaseDelta: bigint;
+  /** Quote-token portion of disposed principal (= unstakeBuffer quote delta) */
+  principalQuoteDelta: bigint;
+  /** Base-token portion of disposed yield (= rewardBuffer base delta) */
+  yieldBaseDelta: bigint;
+  /** Quote-token portion of disposed yield (= rewardBuffer quote delta) */
+  yieldQuoteDelta: bigint;
+  /** Total principal value in quote-token units (= principalBaseDelta × P + principalQuoteDelta) */
+  principalQuoteValue: bigint;
+  /** Total yield value in quote-token units (= yieldBaseDelta × P + yieldQuoteDelta) */
+  yieldQuoteValue: bigint;
+
+  /** Source of the dispose event (only meaningful for STAKING_DISPOSE) */
+  source: StakingDisposeSource | null;
+}
+
+// ============================================================================
+// JSON INTERFACE
+// ============================================================================
+
+export interface UniswapV3StakingLedgerEventConfigJSON {
+  chainId: number;
+  vaultAddress: string;
+  blockNumber: string;
+  txIndex: number;
+  logIndex: number;
+  txHash: string;
+  blockHash: string;
+  deltaL: string;
+  liquidityAfter: string;
+  effectiveBps: number;
+  sqrtPriceX96: string;
+  principalBaseDelta: string;
+  principalQuoteDelta: string;
+  yieldBaseDelta: string;
+  yieldQuoteDelta: string;
+  principalQuoteValue: string;
+  yieldQuoteValue: string;
+  source: StakingDisposeSource | null;
+}
+
+// ============================================================================
+// SERIALIZATION HELPERS
+// ============================================================================
+
+export function stakingLedgerEventConfigToJSON(
+  config: UniswapV3StakingLedgerEventConfig,
+): UniswapV3StakingLedgerEventConfigJSON {
+  return {
+    chainId: config.chainId,
+    vaultAddress: config.vaultAddress,
+    blockNumber: config.blockNumber.toString(),
+    txIndex: config.txIndex,
+    logIndex: config.logIndex,
+    txHash: config.txHash,
+    blockHash: config.blockHash,
+    deltaL: config.deltaL.toString(),
+    liquidityAfter: config.liquidityAfter.toString(),
+    effectiveBps: config.effectiveBps,
+    sqrtPriceX96: config.sqrtPriceX96.toString(),
+    principalBaseDelta: config.principalBaseDelta.toString(),
+    principalQuoteDelta: config.principalQuoteDelta.toString(),
+    yieldBaseDelta: config.yieldBaseDelta.toString(),
+    yieldQuoteDelta: config.yieldQuoteDelta.toString(),
+    principalQuoteValue: config.principalQuoteValue.toString(),
+    yieldQuoteValue: config.yieldQuoteValue.toString(),
+    source: config.source,
+  };
+}
+
+export function stakingLedgerEventConfigFromJSON(
+  json: UniswapV3StakingLedgerEventConfigJSON,
+): UniswapV3StakingLedgerEventConfig {
+  return {
+    chainId: json.chainId,
+    vaultAddress: json.vaultAddress,
+    blockNumber: BigInt(json.blockNumber),
+    txIndex: json.txIndex,
+    logIndex: json.logIndex,
+    txHash: json.txHash,
+    blockHash: json.blockHash,
+    deltaL: BigInt(json.deltaL),
+    liquidityAfter: BigInt(json.liquidityAfter),
+    effectiveBps: json.effectiveBps,
+    sqrtPriceX96: BigInt(json.sqrtPriceX96),
+    principalBaseDelta: BigInt(json.principalBaseDelta),
+    principalQuoteDelta: BigInt(json.principalQuoteDelta),
+    yieldBaseDelta: BigInt(json.yieldBaseDelta),
+    yieldQuoteDelta: BigInt(json.yieldQuoteDelta),
+    principalQuoteValue: BigInt(json.principalQuoteValue),
+    yieldQuoteValue: BigInt(json.yieldQuoteValue),
+    source: json.source,
+  };
+}

--- a/packages/midcurve-shared/src/types/position-ledger-event/uniswapv3-staking/uniswapv3-staking-ledger-event-state.ts
+++ b/packages/midcurve-shared/src/types/position-ledger-event/uniswapv3-staking/uniswapv3-staking-ledger-event-state.ts
@@ -1,0 +1,265 @@
+/**
+ * UniswapV3 Staking Ledger Event State
+ *
+ * Discriminated union of staking-vault event-specific data.
+ * Four event types:
+ * - STAKING_DEPOSIT — initial Stake or top-up Stake
+ * - STAKING_DISPOSE — Swap (executor settlement) or FlashClose (owner exit)
+ * - STAKING_YIELD_TARGET_SET — marker (no financial impact)
+ * - STAKING_PENDING_BPS_SET — marker (no financial impact)
+ */
+
+// ============================================================================
+// COMMON BASE
+// ============================================================================
+
+export interface UniswapV3StakingLedgerEventStateBase {
+  /** Pool sqrtPriceX96 (Q64.96) at event time */
+  poolPrice: bigint;
+  /** Token amounts involved in this event ([token0Amount, token1Amount]) */
+  tokenAmounts: bigint[];
+}
+
+// ============================================================================
+// EVENT-SPECIFIC INTERFACES
+// ============================================================================
+
+export interface UniswapV3StakingDepositEvent
+  extends UniswapV3StakingLedgerEventStateBase {
+  eventType: 'STAKING_DEPOSIT';
+  /** True for the initial Stake, false for a top-up Stake */
+  isInitial: boolean;
+  /** Owner address (= position owner; vaults are owner-bound 1:1) */
+  owner: string;
+  /** Base-token amount deposited */
+  baseAmount: bigint;
+  /** Quote-token amount deposited */
+  quoteAmount: bigint;
+  /** Yield target supplied with the stake (initial: total; top-up: same as before, contract semantics) */
+  yieldTarget: bigint;
+  /** NFT token id minted by the vault */
+  underlyingTokenId: number;
+}
+
+export interface UniswapV3StakingDisposeEvent
+  extends UniswapV3StakingLedgerEventStateBase {
+  eventType: 'STAKING_DISPOSE';
+  /** Source of the dispose ('swap' or 'flashClose') */
+  source: 'swap' | 'flashClose';
+  /** Effective bps applied (1..10000) */
+  effectiveBps: number;
+  /** Address that triggered the dispose:
+   *  - Swap: executor
+   *  - FlashClose: owner */
+  initiator: string;
+  /** Principal portion (base) returned to unstakeBuffer */
+  principalBase: bigint;
+  /** Principal portion (quote) returned to unstakeBuffer */
+  principalQuote: bigint;
+  /** Yield portion (base) returned to rewardBuffer */
+  yieldBase: bigint;
+  /** Yield portion (quote) returned to rewardBuffer */
+  yieldQuote: bigint;
+  /** For source='swap': tokenIn/tokenOut/amountIn/amountOut from the Swap event payload.
+   *  For source='flashClose': zeros (no executor swap leg). */
+  tokenIn: string;
+  tokenOut: string;
+  amountIn: bigint;
+  amountOut: bigint;
+}
+
+export interface UniswapV3StakingYieldTargetSetEvent
+  extends UniswapV3StakingLedgerEventStateBase {
+  eventType: 'STAKING_YIELD_TARGET_SET';
+  owner: string;
+  oldTarget: bigint;
+  newTarget: bigint;
+}
+
+export interface UniswapV3StakingPendingBpsSetEvent
+  extends UniswapV3StakingLedgerEventStateBase {
+  eventType: 'STAKING_PENDING_BPS_SET';
+  owner: string;
+  oldBps: number;
+  newBps: number;
+}
+
+// ============================================================================
+// UNION TYPE
+// ============================================================================
+
+export type UniswapV3StakingLedgerEventState =
+  | UniswapV3StakingDepositEvent
+  | UniswapV3StakingDisposeEvent
+  | UniswapV3StakingYieldTargetSetEvent
+  | UniswapV3StakingPendingBpsSetEvent;
+
+// ============================================================================
+// JSON TYPES
+// ============================================================================
+
+export interface UniswapV3StakingLedgerEventStateBaseJSON {
+  poolPrice: string;
+  tokenAmounts: string[];
+}
+
+export type UniswapV3StakingLedgerEventStateJSON =
+  | (UniswapV3StakingLedgerEventStateBaseJSON & {
+      eventType: 'STAKING_DEPOSIT';
+      isInitial: boolean;
+      owner: string;
+      baseAmount: string;
+      quoteAmount: string;
+      yieldTarget: string;
+      underlyingTokenId: number;
+    })
+  | (UniswapV3StakingLedgerEventStateBaseJSON & {
+      eventType: 'STAKING_DISPOSE';
+      source: 'swap' | 'flashClose';
+      effectiveBps: number;
+      initiator: string;
+      principalBase: string;
+      principalQuote: string;
+      yieldBase: string;
+      yieldQuote: string;
+      tokenIn: string;
+      tokenOut: string;
+      amountIn: string;
+      amountOut: string;
+    })
+  | (UniswapV3StakingLedgerEventStateBaseJSON & {
+      eventType: 'STAKING_YIELD_TARGET_SET';
+      owner: string;
+      oldTarget: string;
+      newTarget: string;
+    })
+  | (UniswapV3StakingLedgerEventStateBaseJSON & {
+      eventType: 'STAKING_PENDING_BPS_SET';
+      owner: string;
+      oldBps: number;
+      newBps: number;
+    });
+
+// ============================================================================
+// SERIALIZATION HELPERS
+// ============================================================================
+
+function baseToJSON(
+  state: UniswapV3StakingLedgerEventStateBase,
+): UniswapV3StakingLedgerEventStateBaseJSON {
+  return {
+    poolPrice: state.poolPrice.toString(),
+    tokenAmounts: state.tokenAmounts.map((a) => a.toString()),
+  };
+}
+
+function baseFromJSON(
+  json: UniswapV3StakingLedgerEventStateBaseJSON,
+): UniswapV3StakingLedgerEventStateBase {
+  return {
+    poolPrice: BigInt(json.poolPrice),
+    tokenAmounts: json.tokenAmounts.map((a) => BigInt(a)),
+  };
+}
+
+export function stakingLedgerEventStateToJSON(
+  state: UniswapV3StakingLedgerEventState,
+): UniswapV3StakingLedgerEventStateJSON {
+  const base = baseToJSON(state);
+  switch (state.eventType) {
+    case 'STAKING_DEPOSIT':
+      return {
+        ...base,
+        eventType: 'STAKING_DEPOSIT',
+        isInitial: state.isInitial,
+        owner: state.owner,
+        baseAmount: state.baseAmount.toString(),
+        quoteAmount: state.quoteAmount.toString(),
+        yieldTarget: state.yieldTarget.toString(),
+        underlyingTokenId: state.underlyingTokenId,
+      };
+    case 'STAKING_DISPOSE':
+      return {
+        ...base,
+        eventType: 'STAKING_DISPOSE',
+        source: state.source,
+        effectiveBps: state.effectiveBps,
+        initiator: state.initiator,
+        principalBase: state.principalBase.toString(),
+        principalQuote: state.principalQuote.toString(),
+        yieldBase: state.yieldBase.toString(),
+        yieldQuote: state.yieldQuote.toString(),
+        tokenIn: state.tokenIn,
+        tokenOut: state.tokenOut,
+        amountIn: state.amountIn.toString(),
+        amountOut: state.amountOut.toString(),
+      };
+    case 'STAKING_YIELD_TARGET_SET':
+      return {
+        ...base,
+        eventType: 'STAKING_YIELD_TARGET_SET',
+        owner: state.owner,
+        oldTarget: state.oldTarget.toString(),
+        newTarget: state.newTarget.toString(),
+      };
+    case 'STAKING_PENDING_BPS_SET':
+      return {
+        ...base,
+        eventType: 'STAKING_PENDING_BPS_SET',
+        owner: state.owner,
+        oldBps: state.oldBps,
+        newBps: state.newBps,
+      };
+  }
+}
+
+export function stakingLedgerEventStateFromJSON(
+  json: UniswapV3StakingLedgerEventStateJSON,
+): UniswapV3StakingLedgerEventState {
+  const base = baseFromJSON(json);
+  switch (json.eventType) {
+    case 'STAKING_DEPOSIT':
+      return {
+        ...base,
+        eventType: 'STAKING_DEPOSIT',
+        isInitial: json.isInitial,
+        owner: json.owner,
+        baseAmount: BigInt(json.baseAmount),
+        quoteAmount: BigInt(json.quoteAmount),
+        yieldTarget: BigInt(json.yieldTarget),
+        underlyingTokenId: json.underlyingTokenId,
+      };
+    case 'STAKING_DISPOSE':
+      return {
+        ...base,
+        eventType: 'STAKING_DISPOSE',
+        source: json.source,
+        effectiveBps: json.effectiveBps,
+        initiator: json.initiator,
+        principalBase: BigInt(json.principalBase),
+        principalQuote: BigInt(json.principalQuote),
+        yieldBase: BigInt(json.yieldBase),
+        yieldQuote: BigInt(json.yieldQuote),
+        tokenIn: json.tokenIn,
+        tokenOut: json.tokenOut,
+        amountIn: BigInt(json.amountIn),
+        amountOut: BigInt(json.amountOut),
+      };
+    case 'STAKING_YIELD_TARGET_SET':
+      return {
+        ...base,
+        eventType: 'STAKING_YIELD_TARGET_SET',
+        owner: json.owner,
+        oldTarget: BigInt(json.oldTarget),
+        newTarget: BigInt(json.newTarget),
+      };
+    case 'STAKING_PENDING_BPS_SET':
+      return {
+        ...base,
+        eventType: 'STAKING_PENDING_BPS_SET',
+        owner: json.owner,
+        oldBps: json.oldBps,
+        newBps: json.newBps,
+      };
+  }
+}

--- a/packages/midcurve-shared/src/types/position-ledger-event/uniswapv3-staking/uniswapv3-staking-position-ledger-event.ts
+++ b/packages/midcurve-shared/src/types/position-ledger-event/uniswapv3-staking/uniswapv3-staking-position-ledger-event.ts
@@ -1,0 +1,232 @@
+/**
+ * UniswapV3 Staking Position Ledger Event
+ *
+ * Concrete implementation for UniswapV3StakingVault position events.
+ * Extends BasePositionLedgerEvent with staking-specific configuration and state.
+ */
+
+import { BasePositionLedgerEvent } from '../base-position-ledger-event.js';
+import type {
+  LedgerEventProtocol,
+  EventType,
+  BasePositionLedgerEventParams,
+  PositionLedgerEventRow,
+  PositionLedgerEventJSON,
+  RewardJSON,
+} from '../position-ledger-event.types.js';
+import { rewardFromJSON } from '../position-ledger-event.types.js';
+import {
+  type UniswapV3StakingLedgerEventConfig,
+  type UniswapV3StakingLedgerEventConfigJSON,
+  stakingLedgerEventConfigToJSON,
+  stakingLedgerEventConfigFromJSON,
+} from './uniswapv3-staking-ledger-event-config.js';
+import {
+  type UniswapV3StakingLedgerEventState,
+  type UniswapV3StakingLedgerEventStateJSON,
+  stakingLedgerEventStateToJSON,
+  stakingLedgerEventStateFromJSON,
+} from './uniswapv3-staking-ledger-event-state.js';
+
+// ============================================================================
+// CONSTRUCTOR PARAMS
+// ============================================================================
+
+export interface UniswapV3StakingPositionLedgerEventParams
+  extends BasePositionLedgerEventParams {
+  config: UniswapV3StakingLedgerEventConfig;
+  state: UniswapV3StakingLedgerEventState;
+}
+
+// ============================================================================
+// DATABASE ROW
+// ============================================================================
+
+export interface UniswapV3StakingPositionLedgerEventRow
+  extends PositionLedgerEventRow {
+  protocol: 'uniswapv3-staking';
+}
+
+// ============================================================================
+// LEDGER EVENT CLASS
+// ============================================================================
+
+export class UniswapV3StakingPositionLedgerEvent extends BasePositionLedgerEvent {
+  readonly protocol: LedgerEventProtocol = 'uniswapv3-staking';
+
+  private readonly _config: UniswapV3StakingLedgerEventConfig;
+  private readonly _state: UniswapV3StakingLedgerEventState;
+
+  constructor(params: UniswapV3StakingPositionLedgerEventParams) {
+    super(params);
+    this._config = params.config;
+    this._state = params.state;
+  }
+
+  // ============================================================================
+  // Config/State Accessors (interface compliance)
+  // ============================================================================
+
+  get config(): Record<string, unknown> {
+    return stakingLedgerEventConfigToJSON(this._config) as unknown as Record<
+      string,
+      unknown
+    >;
+  }
+
+  get state(): Record<string, unknown> {
+    return stakingLedgerEventStateToJSON(this._state) as unknown as Record<
+      string,
+      unknown
+    >;
+  }
+
+  // ============================================================================
+  // Typed Accessors
+  // ============================================================================
+
+  get typedConfig(): UniswapV3StakingLedgerEventConfig {
+    return this._config;
+  }
+
+  get typedState(): UniswapV3StakingLedgerEventState {
+    return this._state;
+  }
+
+  // ============================================================================
+  // Convenience Accessors - Config
+  // ============================================================================
+
+  get chainId(): number {
+    return this._config.chainId;
+  }
+
+  get vaultAddress(): string {
+    return this._config.vaultAddress;
+  }
+
+  get blockNumber(): bigint {
+    return this._config.blockNumber;
+  }
+
+  get txIndex(): number {
+    return this._config.txIndex;
+  }
+
+  get logIndex(): number {
+    return this._config.logIndex;
+  }
+
+  get txHash(): string {
+    return this._config.txHash;
+  }
+
+  get blockHash(): string {
+    return this._config.blockHash;
+  }
+
+  get deltaL(): bigint {
+    return this._config.deltaL;
+  }
+
+  get liquidityAfter(): bigint {
+    return this._config.liquidityAfter;
+  }
+
+  // ============================================================================
+  // Event Properties (from state)
+  // ============================================================================
+
+  get poolPrice(): bigint {
+    return this._state.poolPrice;
+  }
+
+  get tokenAmounts(): bigint[] {
+    return this._state.tokenAmounts;
+  }
+
+  get token0Amount(): bigint {
+    return this._state.tokenAmounts[0] ?? 0n;
+  }
+
+  get token1Amount(): bigint {
+    return this._state.tokenAmounts[1] ?? 0n;
+  }
+
+  // ============================================================================
+  // Serialization
+  // ============================================================================
+
+  override toJSON(): PositionLedgerEventJSON {
+    return {
+      ...super.toJSON(),
+      poolPrice: this.poolPrice.toString(),
+      token0Amount: this.token0Amount.toString(),
+      token1Amount: this.token1Amount.toString(),
+    };
+  }
+
+  // ============================================================================
+  // Factory Methods
+  // ============================================================================
+
+  static fromDB(
+    row: UniswapV3StakingPositionLedgerEventRow,
+  ): UniswapV3StakingPositionLedgerEvent {
+    const configJSON = row.config as unknown as UniswapV3StakingLedgerEventConfigJSON;
+    const stateJSON = row.state as unknown as UniswapV3StakingLedgerEventStateJSON;
+    const rewardsJSON = row.rewards as unknown as RewardJSON[];
+
+    return new UniswapV3StakingPositionLedgerEvent({
+      id: row.id,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+      positionId: row.positionId,
+      previousId: row.previousId,
+      timestamp: row.timestamp,
+      eventType: row.eventType as EventType,
+      inputHash: row.inputHash,
+      tokenValue:
+        typeof row.tokenValue === 'bigint'
+          ? row.tokenValue
+          : BigInt(row.tokenValue),
+      rewards: rewardsJSON.map(rewardFromJSON),
+      deltaCostBasis:
+        typeof row.deltaCostBasis === 'bigint'
+          ? row.deltaCostBasis
+          : BigInt(row.deltaCostBasis),
+      costBasisAfter:
+        typeof row.costBasisAfter === 'bigint'
+          ? row.costBasisAfter
+          : BigInt(row.costBasisAfter),
+      deltaPnl:
+        typeof row.deltaPnl === 'bigint'
+          ? row.deltaPnl
+          : BigInt(row.deltaPnl),
+      pnlAfter:
+        typeof row.pnlAfter === 'bigint'
+          ? row.pnlAfter
+          : BigInt(row.pnlAfter),
+      deltaCollectedYield:
+        typeof row.deltaCollectedYield === 'bigint'
+          ? row.deltaCollectedYield
+          : BigInt(row.deltaCollectedYield),
+      collectedYieldAfter:
+        typeof row.collectedYieldAfter === 'bigint'
+          ? row.collectedYieldAfter
+          : BigInt(row.collectedYieldAfter),
+      deltaRealizedCashflow:
+        typeof row.deltaRealizedCashflow === 'bigint'
+          ? row.deltaRealizedCashflow
+          : BigInt(row.deltaRealizedCashflow),
+      realizedCashflowAfter:
+        typeof row.realizedCashflowAfter === 'bigint'
+          ? row.realizedCashflowAfter
+          : BigInt(row.realizedCashflowAfter),
+      isIgnored: row.isIgnored ?? false,
+      ignoredReason: row.ignoredReason ?? null,
+      config: stakingLedgerEventConfigFromJSON(configJSON),
+      state: stakingLedgerEventStateFromJSON(stateJSON),
+    });
+  }
+}

--- a/packages/midcurve-shared/src/types/position/factory.ts
+++ b/packages/midcurve-shared/src/types/position/factory.ts
@@ -16,6 +16,10 @@ import {
   UniswapV3VaultPosition,
   type UniswapV3VaultPositionRow,
 } from './uniswapv3-vault/uniswapv3-vault-position.js';
+import {
+  UniswapV3StakingPosition,
+  type UniswapV3StakingPositionRow,
+} from './uniswapv3-staking/uniswapv3-staking-position.js';
 
 // ============================================================================
 // POSITION FACTORY
@@ -57,6 +61,9 @@ export class PositionFactory {
       case 'uniswapv3-vault':
         return UniswapV3VaultPosition.fromDB(row as UniswapV3VaultPositionRow, token0, token1);
 
+      case 'uniswapv3-staking':
+        return UniswapV3StakingPosition.fromDB(row as UniswapV3StakingPositionRow, token0, token1);
+
       default:
         throw new Error(`Unknown position protocol: ${row.protocol}`);
     }
@@ -90,6 +97,19 @@ export class PositionFactory {
         return UniswapV3VaultPosition.fromJSON(json, token0 as unknown as TokenInterface, token1 as unknown as TokenInterface);
       }
 
+      case 'uniswapv3-staking': {
+        const token0 = json.pool?.token0;
+        const token1 = json.pool?.token1;
+        if (!token0 || !token1) {
+          throw new Error('UniswapV3StakingPosition.fromJSON requires pool.token0 and pool.token1');
+        }
+        return UniswapV3StakingPosition.fromJSON(
+          json,
+          token0 as unknown as TokenInterface,
+          token1 as unknown as TokenInterface,
+        );
+      }
+
       default:
         throw new Error(`Unknown position protocol: ${json.protocol}`);
     }
@@ -102,6 +122,6 @@ export class PositionFactory {
    * @returns True if protocol is supported
    */
   static isSupported(protocol: string): protocol is PositionProtocol {
-    return ['uniswapv3', 'uniswapv3-vault'].includes(protocol);
+    return ['uniswapv3', 'uniswapv3-vault', 'uniswapv3-staking'].includes(protocol);
   }
 }

--- a/packages/midcurve-shared/src/types/position/index.ts
+++ b/packages/midcurve-shared/src/types/position/index.ts
@@ -61,6 +61,21 @@ export {
   vaultPositionStateFromJSON,
 } from './uniswapv3-vault/index.js';
 
+// UniswapV3 Staking specific
+export {
+  UniswapV3StakingPosition,
+  UniswapV3StakingPositionConfig,
+  type UniswapV3StakingPositionParams,
+  type UniswapV3StakingPositionRow,
+  type UniswapV3StakingPositionConfigData,
+  type UniswapV3StakingPositionConfigJSON,
+  type UniswapV3StakingPositionState,
+  type UniswapV3StakingPositionStateJSON,
+  type StakingState,
+  stakingPositionStateToJSON,
+  stakingPositionStateFromJSON,
+} from './uniswapv3-staking/index.js';
+
 // Simulation overlay
 export {
   CloseOrderSimulationOverlay,
@@ -74,9 +89,13 @@ export {
 // Import for use in type alias
 import type { UniswapV3Position as UniswapV3PositionType } from './uniswapv3/index.js';
 import type { UniswapV3VaultPosition as UniswapV3VaultPositionType } from './uniswapv3-vault/index.js';
+import type { UniswapV3StakingPosition as UniswapV3StakingPositionType } from './uniswapv3-staking/index.js';
 
 /**
  * Union type for all position implementations.
  * Extend this as new protocols are added (Orca, Raydium, etc.)
  */
-export type AnyPosition = UniswapV3PositionType | UniswapV3VaultPositionType;
+export type AnyPosition =
+  | UniswapV3PositionType
+  | UniswapV3VaultPositionType
+  | UniswapV3StakingPositionType;

--- a/packages/midcurve-shared/src/types/position/position.types.ts
+++ b/packages/midcurve-shared/src/types/position/position.types.ts
@@ -16,7 +16,7 @@ import type { TokenInterface } from '../token/index.js';
  * Supported position protocols.
  * Extensible for future protocols (orca, raydium, etc.)
  */
-export type PositionProtocol = 'uniswapv3' | 'uniswapv3-vault';
+export type PositionProtocol = 'uniswapv3' | 'uniswapv3-vault' | 'uniswapv3-staking';
 
 /**
  * Supported position types.

--- a/packages/midcurve-shared/src/types/position/uniswapv3-staking/index.ts
+++ b/packages/midcurve-shared/src/types/position/uniswapv3-staking/index.ts
@@ -1,0 +1,23 @@
+/**
+ * UniswapV3 Staking Position Exports
+ */
+
+export {
+  UniswapV3StakingPosition,
+  type UniswapV3StakingPositionParams,
+  type UniswapV3StakingPositionRow,
+} from './uniswapv3-staking-position.js';
+
+export {
+  UniswapV3StakingPositionConfig,
+  type UniswapV3StakingPositionConfigData,
+  type UniswapV3StakingPositionConfigJSON,
+} from './uniswapv3-staking-position-config.js';
+
+export {
+  type UniswapV3StakingPositionState,
+  type UniswapV3StakingPositionStateJSON,
+  type StakingState,
+  stakingPositionStateToJSON,
+  stakingPositionStateFromJSON,
+} from './uniswapv3-staking-position-state.js';

--- a/packages/midcurve-shared/src/types/position/uniswapv3-staking/uniswapv3-staking-position-config.ts
+++ b/packages/midcurve-shared/src/types/position/uniswapv3-staking/uniswapv3-staking-position-config.ts
@@ -1,0 +1,156 @@
+/**
+ * UniswapV3 Staking Position Configuration
+ *
+ * Immutable configuration for UniswapV3StakingVault positions.
+ * Each Position row corresponds to a single staking-vault clone (1:1 with owner).
+ */
+
+// ============================================================================
+// DATA INTERFACE
+// ============================================================================
+
+export interface UniswapV3StakingPositionConfigData {
+  /** Chain ID where the staking vault is deployed */
+  chainId: number;
+
+  /** UniswapV3StakingVault clone address (EIP-55 checksummed) */
+  vaultAddress: string;
+
+  /** UniswapV3StakingVaultFactory address (EIP-55 checksummed) */
+  factoryAddress: string;
+
+  /** Owner address bound to the vault clone (EIP-55 checksummed) */
+  ownerAddress: string;
+
+  /** NFT token id minted by the vault on `stake()` */
+  underlyingTokenId: number;
+
+  /** Whether token0 is the quote token (immutable; encoded on-chain at stake) */
+  isToken0Quote: boolean;
+
+  /** Uniswap V3 pool address (EIP-55 checksummed) */
+  poolAddress: string;
+
+  /** Token0 ERC-20 contract address (EIP-55 checksummed) */
+  token0Address: string;
+
+  /** Token1 ERC-20 contract address (EIP-55 checksummed) */
+  token1Address: string;
+
+  /** Fee tier in basis points (100, 500, 3000, 10000) */
+  feeBps: number;
+
+  /** Tick spacing for this fee tier */
+  tickSpacing: number;
+
+  /** Lower tick bound of the underlying position */
+  tickLower: number;
+
+  /** Upper tick bound of the underlying position */
+  tickUpper: number;
+
+  /** Lower price range bound in quote token units (bigint) */
+  priceRangeLower: bigint;
+
+  /** Upper price range bound in quote token units (bigint) */
+  priceRangeUpper: bigint;
+}
+
+// ============================================================================
+// JSON INTERFACE
+// ============================================================================
+
+export interface UniswapV3StakingPositionConfigJSON {
+  chainId: number;
+  vaultAddress: string;
+  factoryAddress: string;
+  ownerAddress: string;
+  underlyingTokenId: number;
+  isToken0Quote: boolean;
+  poolAddress: string;
+  tickLower: number;
+  tickUpper: number;
+  priceRangeLower: string;
+  priceRangeUpper: string;
+  // Pool-level fields (present in DB JSON, optional in API responses)
+  token0Address?: string;
+  token1Address?: string;
+  feeBps?: number;
+  tickSpacing?: number;
+}
+
+// ============================================================================
+// CONFIG CLASS
+// ============================================================================
+
+export class UniswapV3StakingPositionConfig
+  implements UniswapV3StakingPositionConfigData
+{
+  readonly chainId: number;
+  readonly vaultAddress: string;
+  readonly factoryAddress: string;
+  readonly ownerAddress: string;
+  readonly underlyingTokenId: number;
+  readonly isToken0Quote: boolean;
+  readonly poolAddress: string;
+  readonly token0Address: string;
+  readonly token1Address: string;
+  readonly feeBps: number;
+  readonly tickSpacing: number;
+  readonly tickLower: number;
+  readonly tickUpper: number;
+  readonly priceRangeLower: bigint;
+  readonly priceRangeUpper: bigint;
+
+  constructor(data: UniswapV3StakingPositionConfigData) {
+    this.chainId = data.chainId;
+    this.vaultAddress = data.vaultAddress;
+    this.factoryAddress = data.factoryAddress;
+    this.ownerAddress = data.ownerAddress;
+    this.underlyingTokenId = data.underlyingTokenId;
+    this.isToken0Quote = data.isToken0Quote;
+    this.poolAddress = data.poolAddress;
+    this.token0Address = data.token0Address;
+    this.token1Address = data.token1Address;
+    this.feeBps = data.feeBps;
+    this.tickSpacing = data.tickSpacing;
+    this.tickLower = data.tickLower;
+    this.tickUpper = data.tickUpper;
+    this.priceRangeLower = data.priceRangeLower;
+    this.priceRangeUpper = data.priceRangeUpper;
+  }
+
+  toJSON(): UniswapV3StakingPositionConfigJSON {
+    return {
+      chainId: this.chainId,
+      vaultAddress: this.vaultAddress,
+      factoryAddress: this.factoryAddress,
+      ownerAddress: this.ownerAddress,
+      underlyingTokenId: this.underlyingTokenId,
+      isToken0Quote: this.isToken0Quote,
+      poolAddress: this.poolAddress,
+      token0Address: this.token0Address,
+      token1Address: this.token1Address,
+      feeBps: this.feeBps,
+      tickSpacing: this.tickSpacing,
+      tickLower: this.tickLower,
+      tickUpper: this.tickUpper,
+      priceRangeLower: this.priceRangeLower.toString(),
+      priceRangeUpper: this.priceRangeUpper.toString(),
+    };
+  }
+
+  static fromJSON(
+    json: UniswapV3StakingPositionConfigJSON,
+  ): UniswapV3StakingPositionConfig {
+    return new UniswapV3StakingPositionConfig({
+      ...json,
+      token0Address: json.token0Address ?? '',
+      token1Address: json.token1Address ?? '',
+      feeBps: json.feeBps ?? 0,
+      tickSpacing: json.tickSpacing ?? 0,
+      priceRangeLower: BigInt(json.priceRangeLower),
+      priceRangeUpper: BigInt(json.priceRangeUpper),
+    });
+  }
+}

--- a/packages/midcurve-shared/src/types/position/uniswapv3-staking/uniswapv3-staking-position-state.ts
+++ b/packages/midcurve-shared/src/types/position/uniswapv3-staking/uniswapv3-staking-position-state.ts
@@ -1,0 +1,133 @@
+/**
+ * UniswapV3 Staking Position State
+ *
+ * Mutable state for UniswapV3StakingVault positions, refreshed on read.
+ * Mirrors the on-chain `state()` lifecycle plus the four settlement buffers
+ * (informational — buffers are drained via unstake()/claimRewards() and do
+ * not affect cost-basis directly).
+ */
+
+// ============================================================================
+// LIFECYCLE
+// ============================================================================
+
+/**
+ * On-chain lifecycle of the staking vault.
+ * Mirrors `enum State` in UniswapV3StakingVault.sol.
+ */
+export type StakingState = 'Empty' | 'Staked' | 'FlashCloseInProgress' | 'Settled';
+
+// ============================================================================
+// STATE INTERFACE
+// ============================================================================
+
+export interface UniswapV3StakingPositionState {
+  /** On-chain vault state */
+  vaultState: StakingState;
+
+  /** Stake terms (immutable while Staked, refreshed on top-up) */
+  stakedBase: bigint;
+  stakedQuote: bigint;
+  yieldTarget: bigint;
+  pendingBps: number;
+
+  /** Settlement buffers (informational — drained by unstake/claimRewards) */
+  unstakeBufferBase: bigint;
+  unstakeBufferQuote: bigint;
+  rewardBufferBase: bigint;
+  rewardBufferQuote: bigint;
+
+  /** Underlying NFT state */
+  liquidity: bigint;
+  isOwnedByUser: boolean;
+
+  /** Computed live yield (claimable on next swap) */
+  unclaimedYieldBase: bigint;
+  unclaimedYieldQuote: bigint;
+
+  /** Pool snapshot at last refresh */
+  sqrtPriceX96: bigint;
+  currentTick: number;
+  poolLiquidity: bigint;
+  feeGrowthGlobal0: bigint;
+  feeGrowthGlobal1: bigint;
+}
+
+// ============================================================================
+// JSON INTERFACE
+// ============================================================================
+
+export interface UniswapV3StakingPositionStateJSON {
+  vaultState: StakingState;
+  stakedBase: string;
+  stakedQuote: string;
+  yieldTarget: string;
+  pendingBps: number;
+  unstakeBufferBase: string;
+  unstakeBufferQuote: string;
+  rewardBufferBase: string;
+  rewardBufferQuote: string;
+  liquidity: string;
+  isOwnedByUser?: boolean;
+  unclaimedYieldBase: string;
+  unclaimedYieldQuote: string;
+  sqrtPriceX96?: string;
+  currentTick?: number;
+  poolLiquidity?: string;
+  feeGrowthGlobal0?: string;
+  feeGrowthGlobal1?: string;
+}
+
+// ============================================================================
+// SERIALIZATION HELPERS
+// ============================================================================
+
+export function stakingPositionStateToJSON(
+  state: UniswapV3StakingPositionState,
+): UniswapV3StakingPositionStateJSON {
+  return {
+    vaultState: state.vaultState,
+    stakedBase: state.stakedBase.toString(),
+    stakedQuote: state.stakedQuote.toString(),
+    yieldTarget: state.yieldTarget.toString(),
+    pendingBps: state.pendingBps,
+    unstakeBufferBase: state.unstakeBufferBase.toString(),
+    unstakeBufferQuote: state.unstakeBufferQuote.toString(),
+    rewardBufferBase: state.rewardBufferBase.toString(),
+    rewardBufferQuote: state.rewardBufferQuote.toString(),
+    liquidity: state.liquidity.toString(),
+    isOwnedByUser: state.isOwnedByUser,
+    unclaimedYieldBase: state.unclaimedYieldBase.toString(),
+    unclaimedYieldQuote: state.unclaimedYieldQuote.toString(),
+    sqrtPriceX96: state.sqrtPriceX96.toString(),
+    currentTick: state.currentTick,
+    poolLiquidity: state.poolLiquidity.toString(),
+    feeGrowthGlobal0: state.feeGrowthGlobal0.toString(),
+    feeGrowthGlobal1: state.feeGrowthGlobal1.toString(),
+  };
+}
+
+export function stakingPositionStateFromJSON(
+  json: UniswapV3StakingPositionStateJSON,
+): UniswapV3StakingPositionState {
+  return {
+    vaultState: json.vaultState,
+    stakedBase: BigInt(json.stakedBase),
+    stakedQuote: BigInt(json.stakedQuote),
+    yieldTarget: BigInt(json.yieldTarget),
+    pendingBps: json.pendingBps,
+    unstakeBufferBase: BigInt(json.unstakeBufferBase),
+    unstakeBufferQuote: BigInt(json.unstakeBufferQuote),
+    rewardBufferBase: BigInt(json.rewardBufferBase),
+    rewardBufferQuote: BigInt(json.rewardBufferQuote),
+    liquidity: BigInt(json.liquidity),
+    isOwnedByUser: json.isOwnedByUser ?? true,
+    unclaimedYieldBase: BigInt(json.unclaimedYieldBase),
+    unclaimedYieldQuote: BigInt(json.unclaimedYieldQuote),
+    sqrtPriceX96: BigInt(json.sqrtPriceX96 ?? '0'),
+    currentTick: json.currentTick ?? 0,
+    poolLiquidity: BigInt(json.poolLiquidity ?? '0'),
+    feeGrowthGlobal0: BigInt(json.feeGrowthGlobal0 ?? '0'),
+    feeGrowthGlobal1: BigInt(json.feeGrowthGlobal1 ?? '0'),
+  };
+}

--- a/packages/midcurve-shared/src/types/position/uniswapv3-staking/uniswapv3-staking-position.ts
+++ b/packages/midcurve-shared/src/types/position/uniswapv3-staking/uniswapv3-staking-position.ts
@@ -1,0 +1,365 @@
+/**
+ * UniswapV3 Staking Position
+ *
+ * Concrete position implementation for UniswapV3StakingVault clones.
+ * Each vault is owner-bound (1:1) and wraps a single Uniswap V3 NFT position
+ * with a quote-side yield target.
+ *
+ * Key differences from UniswapV3VaultPosition:
+ * - No share token model — `liquidity` is the user's whole position liquidity
+ * - `isClosed()` is derived from `vaultState === 'Settled'`
+ * - Yield is realized at swap (Model A) — never collected separately as fees
+ */
+
+import { BasePosition } from '../base-position.js';
+import { UniswapV3Pool } from '../../pool/index.js';
+import { UniswapV3PoolConfig } from '../../pool/uniswapv3/uniswapv3-pool-config.js';
+import type { PoolInterface } from '../../pool/index.js';
+import type { Erc20Token, TokenInterface } from '../../token/index.js';
+import type {
+  PositionProtocol,
+  BasePositionParams,
+  PositionRow,
+  PnLSimulationResult,
+  PositionJSON,
+} from '../position.types.js';
+import {
+  UniswapV3StakingPositionConfig,
+  type UniswapV3StakingPositionConfigJSON,
+} from './uniswapv3-staking-position-config.js';
+import {
+  type UniswapV3StakingPositionState,
+  type UniswapV3StakingPositionStateJSON,
+  stakingPositionStateToJSON,
+  stakingPositionStateFromJSON,
+} from './uniswapv3-staking-position-state.js';
+import { calculatePositionValue } from '../../../utils/uniswapv3/liquidity.js';
+import { priceToSqrtRatioX96 } from '../../../utils/uniswapv3/price.js';
+
+// ============================================================================
+// CONSTRUCTOR PARAMS
+// ============================================================================
+
+export interface UniswapV3StakingPositionParams extends BasePositionParams {
+  config: UniswapV3StakingPositionConfig;
+  state: UniswapV3StakingPositionState;
+}
+
+// ============================================================================
+// DATABASE ROW
+// ============================================================================
+
+export interface UniswapV3StakingPositionRow extends PositionRow {
+  protocol: 'uniswapv3-staking';
+}
+
+// ============================================================================
+// POSITION CLASS
+// ============================================================================
+
+export class UniswapV3StakingPosition extends BasePosition {
+  readonly protocol: PositionProtocol = 'uniswapv3-staking';
+
+  private readonly _config: UniswapV3StakingPositionConfig;
+  private readonly _state: UniswapV3StakingPositionState;
+
+  constructor(params: UniswapV3StakingPositionParams) {
+    super(params);
+    this._config = params.config;
+    this._state = params.state;
+  }
+
+  // ============================================================================
+  // Hash builder
+  // ============================================================================
+
+  /**
+   * Canonical positionHash for staking vaults.
+   * Vault clones are owner-bound 1:1, so vaultAddress alone disambiguates.
+   */
+  static createHash(chainId: number, vaultAddress: string): string {
+    return `uniswapv3-staking/${chainId}/${vaultAddress}`;
+  }
+
+  // ============================================================================
+  // Computed Pool (same underlying pool as the wrapped NFT)
+  // ============================================================================
+
+  get pool(): PoolInterface {
+    return new UniswapV3Pool({
+      id: `uniswapv3/${this._config.chainId}/${this._config.poolAddress}`,
+      token0: this.token0,
+      token1: this.token1,
+      config: new UniswapV3PoolConfig({
+        chainId: this._config.chainId,
+        address: this._config.poolAddress,
+        token0: this._config.token0Address,
+        token1: this._config.token1Address,
+        feeBps: this._config.feeBps,
+        tickSpacing: this._config.tickSpacing,
+      }),
+      state: {
+        sqrtPriceX96: this._state.sqrtPriceX96,
+        currentTick: this._state.currentTick,
+        liquidity: this._state.poolLiquidity,
+        feeGrowthGlobal0: this._state.feeGrowthGlobal0,
+        feeGrowthGlobal1: this._state.feeGrowthGlobal1,
+      },
+      createdAt: this.createdAt,
+      updatedAt: this.updatedAt,
+    });
+  }
+
+  // ============================================================================
+  // Config/State Accessors (PositionInterface compliance)
+  // ============================================================================
+
+  get config(): Record<string, unknown> {
+    return this._config.toJSON() as unknown as Record<string, unknown>;
+  }
+
+  get state(): Record<string, unknown> {
+    return stakingPositionStateToJSON(this._state) as unknown as Record<
+      string,
+      unknown
+    >;
+  }
+
+  // ============================================================================
+  // Typed Accessors
+  // ============================================================================
+
+  get typedConfig(): UniswapV3StakingPositionConfig {
+    return this._config;
+  }
+
+  get typedState(): UniswapV3StakingPositionState {
+    return this._state;
+  }
+
+  // ============================================================================
+  // Convenience Accessors - Config
+  // ============================================================================
+
+  get chainId(): number {
+    return this._config.chainId;
+  }
+
+  get vaultAddress(): string {
+    return this._config.vaultAddress;
+  }
+
+  get factoryAddress(): string {
+    return this._config.factoryAddress;
+  }
+
+  get ownerAddress(): string {
+    return this._config.ownerAddress;
+  }
+
+  get underlyingTokenId(): number {
+    return this._config.underlyingTokenId;
+  }
+
+  get poolAddress(): string {
+    return this._config.poolAddress;
+  }
+
+  get tickLower(): number {
+    return this._config.tickLower;
+  }
+
+  get tickUpper(): number {
+    return this._config.tickUpper;
+  }
+
+  // ============================================================================
+  // Convenience Accessors - State
+  // ============================================================================
+
+  get vaultState(): UniswapV3StakingPositionState['vaultState'] {
+    return this._state.vaultState;
+  }
+
+  get liquidity(): bigint {
+    return this._state.liquidity;
+  }
+
+  get stakedBase(): bigint {
+    return this._state.stakedBase;
+  }
+
+  get stakedQuote(): bigint {
+    return this._state.stakedQuote;
+  }
+
+  get yieldTarget(): bigint {
+    return this._state.yieldTarget;
+  }
+
+  get pendingBps(): number {
+    return this._state.pendingBps;
+  }
+
+  get unclaimedYieldBase(): bigint {
+    return this._state.unclaimedYieldBase;
+  }
+
+  get unclaimedYieldQuote(): bigint {
+    return this._state.unclaimedYieldQuote;
+  }
+
+  /** Lifecycle helper — Settled means no further interactions are possible. */
+  isClosed(): boolean {
+    return this._state.vaultState === 'Settled';
+  }
+
+  // ============================================================================
+  // Position Properties (from config)
+  // ============================================================================
+
+  get isToken0Quote(): boolean {
+    return this._config.isToken0Quote;
+  }
+
+  get priceRangeLower(): bigint {
+    return this._config.priceRangeLower;
+  }
+
+  get priceRangeUpper(): bigint {
+    return this._config.priceRangeUpper;
+  }
+
+  getBaseToken(): TokenInterface {
+    return this.isToken0Quote ? this.token1 : this.token0;
+  }
+
+  getQuoteToken(): TokenInterface {
+    return this.isToken0Quote ? this.token0 : this.token1;
+  }
+
+  // ============================================================================
+  // Serialization
+  // ============================================================================
+
+  override toJSON(): PositionJSON {
+    return {
+      ...super.toJSON(),
+      isToken0Quote: this.isToken0Quote,
+      priceRangeLower: this.priceRangeLower.toString(),
+      priceRangeUpper: this.priceRangeUpper.toString(),
+    };
+  }
+
+  // ============================================================================
+  // PnL Simulation
+  // ============================================================================
+
+  simulatePnLAtPrice(price: bigint): PnLSimulationResult {
+    const baseIsToken0 = !this.isToken0Quote;
+
+    const baseToken = this.getBaseToken() as Erc20Token;
+    const quoteToken = this.getQuoteToken() as Erc20Token;
+    const sqrtPriceJSBI = priceToSqrtRatioX96(
+      baseToken.address,
+      quoteToken.address,
+      baseToken.decimals,
+      price,
+    );
+    const sqrtPriceX96 = BigInt(sqrtPriceJSBI.toString());
+
+    const positionValue = calculatePositionValue(
+      this.liquidity,
+      sqrtPriceX96,
+      this.tickLower,
+      this.tickUpper,
+      baseIsToken0,
+    );
+
+    const pnlValue = positionValue - this.costBasis;
+    const pnlPercent =
+      this.costBasis > 0n
+        ? Number((pnlValue * 1000000n) / this.costBasis) / 10000
+        : 0;
+
+    return { positionValue, pnlValue, pnlPercent };
+  }
+
+  // ============================================================================
+  // Factory Methods
+  // ============================================================================
+
+  static fromDB(
+    row: UniswapV3StakingPositionRow,
+    token0: TokenInterface,
+    token1: TokenInterface,
+  ): UniswapV3StakingPosition {
+    const configJSON = row.config as unknown as UniswapV3StakingPositionConfigJSON;
+    const stateJSON = row.state as unknown as UniswapV3StakingPositionStateJSON;
+
+    return new UniswapV3StakingPosition({
+      id: row.id,
+      positionHash: row.positionHash,
+      userId: row.userId,
+      type: row.type,
+      token0,
+      token1,
+      currentValue: row.currentValue,
+      costBasis: row.costBasis,
+      realizedPnl: row.realizedPnl,
+      unrealizedPnl: row.unrealizedPnl,
+      realizedCashflow: row.realizedCashflow,
+      unrealizedCashflow: row.unrealizedCashflow,
+      collectedYield: row.collectedYield,
+      unclaimedYield: row.unclaimedYield,
+      lastYieldClaimedAt: row.lastYieldClaimedAt,
+      baseApr: row.baseApr,
+      rewardApr: row.rewardApr,
+      totalApr: row.totalApr,
+      positionOpenedAt: row.positionOpenedAt,
+      archivedAt: row.archivedAt,
+      isArchived: row.isArchived,
+      config: UniswapV3StakingPositionConfig.fromJSON(configJSON),
+      state: stakingPositionStateFromJSON(stateJSON),
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    });
+  }
+
+  static fromJSON(
+    json: PositionJSON,
+    token0: TokenInterface,
+    token1: TokenInterface,
+  ): UniswapV3StakingPosition {
+    const configJSON = json.config as unknown as UniswapV3StakingPositionConfigJSON;
+    const stateJSON = json.state as unknown as UniswapV3StakingPositionStateJSON;
+
+    return new UniswapV3StakingPosition({
+      id: json.id,
+      positionHash: json.positionHash ?? null,
+      userId: json.userId,
+      type: json.type,
+      token0,
+      token1,
+      currentValue: BigInt(json.currentValue),
+      costBasis: BigInt(json.costBasis),
+      realizedPnl: BigInt(json.realizedPnl),
+      unrealizedPnl: BigInt(json.unrealizedPnl),
+      realizedCashflow: BigInt(json.realizedCashflow),
+      unrealizedCashflow: BigInt(json.unrealizedCashflow),
+      collectedYield: BigInt(json.collectedYield),
+      unclaimedYield: BigInt(json.unclaimedYield),
+      lastYieldClaimedAt: new Date(json.lastYieldClaimedAt),
+      baseApr: json.baseApr,
+      rewardApr: json.rewardApr,
+      totalApr: json.totalApr,
+      positionOpenedAt: new Date(json.positionOpenedAt),
+      archivedAt: json.archivedAt ? new Date(json.archivedAt) : null,
+      isArchived: json.isArchived,
+      config: UniswapV3StakingPositionConfig.fromJSON(configJSON),
+      state: stakingPositionStateFromJSON(stateJSON),
+      createdAt: new Date(json.createdAt),
+      updatedAt: new Date(json.updatedAt),
+    });
+  }
+}

--- a/packages/midcurve-shared/src/types/shared-contract/shared-contract.types.ts
+++ b/packages/midcurve-shared/src/types/shared-contract/shared-contract.types.ts
@@ -24,6 +24,7 @@ export const SharedContractName = {
   MIDCURVE_TREASURY: 'MidcurveTreasury',
   UNISWAP_V3_VAULT_FACTORY: 'UniswapV3VaultFactory',
   UNISWAP_V3_VAULT_POSITION_CLOSER: 'UniswapV3VaultPositionCloser',
+  UNISWAP_V3_STAKING_VAULT_FACTORY: 'UniswapV3StakingVaultFactory',
 } as const;
 
 export type SharedContractName =

--- a/packages/midcurve-shared/src/utils/token-hash.ts
+++ b/packages/midcurve-shared/src/utils/token-hash.ts
@@ -8,6 +8,7 @@
  * - ERC-20: "erc20/{chainId}/{address}" → { tokenType: 'erc20', chainId, address }
  * - ERC-721: "erc721/{chainId}/{contractAddress}/{tokenId}" → { tokenType: 'erc721', chainId, contractAddress, tokenId }
  * - Basic Currency: "basic-currency/{currencyCode}" → { tokenType: 'basic-currency', currencyCode }
+ * - Staking Share: "staking-share/{chainId}/{vaultAddress}" → { tokenType: 'staking-share', chainId, vaultAddress }
  *
  * @example
  * ```typescript
@@ -53,10 +54,26 @@ export interface BasicCurrencyTokenHashData {
 }
 
 /**
+ * Parsed staking-share token hash.
+ *
+ * Represents a synthetic share token for a single UniswapV3StakingVault clone.
+ * Vault clones are owner-bound 1:1, so the vault address alone disambiguates.
+ */
+export interface StakingShareTokenHashData {
+  tokenType: 'staking-share';
+  chainId: number;
+  vaultAddress: string;
+}
+
+/**
  * Discriminated union of all parsed token hash types.
  * Extend this union when adding new token type support.
  */
-export type ParsedTokenHash = Erc20TokenHashData | Erc721TokenHashData | BasicCurrencyTokenHashData;
+export type ParsedTokenHash =
+  | Erc20TokenHashData
+  | Erc721TokenHashData
+  | BasicCurrencyTokenHashData
+  | StakingShareTokenHashData;
 
 // ============================================================================
 // CREATION
@@ -140,6 +157,36 @@ export function createBasicCurrencyTokenHash(currencyCode: string): string {
   return `basic-currency/${currencyCode}`;
 }
 
+/**
+ * Create a token hash for a UniswapV3StakingVault staking share.
+ *
+ * Vault clones are owner-bound 1:1, so vaultAddress is the disambiguator.
+ *
+ * @param chainId - EVM chain ID (must be a positive integer)
+ * @param vaultAddress - EIP-55 normalized vault contract address (caller must normalize)
+ * @returns Token hash string in format "staking-share/{chainId}/{vaultAddress}"
+ * @throws Error if any parameter is invalid
+ */
+export function createStakingShareTokenHash(chainId: number, vaultAddress: string): string {
+  if (chainId === undefined || chainId === null) {
+    throw new Error('chainId is required for staking-share token hash creation');
+  }
+  if (typeof chainId !== 'number' || !Number.isInteger(chainId) || chainId <= 0) {
+    throw new Error(`chainId must be a positive integer, got ${chainId}`);
+  }
+
+  if (!vaultAddress || typeof vaultAddress !== 'string') {
+    throw new Error('vaultAddress is required for staking-share token hash creation');
+  }
+  if (!vaultAddress.startsWith('0x') || vaultAddress.length !== 42) {
+    throw new Error(
+      `vaultAddress must be a valid 0x-prefixed 42-character hex string, got "${vaultAddress}"`
+    );
+  }
+
+  return `staking-share/${chainId}/${vaultAddress}`;
+}
+
 // ============================================================================
 // PARSING
 // ============================================================================
@@ -213,6 +260,23 @@ export function parseTokenHash(hash: string): ParsedTokenHash {
         throw new Error(`Invalid currencyCode in tokenHash: empty string`);
       }
       return { tokenType: 'basic-currency', currencyCode };
+    }
+
+    case 'staking-share': {
+      if (parts.length !== 3) {
+        throw new Error(
+          `Invalid staking-share tokenHash: "${hash}" (expected "staking-share/{chainId}/{vaultAddress}")`
+        );
+      }
+      const chainId = Number(parts[1]);
+      const vaultAddress = parts[2]!;
+      if (!Number.isInteger(chainId) || chainId <= 0) {
+        throw new Error(`Invalid chainId in tokenHash: "${parts[1]}"`);
+      }
+      if (!vaultAddress.startsWith('0x') || vaultAddress.length !== 42) {
+        throw new Error(`Invalid vaultAddress in tokenHash: "${parts[2]}"`);
+      }
+      return { tokenType: 'staking-share', chainId, vaultAddress };
     }
 
     default:


### PR DESCRIPTION
## Summary

PR1 of 5 for SPEC-0003b (UniswapV3 Staking Vault — Backend Integration). Lands the type-system scaffolding, Prisma enum migration, and a self-contained ledger service that ingests `UniswapV3StakingVault` events and produces balanced `PositionLedgerEvent` chains with **Model A** semantics (yield → `deltaCollectedYield`, NOT `deltaPnl`).

Following the staged plan agreed in #63:
- **PR1 (this)** — shared types + Prisma migration + ledger service
- PR2 — on-chain subscriber + domain events
- PR3 — journal-posting rule
- PR4 — REST API
- PR5 — MCP tools

## What changed

### Shared types (`@midcurve/shared`)
- `types/position/uniswapv3-staking/` — `UniswapV3StakingPositionConfig`, `UniswapV3StakingPositionState` (with `vaultState` lifecycle + four settlement buffers + computed unclaimed yield), `UniswapV3StakingPosition` extending `BasePosition`. `createHash()` produces `uniswapv3-staking/{chainId}/{vaultAddress}` per SPEC §2.
- `types/position-ledger-event/uniswapv3-staking/` — config persists the principal/yield split on `STAKING_DISPOSE` events (per SPEC §6.4). Discriminated state union for the four event types: `STAKING_DEPOSIT`, `STAKING_DISPOSE`, `STAKING_YIELD_TARGET_SET`, `STAKING_PENDING_BPS_SET`.
- `LedgerEventProtocol` / `PositionProtocol` / `EventType` unions extended; both factories now dispatch the staking branch; `AnyPosition` union updated.
- `createStakingShareTokenHash(chainId, vaultAddress)` + `StakingShareTokenHashData` parsing branch in `utils/token-hash.ts` (per SPEC §4.3).

### Database (`@midcurve/database`)
- `TokenLotTransferEvent` enum gains `STAKING_DEPOSIT` and `STAKING_DISPOSE` (per SPEC §4.2).
- Migration: `20260504155248_add_staking_token_lot_events`.

### Service (`packages/midcurve-services`)
- `UniswapV3StakingLedgerService` (~830 LoC) mirroring the structural shape of `UniswapV3VaultLedgerService`: per-position instance, validate / decode / insert with placeholder zeros, then `recalculateAggregates` rebuilds running totals chronologically.
- **FlashClose composition**: same-TX `FlashCloseInitiated` + auto-drained `Unstake` + `ClaimRewards` → single synthesized `STAKING_DISPOSE` with `source: 'flashClose'`. Standalone `Unstake` / `ClaimRewards` (owner-driven drains) are suppressed.
- **Per-event chainContext** (`vault.state()` at block-1, NFPM liquidity at block, `stakedBase`/`stakedQuote` at block-1 for Swap, buffer deltas) is provided by the caller — keeps the service RPC-free, easily testable. PR2's subscriber will fill these in via `evmConfig`.
- **Top-up disambiguation** (per SPEC §3.1): chain-from-previous if a prior `STAKING_DEPOSIT` exists, otherwise read `vault.state()` at block-1.
- **Model A divergence in recalculateAggregates**: for `STAKING_DISPOSE`, `deltaPnl = principalQuoteValue − proportionalCostBasis` (yield is excluded); `deltaCollectedYield = yieldQuoteValue`.
- Event signatures are baked-in literal hex constants (matching `VAULT_EVENT_SIGNATURES` style).

### Tests
16 unit tests against synthesized log fixtures covering:
1. Stake (initial) — `STAKING_DEPOSIT`, `costBasisAfter` set, `pnlAfter=0`
2. Stake (top-up) — second `STAKING_DEPOSIT` with `vaultStateBefore: 'Staked'` precondition, `liquidityBefore` chained from event #1
3. Swap (50% partial) — `STAKING_DISPOSE` with principal/yield split, full Model A breakdown verified
4. FlashClose composition — single synthesized `STAKING_DISPOSE`, no standalone rows
5. Marker events (`YieldTargetSet`, `PartialUnstakeBpsSet`)
6. Standalone drains suppressed
7. Validation: wrong contract / wrong owner / unknown topic0
8. Idempotency: re-running yields same row count
9. Reorg: `deleteAllByBlockHash` cascades; `removed: true` triggers deletion
10. **Model A invariant (§12.4)**: flat-principal yield-only → `pnlAfter=0`. Positive principal-floor gain → `pnlAfter > 0` independent of yield.

## Acceptance criteria from §12 covered by this PR

- §12.2 (ledger correctness) — fully (`costBasisAfter` / `collectedYieldAfter` on event rows)
- §12.4 (Model A invariant) — fully
- §12.5 (idempotency) — fully (ledger level)
- §12.6 (reorg safety) — fully (ledger level)
- §12.3 (journal balance), §12.7 (API parity), §12.8 (no write endpoints) — deferred to PR3 / PR4

## Out of scope

- `OnchainDataSubscribers` rows + WebSocket subscription → PR2
- Domain event publishing → PR2
- `TokenLot`/`TokenLotDisposal`, journal entries, `staking-share` token upsert → PR3
- REST endpoints → PR4
- MCP tools → PR5

Refs #63

## Test plan
- [x] `pnpm typecheck` — all 14 packages pass
- [x] `pnpm --filter @midcurve/services test:run` — 154 tests pass (16 new staking)
- [x] `pnpm --filter @midcurve/shared test:run` — 127 tests pass
- [x] Migration applied: `psql ... 'SELECT unnest(enum_range(NULL::accounting."TokenLotTransferEvent"))'` shows `STAKING_DEPOSIT` and `STAKING_DISPOSE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)