### PR TITLE
feat: chain-import + domain events on staking ledger service (SPEC-0003b PR2)

### DIFF
--- a/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.test.ts
+++ b/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.test.ts
@@ -1047,10 +1047,17 @@ describe('UniswapV3StakingLedgerService', () => {
             return client;
         }
 
-        function makeEvmConfig(client: ReturnType<typeof makeMockClient>) {
+        type FinalityOverride =
+            | { type: 'blockTag' }
+            | { type: 'blockHeight'; minBlockHeight: number };
+
+        function makeEvmConfig(
+            client: ReturnType<typeof makeMockClient>,
+            finality: FinalityOverride = { type: 'blockTag' },
+        ) {
             return {
                 getPublicClient: vi.fn(() => client),
-                getFinalityConfig: vi.fn(() => ({ type: 'blockTag' as const })),
+                getFinalityConfig: vi.fn(() => finality),
             } as any;
         }
 
@@ -1352,6 +1359,49 @@ describe('UniswapV3StakingLedgerService', () => {
                 (c) => (c[0] as { event?: { name: string } }).event?.name === 'Stake',
             );
             expect((stakeCallB?.[0] as { fromBlock: bigint }).fromBlock).toBe(300n);
+
+            // Case C: finality.type === 'blockHeight' (L2 path — Arbitrum/Base).
+            // currentBlock=600, minBlockHeight=100 → derived finalized = 500.
+            // lastEvent.block = 500 → MIN(500, 500) = 500.
+            const clientC = makeMockClient({
+                currentBlock: 600n,
+                logsByEventName: {
+                    Stake: [], YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [], Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+            });
+            await service.syncFromChain(
+                makePosition(),
+                makeEvmConfig(clientC, { type: 'blockHeight', minBlockHeight: 100 }),
+                poolPriceService,
+            );
+            const stakeCallC = clientC.getLogs.mock.calls.find(
+                (c) => (c[0] as { event?: { name: string } }).event?.name === 'Stake',
+            );
+            expect((stakeCallC?.[0] as { fromBlock: bigint }).fromBlock).toBe(500n);
+            // Sanity: the blockHeight branch uses getBlockNumber (not getBlock)
+            expect(clientC.getBlockNumber).toHaveBeenCalled();
+            expect(clientC.getBlock).not.toHaveBeenCalled();
+
+            // Case D: same blockHeight finality, but currentBlock - minBlockHeight < lastEvent.block
+            // → MIN(derived finalized, lastEvent.block) picks the derived finalized.
+            // currentBlock=400, minBlockHeight=200 → derived = 200; lastEvent.block=500 → MIN=200.
+            const clientD = makeMockClient({
+                currentBlock: 400n,
+                logsByEventName: {
+                    Stake: [], YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [], Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+            });
+            await service.syncFromChain(
+                makePosition(),
+                makeEvmConfig(clientD, { type: 'blockHeight', minBlockHeight: 200 }),
+                poolPriceService,
+            );
+            const stakeCallD = clientD.getLogs.mock.calls.find(
+                (c) => (c[0] as { event?: { name: string } }).event?.name === 'Stake',
+            );
+            expect((stakeCallD?.[0] as { fromBlock: bigint }).fromBlock).toBe(200n);
         });
 
         // ----------------------------------------------------------------------

--- a/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.test.ts
+++ b/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.test.ts
@@ -17,12 +17,28 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { encodeAbiParameters, keccak256, toBytes, pad } from 'viem';
 import type { PrismaClient } from '@midcurve/database';
+import type { UniswapV3StakingPosition } from '@midcurve/shared';
 import {
     UniswapV3StakingLedgerService,
     STAKING_VAULT_EVENT_SIGNATURES,
     type StakingRawLogInput,
     type StakingLogChainContext,
 } from './uniswapv3-staking-ledger-service.js';
+
+// ============================================================================
+// MODULE MOCK: domain event publisher
+// ============================================================================
+
+const mockCreateAndPublish = vi.fn();
+const mockPublisher = { createAndPublish: mockCreateAndPublish };
+
+vi.mock('../../events/index.js', async (importOriginal) => {
+    const original: object = await (importOriginal as () => Promise<object>)();
+    return {
+        ...original,
+        getDomainEventPublisher: vi.fn(() => mockPublisher),
+    };
+});
 
 // ============================================================================
 // FIXTURES
@@ -919,6 +935,587 @@ describe('UniswapV3StakingLedgerService', () => {
             // deltaPnl = 4500 - 1500 = 3000 (purely principal-floor gain)
             expect(BigInt(dispose.deltaPnl)).toBeGreaterThan(0n);
             expect(dispose.deltaCollectedYield).toBe('0');
+        });
+    });
+
+    // ============================================================================
+    // PR2 — syncFromChain end-to-end (chain pull + publish)
+    // ============================================================================
+
+    describe('syncFromChain', () => {
+        const FACTORY_ADDRESS = '0xFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFA';
+        const POSITION_HASH = `uniswapv3-staking/${CHAIN_ID}/${VAULT_ADDRESS}`;
+
+        // Duck-typed UniswapV3StakingPosition: only the fields syncFromChain
+        // and importLogsForPosition read.
+        function makePosition(): UniswapV3StakingPosition {
+            return {
+                id: POSITION_ID,
+                userId: 'user_test',
+                positionHash: POSITION_HASH,
+                chainId: CHAIN_ID,
+                vaultAddress: VAULT_ADDRESS,
+                ownerAddress: OWNER_ADDRESS,
+                underlyingTokenId: 42,
+                factoryAddress: FACTORY_ADDRESS,
+                typedConfig: {
+                    isToken0Quote: false,
+                    vaultAddress: VAULT_ADDRESS,
+                    poolAddress: POOL_ADDRESS,
+                },
+            } as unknown as UniswapV3StakingPosition;
+        }
+
+        // Build a viem Log shape from a StakingRawLogInput.
+        function toViemLog(raw: StakingRawLogInput) {
+            return {
+                address: raw.address,
+                topics: raw.topics,
+                data: raw.data,
+                blockNumber: typeof raw.blockNumber === 'string' ? BigInt(raw.blockNumber) : raw.blockNumber,
+                blockHash: raw.blockHash,
+                transactionHash: raw.transactionHash,
+                transactionIndex: typeof raw.transactionIndex === 'string' ? Number(raw.transactionIndex) : raw.transactionIndex,
+                logIndex: typeof raw.logIndex === 'string' ? Number(raw.logIndex) : raw.logIndex,
+                removed: raw.removed ?? false,
+            };
+        }
+
+        interface MockClientOpts {
+            finalizedBlock?: bigint;
+            currentBlock?: bigint;
+            logsByEventName: Record<string, ReturnType<typeof toViemLog>[]>;
+            vaultStateByBlock?: Record<string, number>; // keyed by string(blockNumber)
+            vaultUintByFnAndBlock?: Record<string, Record<string, bigint>>; // [fn][block]
+            nfpmLiquidityByBlock?: Record<string, bigint>;
+            vaultCreatedLogs?: ReturnType<typeof toViemLog>[];
+        }
+
+        function makeMockClient(opts: MockClientOpts) {
+            const client = {
+                chain: { id: CHAIN_ID },
+                getChainId: vi.fn(async () => CHAIN_ID),
+                getBlock: vi.fn(async ({ blockTag }: { blockTag?: string }) => {
+                    if (blockTag === 'finalized') {
+                        return { number: opts.finalizedBlock ?? 1_000_000n };
+                    }
+                    throw new Error(`Unsupported blockTag: ${blockTag}`);
+                }),
+                getBlockNumber: vi.fn(async () => opts.currentBlock ?? 1_000_000n),
+                getLogs: vi.fn(async (params: {
+                    address?: string;
+                    event?: { name: string };
+                    args?: Record<string, unknown>;
+                    fromBlock?: bigint;
+                    toBlock?: bigint | 'latest';
+                }) => {
+                    const eventName = params.event?.name;
+                    if (eventName === 'VaultCreated') {
+                        return opts.vaultCreatedLogs ?? [];
+                    }
+                    return opts.logsByEventName[eventName ?? ''] ?? [];
+                }),
+                readContract: vi.fn(async (params: {
+                    functionName: string;
+                    args?: unknown[];
+                    blockNumber?: bigint;
+                }) => {
+                    const fn = params.functionName;
+                    const blockKey = params.blockNumber !== undefined
+                        ? params.blockNumber.toString()
+                        : 'latest';
+                    if (fn === 'state') {
+                        return opts.vaultStateByBlock?.[blockKey] ?? 0;
+                    }
+                    if (fn === 'positions') {
+                        const liquidity = opts.nfpmLiquidityByBlock?.[blockKey] ?? 0n;
+                        return [
+                            0n, '0x0000000000000000000000000000000000000000',
+                            TOKEN0, TOKEN1, 3000, -100, 100,
+                            liquidity, 0n, 0n, 0n, 0n,
+                        ];
+                    }
+                    if (
+                        fn === 'stakedBase' || fn === 'stakedQuote' ||
+                        fn === 'rewardBufferBase' || fn === 'rewardBufferQuote'
+                    ) {
+                        return opts.vaultUintByFnAndBlock?.[fn]?.[blockKey] ?? 0n;
+                    }
+                    throw new Error(`Unmocked readContract: ${fn} at block ${blockKey}`);
+                }),
+            };
+            return client;
+        }
+
+        function makeEvmConfig(client: ReturnType<typeof makeMockClient>) {
+            return {
+                getPublicClient: vi.fn(() => client),
+                getFinalityConfig: vi.fn(() => ({ type: 'blockTag' as const })),
+            } as any;
+        }
+
+        beforeEach(() => {
+            mockCreateAndPublish.mockReset();
+        });
+
+        // ----------------------------------------------------------------------
+        // 1. Happy path: Stake + Swap end-to-end
+        // ----------------------------------------------------------------------
+        it('happy path — Stake + Swap → 2 ledger rows + 2 domain events', async () => {
+            const stakeRaw = makeStakeLog(100n, '0xtxStake', '0xblkStake', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const swapRaw = makeSwapLog(200n, '0xtxSwap', '0xblkSwap', 0, {
+                tokenIn: TOKEN1, amountIn: 250n, tokenOut: TOKEN0, amountOut: 250n,
+                effectiveBps: 5000,
+                chainContext: {
+                    stakedBaseBefore: 1000n, stakedQuoteBefore: 500n,
+                    rewardBufferBaseDelta: 50n, rewardBufferQuoteDelta: 25n,
+                    liquidityAfter: 500_000n,
+                },
+            });
+
+            const client = makeMockClient({
+                finalizedBlock: 1_000_000n,
+                logsByEventName: {
+                    Stake: [toViemLog(stakeRaw)],
+                    Swap: [toViemLog(swapRaw)],
+                    YieldTargetSet: [],
+                    PartialUnstakeBpsSet: [],
+                    Unstake: [],
+                    ClaimRewards: [],
+                    FlashCloseInitiated: [],
+                },
+                // Stake at block 100, vaultState read at block 99 (block-1)
+                vaultStateByBlock: { '99': 0 /* Empty */ },
+                // NFPM liquidity reads
+                nfpmLiquidityByBlock: { '100': 1_000_000n, '200': 500_000n },
+                // Swap at block 200; vault state reads at block 199 + 200
+                vaultUintByFnAndBlock: {
+                    stakedBase: { '199': 1000n },
+                    stakedQuote: { '199': 500n },
+                    rewardBufferBase: { '199': 0n, '200': 50n },
+                    rewardBufferQuote: { '199': 0n, '200': 25n },
+                },
+                // VaultCreated lookup — returns the vault's birth block (used because no prior events)
+                vaultCreatedLogs: [{
+                    address: FACTORY_ADDRESS,
+                    topics: [
+                        keccak256(toBytes('VaultCreated(address,address)')),
+                        pad(OWNER_ADDRESS.toLowerCase() as `0x${string}`, { size: 32 }),
+                        pad(VAULT_ADDRESS.toLowerCase() as `0x${string}`, { size: 32 }),
+                    ],
+                    data: '0x',
+                    blockNumber: 50n, // birth block, well before our stake at 100
+                    blockHash: '0xblkBirth',
+                    transactionHash: '0xtxBirth',
+                    transactionIndex: 0,
+                    logIndex: 0,
+                    removed: false,
+                }],
+            });
+            const evmConfig = makeEvmConfig(client);
+
+            const result = await service.syncFromChain(
+                makePosition(), evmConfig, poolPriceService,
+            );
+
+            // 2 ledger rows
+            expect(fake.store.length).toBe(2);
+            const events = [...fake.store].sort(
+                (a, b) => Number((a.config as any).blockNumber) - Number((b.config as any).blockNumber),
+            );
+            expect(events[0]!.eventType).toBe('STAKING_DEPOSIT');
+            expect(events[1]!.eventType).toBe('STAKING_DISPOSE');
+
+            // 2 domain events (one increased, one decreased), no reverts
+            expect(mockCreateAndPublish).toHaveBeenCalledTimes(2);
+            const types = mockCreateAndPublish.mock.calls.map((c) => c[0].type);
+            expect(types).toEqual([
+                'position.liquidity.increased',
+                'position.liquidity.decreased',
+            ]);
+
+            // Payloads carry the right ledgerInputHash + positionHash
+            const incCall = mockCreateAndPublish.mock.calls[0]![0];
+            expect(incCall.payload.positionHash).toBe(POSITION_HASH);
+            expect(incCall.payload.ledgerInputHash).toBe(events[0]!.inputHash);
+            expect(incCall.entityId).toBe(POSITION_ID);
+            expect(incCall.entityType).toBe('position');
+
+            // Result aggregates reflect the import
+            expect(result.postImportAggregates.liquidityAfter).toBe(500_000n);
+        });
+
+        // ----------------------------------------------------------------------
+        // 2. fetchStakingVaultLogs: 7 parallel getLogs calls
+        // ----------------------------------------------------------------------
+        it('fetchStakingVaultLogs — issues 7 parallel getLogs calls (one per event signature)', async () => {
+            const client = makeMockClient({
+                finalizedBlock: 1_000_000n,
+                logsByEventName: {
+                    Stake: [], YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [], Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+                // Provide a VaultCreated record so resolveFromBlock can find a birth block
+                vaultCreatedLogs: [{
+                    address: FACTORY_ADDRESS,
+                    topics: [
+                        keccak256(toBytes('VaultCreated(address,address)')),
+                        pad(OWNER_ADDRESS.toLowerCase() as `0x${string}`, { size: 32 }),
+                        pad(VAULT_ADDRESS.toLowerCase() as `0x${string}`, { size: 32 }),
+                    ],
+                    data: '0x', blockNumber: 50n, blockHash: '0xblkBirth',
+                    transactionHash: '0xtxBirth', transactionIndex: 0, logIndex: 0, removed: false,
+                }],
+            });
+            const evmConfig = makeEvmConfig(client);
+
+            await service.syncFromChain(makePosition(), evmConfig, poolPriceService);
+
+            // First getLogs is the VaultCreated factory lookup, then 7 vault-event calls.
+            const eventNames = client.getLogs.mock.calls.map(
+                (c) => (c[0] as { event?: { name: string } }).event?.name,
+            );
+            const vaultEventCalls = eventNames.filter((n) => n !== 'VaultCreated');
+            expect(vaultEventCalls.sort()).toEqual([
+                'ClaimRewards',
+                'FlashCloseInitiated',
+                'PartialUnstakeBpsSet',
+                'Stake',
+                'Swap',
+                'Unstake',
+                'YieldTargetSet',
+            ]);
+        });
+
+        // ----------------------------------------------------------------------
+        // 3. populateChainContext branches
+        // ----------------------------------------------------------------------
+        it('populateChainContext — Stake reads vault.state at block-1 + NFPM liquidity at block', async () => {
+            const stakeRaw = makeStakeLog(100n, '0xtxS', '0xblkS', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 0n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 0n }, // ignored — re-fetched
+            });
+            const client = makeMockClient({
+                finalizedBlock: 1_000_000n,
+                logsByEventName: {
+                    Stake: [toViemLog(stakeRaw)],
+                    YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [], Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+                vaultStateByBlock: { '99': 0 /* Empty */ },
+                nfpmLiquidityByBlock: { '100': 1_000_000n },
+                vaultCreatedLogs: [{
+                    address: FACTORY_ADDRESS,
+                    topics: [
+                        keccak256(toBytes('VaultCreated(address,address)')),
+                        pad(OWNER_ADDRESS.toLowerCase() as `0x${string}`, { size: 32 }),
+                        pad(VAULT_ADDRESS.toLowerCase() as `0x${string}`, { size: 32 }),
+                    ],
+                    data: '0x', blockNumber: 50n, blockHash: '0xblkBirth',
+                    transactionHash: '0xtxBirth', transactionIndex: 0, logIndex: 0, removed: false,
+                }],
+            });
+            const evmConfig = makeEvmConfig(client);
+
+            await service.syncFromChain(makePosition(), evmConfig, poolPriceService);
+
+            // Verify the contract reads happened on the right blocks.
+            const reads = client.readContract.mock.calls.map((c) => c[0]);
+            const stateRead = reads.find((r: any) => r.functionName === 'state');
+            expect(stateRead?.blockNumber).toBe(99n);
+            const positionsRead = reads.find((r: any) => r.functionName === 'positions');
+            expect(positionsRead?.blockNumber).toBe(100n);
+
+            const dep = fake.store[0]!;
+            expect((dep.config as any).liquidityAfter).toBe('1000000');
+            expect((dep.state as any).isInitial).toBe(true);
+        });
+
+        it('populateChainContext — Swap reads stakedBefore + buffer deltas + NFPM liquidity', async () => {
+            // Pre-populate a STAKING_DEPOSIT so Swap is not the first event
+            const stake = makeStakeLog(100n, '0xtxA', '0xblkA', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 0n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake], poolPriceService,
+            );
+            mockCreateAndPublish.mockReset();
+
+            const swapRaw = makeSwapLog(200n, '0xtxB', '0xblkB', 0, {
+                tokenIn: TOKEN1, amountIn: 0n, tokenOut: TOKEN0, amountOut: 0n,
+                effectiveBps: 5000,
+                chainContext: { liquidityAfter: 0n, stakedBaseBefore: 0n, stakedQuoteBefore: 0n,
+                                rewardBufferBaseDelta: 0n, rewardBufferQuoteDelta: 0n }, // ignored
+            });
+            const client = makeMockClient({
+                finalizedBlock: 1_000_000n,
+                logsByEventName: {
+                    Stake: [], YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [toViemLog(swapRaw)],
+                    Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+                vaultUintByFnAndBlock: {
+                    stakedBase: { '199': 1000n },
+                    stakedQuote: { '199': 500n },
+                    rewardBufferBase: { '199': 0n, '200': 50n },
+                    rewardBufferQuote: { '199': 0n, '200': 25n },
+                },
+                nfpmLiquidityByBlock: { '200': 500_000n },
+            });
+            const evmConfig = makeEvmConfig(client);
+
+            await service.syncFromChain(makePosition(), evmConfig, poolPriceService);
+
+            const dispose = fake.store.find((e) => e.eventType === 'STAKING_DISPOSE')!;
+            const cfg = dispose.config as any;
+            expect(cfg.principalBaseDelta).toBe('500'); // 1000 × 5000/10000
+            expect(cfg.principalQuoteDelta).toBe('250'); // 500 × 5000/10000
+            expect(cfg.yieldBaseDelta).toBe('50');
+            expect(cfg.yieldQuoteDelta).toBe('25');
+            expect(cfg.liquidityAfter).toBe('500000');
+        });
+
+        // ----------------------------------------------------------------------
+        // 4. resolveFromBlock — no prior event → factory VaultCreated lookup
+        // ----------------------------------------------------------------------
+        it('resolveFromBlock — uses factory VaultCreated event when no prior ledger event', async () => {
+            const client = makeMockClient({
+                finalizedBlock: 1_000_000n,
+                logsByEventName: {
+                    Stake: [], YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [], Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+                vaultCreatedLogs: [{
+                    address: FACTORY_ADDRESS,
+                    topics: [
+                        keccak256(toBytes('VaultCreated(address,address)')),
+                        pad(OWNER_ADDRESS.toLowerCase() as `0x${string}`, { size: 32 }),
+                        pad(VAULT_ADDRESS.toLowerCase() as `0x${string}`, { size: 32 }),
+                    ],
+                    data: '0x', blockNumber: 12345n, blockHash: '0xblkBirth',
+                    transactionHash: '0xtxBirth', transactionIndex: 0, logIndex: 0, removed: false,
+                }],
+            });
+            const evmConfig = makeEvmConfig(client);
+
+            await service.syncFromChain(makePosition(), evmConfig, poolPriceService);
+
+            // The vault-event getLogs should have used fromBlock = 12345n.
+            const stakeCall = client.getLogs.mock.calls.find(
+                (c) => (c[0] as { event?: { name: string } }).event?.name === 'Stake',
+            );
+            expect((stakeCall?.[0] as { fromBlock: bigint }).fromBlock).toBe(12345n);
+        });
+
+        // ----------------------------------------------------------------------
+        // 5. resolveFromBlock — with prior event → MIN(finalized, lastEvent.block)
+        // ----------------------------------------------------------------------
+        it('resolveFromBlock — uses MIN(finalizedBlock, lastEventBlock) when a prior event exists', async () => {
+            // Pre-populate a stake at block 500 in fake.store via importLogsForPosition
+            const stake = makeStakeLog(500n, '0xtxA', '0xblkA', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 0n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake], poolPriceService,
+            );
+            mockCreateAndPublish.mockReset();
+
+            // Case A: finalized > lastEvent.block → use lastEvent.block (500)
+            const clientA = makeMockClient({
+                finalizedBlock: 1_000_000n,
+                logsByEventName: {
+                    Stake: [], YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [], Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+            });
+            await service.syncFromChain(makePosition(), makeEvmConfig(clientA), poolPriceService);
+            const stakeCallA = clientA.getLogs.mock.calls.find(
+                (c) => (c[0] as { event?: { name: string } }).event?.name === 'Stake',
+            );
+            expect((stakeCallA?.[0] as { fromBlock: bigint }).fromBlock).toBe(500n);
+
+            // Case B: finalized < lastEvent.block → use finalized (300)
+            const clientB = makeMockClient({
+                finalizedBlock: 300n,
+                logsByEventName: {
+                    Stake: [], YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [], Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+            });
+            await service.syncFromChain(makePosition(), makeEvmConfig(clientB), poolPriceService);
+            const stakeCallB = clientB.getLogs.mock.calls.find(
+                (c) => (c[0] as { event?: { name: string } }).event?.name === 'Stake',
+            );
+            expect((stakeCallB?.[0] as { fromBlock: bigint }).fromBlock).toBe(300n);
+        });
+
+        // ----------------------------------------------------------------------
+        // 6. Reorg revert publishing
+        // ----------------------------------------------------------------------
+        it('reorg — removed:true log triggers position.liquidity.reverted publish', async () => {
+            // Pre-populate one stake event so there's something to revert
+            const stake = makeStakeLog(100n, '0xtxA', '0xblkA', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 0n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake], poolPriceService,
+            );
+            mockCreateAndPublish.mockReset();
+
+            // Now sync sees the same log returned by getLogs but flagged removed
+            const removedLog = { ...toViemLog(stake), removed: true };
+            const client = makeMockClient({
+                finalizedBlock: 1_000_000n,
+                logsByEventName: {
+                    Stake: [removedLog],
+                    YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [], Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+            });
+            await service.syncFromChain(makePosition(), makeEvmConfig(client), poolPriceService);
+
+            // Expect exactly one revert publish, no insert publish.
+            expect(mockCreateAndPublish).toHaveBeenCalledTimes(1);
+            const call = mockCreateAndPublish.mock.calls[0]![0];
+            expect(call.type).toBe('position.liquidity.reverted');
+            expect(call.payload.blockHash).toBe('0xblkA');
+            expect(call.payload.deletedCount).toBe(1);
+            expect(fake.store.length).toBe(0);
+        });
+
+        // ----------------------------------------------------------------------
+        // 7. Marker event — no domain event publish
+        // ----------------------------------------------------------------------
+        it('marker — YieldTargetSet inserts a ledger row but does NOT publish a domain event', async () => {
+            // Pre-stake so liquidityAfter is meaningful for the marker
+            const stake = makeStakeLog(100n, '0xtxA', '0xblkA', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 0n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake], poolPriceService,
+            );
+            mockCreateAndPublish.mockReset();
+
+            const ytRaw = makeYieldTargetSetLog(150n, '0xtxYT', '0xblkYT', 0, {
+                oldTarget: 0n, newTarget: 999n,
+            });
+            const client = makeMockClient({
+                finalizedBlock: 1_000_000n,
+                logsByEventName: {
+                    Stake: [],
+                    YieldTargetSet: [toViemLog(ytRaw)],
+                    PartialUnstakeBpsSet: [],
+                    Swap: [], Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+            });
+            await service.syncFromChain(makePosition(), makeEvmConfig(client), poolPriceService);
+
+            const ytRow = fake.store.find((e) => e.eventType === 'STAKING_YIELD_TARGET_SET');
+            expect(ytRow).toBeDefined();
+            expect(mockCreateAndPublish).not.toHaveBeenCalled();
+        });
+
+        // ----------------------------------------------------------------------
+        // 8. Idempotency — second sync with same logs adds no new rows nor publishes
+        // ----------------------------------------------------------------------
+        it('idempotency — re-running syncFromChain with the same logs is a no-op', async () => {
+            const stakeRaw = makeStakeLog(100n, '0xtxA', '0xblkA', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 0n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const client = makeMockClient({
+                finalizedBlock: 1_000_000n,
+                logsByEventName: {
+                    Stake: [toViemLog(stakeRaw)],
+                    YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [], Unstake: [], ClaimRewards: [], FlashCloseInitiated: [],
+                },
+                vaultStateByBlock: { '99': 0 },
+                nfpmLiquidityByBlock: { '100': 1_000_000n },
+                vaultCreatedLogs: [{
+                    address: FACTORY_ADDRESS,
+                    topics: [
+                        keccak256(toBytes('VaultCreated(address,address)')),
+                        pad(OWNER_ADDRESS.toLowerCase() as `0x${string}`, { size: 32 }),
+                        pad(VAULT_ADDRESS.toLowerCase() as `0x${string}`, { size: 32 }),
+                    ],
+                    data: '0x', blockNumber: 50n, blockHash: '0xblkBirth',
+                    transactionHash: '0xtxBirth', transactionIndex: 0, logIndex: 0, removed: false,
+                }],
+            });
+            const evmConfig = makeEvmConfig(client);
+
+            await service.syncFromChain(makePosition(), evmConfig, poolPriceService);
+            const after1 = fake.store.length;
+            const publishes1 = mockCreateAndPublish.mock.calls.length;
+
+            await service.syncFromChain(makePosition(), evmConfig, poolPriceService);
+            const after2 = fake.store.length;
+            const publishes2 = mockCreateAndPublish.mock.calls.length;
+
+            expect(after1).toBe(1);
+            expect(after2).toBe(1);          // no new rows
+            expect(publishes2).toBe(publishes1); // no new publishes
+        });
+
+        // ----------------------------------------------------------------------
+        // 9. FlashClose end-to-end via syncFromChain (refinement #3)
+        // ----------------------------------------------------------------------
+        it('flashClose — FlashCloseInitiated + same-tx Unstake + ClaimRewards → 1 dispose row + 1 decreased event', async () => {
+            // Pre-stake so the flashClose dispose has a cost basis to consume
+            const stake = makeStakeLog(100n, '0xtxA', '0xblkA', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 0n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake], poolPriceService,
+            );
+            mockCreateAndPublish.mockReset();
+
+            const fci = makeFlashCloseInitiatedLog(200n, '0xtxFC', '0xblkFC', 0, {
+                bps: 10000,
+                callbackTarget: '0xE5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5E5',
+                chainContext: { liquidityAfter: 0n },
+            });
+            const unstake = makeUnstakeLog(200n, '0xtxFC', '0xblkFC', 1, {
+                base: 1000n, quote: 500n,
+            });
+            const claim = makeClaimRewardsLog(200n, '0xtxFC', '0xblkFC', 2, {
+                base: 100n, quote: 50n,
+            });
+
+            const client = makeMockClient({
+                finalizedBlock: 1_000_000n,
+                logsByEventName: {
+                    Stake: [],
+                    YieldTargetSet: [], PartialUnstakeBpsSet: [],
+                    Swap: [],
+                    Unstake: [toViemLog(unstake)],
+                    ClaimRewards: [toViemLog(claim)],
+                    FlashCloseInitiated: [toViemLog(fci)],
+                },
+                nfpmLiquidityByBlock: { '200': 0n },
+            });
+            const evmConfig = makeEvmConfig(client);
+
+            await service.syncFromChain(makePosition(), evmConfig, poolPriceService);
+
+            // Exactly 1 STAKING_DISPOSE row (composition succeeded — Unstake/Claim folded)
+            const disposes = fake.store.filter((e) => e.eventType === 'STAKING_DISPOSE');
+            expect(disposes.length).toBe(1);
+            expect((disposes[0]!.state as any).source).toBe('flashClose');
+
+            // Exactly 1 domain event (decreased) — neither Unstake nor ClaimRewards leaks through
+            expect(mockCreateAndPublish).toHaveBeenCalledTimes(1);
+            const call = mockCreateAndPublish.mock.calls[0]![0];
+            expect(call.type).toBe('position.liquidity.decreased');
         });
     });
 });

--- a/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.ts
+++ b/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.ts
@@ -19,7 +19,7 @@
  *   This differs from UniswapV3LedgerService where COLLECT events add fees to PnL.
  */
 
-import { decodeAbiParameters } from 'viem';
+import { decodeAbiParameters, parseAbiItem, type Address, type PublicClient } from 'viem';
 import { prisma as prismaClient, PrismaClient } from '@midcurve/database';
 import {
     UniswapV3StakingPositionLedgerEvent,
@@ -29,6 +29,7 @@ import {
     valueOfToken1AmountInToken0,
 } from '@midcurve/shared';
 import type {
+    UniswapV3StakingPosition,
     UniswapV3StakingPositionLedgerEventRow,
     UniswapV3StakingLedgerEventConfig,
     UniswapV3StakingLedgerEventState,
@@ -40,6 +41,16 @@ import { createServiceLogger } from '../../logging/index.js';
 import type { ServiceLogger } from '../../logging/index.js';
 import type { PrismaTransactionClient } from '../../clients/prisma/index.js';
 import type { UniswapV3PoolPriceService } from '../pool-price/uniswapv3-pool-price-service.js';
+import type { EvmConfig } from '../../config/evm.js';
+import {
+    getPositionManagerAddress,
+    UNISWAP_V3_POSITION_MANAGER_ABI,
+} from '../../config/uniswapv3.js';
+import { getDomainEventPublisher } from '../../events/index.js';
+import type {
+    PositionLedgerEventPayload,
+    PositionLiquidityRevertedPayload,
+} from '../../events/types.js';
 
 // ============================================================================
 // EVENT SIGNATURES
@@ -62,14 +73,94 @@ export const STAKING_VAULT_EVENT_SIGNATURES = {
 export type ValidStakingEventType = keyof typeof STAKING_VAULT_EVENT_SIGNATURES;
 
 // ============================================================================
+// PARSED ABI ITEMS (for client.getLogs filtering)
+// ============================================================================
+
+const STAKING_VAULT_PARSED_EVENTS = {
+    STAKE: parseAbiItem(
+        'event Stake(address indexed owner, uint256 base, uint256 quote, uint256 yieldTarget, uint256 tokenId)',
+    ),
+    YIELD_TARGET_SET: parseAbiItem(
+        'event YieldTargetSet(address indexed owner, uint256 oldTarget, uint256 newTarget)',
+    ),
+    PARTIAL_UNSTAKE_BPS_SET: parseAbiItem(
+        'event PartialUnstakeBpsSet(address indexed owner, uint16 oldBps, uint16 newBps)',
+    ),
+    SWAP: parseAbiItem(
+        'event Swap(address indexed executor, address tokenIn, uint256 amountIn, address tokenOut, uint256 amountOut, uint16 effectiveBps)',
+    ),
+    UNSTAKE: parseAbiItem(
+        'event Unstake(address indexed owner, uint256 base, uint256 quote)',
+    ),
+    CLAIM_REWARDS: parseAbiItem(
+        'event ClaimRewards(address indexed owner, uint256 baseAmount, uint256 quoteAmount)',
+    ),
+    FLASH_CLOSE_INITIATED: parseAbiItem(
+        'event FlashCloseInitiated(address indexed owner, uint16 bps, address indexed callbackTarget, bytes data)',
+    ),
+} as const;
+
+/**
+ * Factory event used by `resolveFromBlock` to find a vault clone's birth block.
+ * `vault` is indexed (topic[2]), so we filter by it directly in `getLogs`.
+ */
+const VAULT_CREATED_EVENT = parseAbiItem(
+    'event VaultCreated(address indexed owner, address indexed vault)',
+);
+
+// ============================================================================
+// STAKING VAULT READ ABI (subset used by populateChainContext)
+// ============================================================================
+
+const STAKING_VAULT_READ_ABI = [
+    {
+        type: 'function', name: 'state', stateMutability: 'view',
+        inputs: [], outputs: [{ type: 'uint8' }],
+    },
+    {
+        type: 'function', name: 'stakedBase', stateMutability: 'view',
+        inputs: [], outputs: [{ type: 'uint256' }],
+    },
+    {
+        type: 'function', name: 'stakedQuote', stateMutability: 'view',
+        inputs: [], outputs: [{ type: 'uint256' }],
+    },
+    {
+        type: 'function', name: 'rewardBufferBase', stateMutability: 'view',
+        inputs: [], outputs: [{ type: 'uint256' }],
+    },
+    {
+        type: 'function', name: 'rewardBufferQuote', stateMutability: 'view',
+        inputs: [], outputs: [{ type: 'uint256' }],
+    },
+] as const;
+
+/** Map `vault.state()` uint8 result back to the typed `StakingState`. */
+const STAKING_STATE_BY_INDEX: Record<number, StakingState> = {
+    0: 'Empty',
+    1: 'Staked',
+    2: 'FlashCloseInProgress',
+    3: 'Settled',
+};
+
+function stakingStateFromIndex(idx: number): StakingState {
+    const state = STAKING_STATE_BY_INDEX[idx];
+    if (state === undefined) {
+        throw new Error(`Unknown vault state index: ${idx}`);
+    }
+    return state;
+}
+
+// ============================================================================
 // RAW LOG TYPES
 // ============================================================================
 
 /**
  * Optional pre-fetched chain state for events that need it.
  *
- * Subscribers (PR2) populate these via NFPM/vault contract reads.
- * Unit tests inject them directly into fixtures.
+ * Populated by `syncFromChain` via NFPM and vault contract reads at the
+ * appropriate block heights. Unit tests inject the same shape directly
+ * into fixtures to exercise `importLogsForPosition` in isolation.
  *
  * Required fields by event type:
  * - Stake: `vaultStateBefore`, `liquidityAfter` (all fields below required for top-up disambiguation)
@@ -1337,5 +1428,412 @@ export class UniswapV3StakingLedgerService {
             yieldQuoteValue,
             source,
         };
+    }
+
+    // ============================================================================
+    // CHAIN IMPORT (PR2) — pull logs, populate context, import, publish events
+    // ============================================================================
+
+    /**
+     * Sync the position's ledger from chain.
+     *
+     * Mirrors `UniswapV3PositionService.refreshAllPositionLogs` (canonical
+     * reference for the NFT version) but is hosted on the ledger service
+     * directly because there is no `UniswapV3StakingPositionService` yet
+     * (that's PR4). This method:
+     *
+     *  1. Resolves `fromBlock`:
+     *     - If a prior event exists: `MIN(finalizedBlock, lastEvent.blockNumber)`
+     *       so any unfinalized tail is re-pulled and reorgs heal.
+     *     - Otherwise: search the factory's `VaultCreated` event for this
+     *       vault to find its birth block (analog of `findNftMintBlock`).
+     *  2. Pulls all 7 vault events via `client.getLogs` over [fromBlock, toBlock]
+     *     in parallel.
+     *  3. Populates per-log `StakingLogChainContext` via NFPM/vault contract reads.
+     *  4. Calls `importLogsForPosition` (PR1) — handles validation, decoding,
+     *     flashClose composition, dedup, reorg detection, recalc.
+     *  5. Publishes domain events via the outbox-backed `DomainEventPublisher`:
+     *     - `position.liquidity.reverted` per blockHash from
+     *       `importResult.allDeletedEvents` (revert events first).
+     *     - `position.liquidity.{increased,decreased}` for each newly inserted
+     *       STAKING_DEPOSIT / STAKING_DISPOSE event. Markers don't publish.
+     */
+    async syncFromChain(
+        position: UniswapV3StakingPosition,
+        evmConfig: EvmConfig,
+        poolPriceService: UniswapV3PoolPriceService,
+        opts: { toBlock?: number | 'latest'; factoryAddress?: string } = {},
+        dbTx?: PrismaTransactionClient,
+    ): Promise<StakingImportLogsResult> {
+        const chainId = position.chainId;
+        const vaultAddress = position.vaultAddress;
+        const ownerAddress = position.ownerAddress;
+        const underlyingTokenId = position.underlyingTokenId;
+        const factoryAddress = opts.factoryAddress ?? position.factoryAddress;
+        const client = evmConfig.getPublicClient(chainId);
+
+        const lastEvent = await this.findLast(dbTx);
+        const fromBlock = await this.resolveFromBlock(
+            client, evmConfig, chainId, vaultAddress, factoryAddress, lastEvent,
+        );
+        const toBlock: bigint | 'latest' =
+            opts.toBlock === undefined || opts.toBlock === 'latest'
+                ? 'latest'
+                : BigInt(opts.toBlock);
+
+        this.logger.info(
+            { positionId: this.positionId, chainId, vaultAddress, fromBlock: fromBlock.toString(), toBlock: toBlock.toString() },
+            'Starting staking-vault sync',
+        );
+
+        const rawLogs = await this.fetchStakingVaultLogs(
+            client, vaultAddress, fromBlock, toBlock,
+        );
+
+        // Populate chainContext for each log that needs it.
+        const enrichedLogs: StakingRawLogInput[] = await Promise.all(
+            rawLogs.map(async (log) => {
+                const chainContext = await this.populateChainContext(
+                    client, vaultAddress, underlyingTokenId, log,
+                );
+                return chainContext === null ? log : { ...log, chainContext };
+            }),
+        );
+
+        const importResult = await this.importLogsForPosition(
+            position,
+            chainId,
+            ownerAddress,
+            enrichedLogs,
+            poolPriceService,
+            dbTx,
+        );
+
+        await this.publishImportEvents(position, importResult, dbTx);
+
+        return importResult;
+    }
+
+    /**
+     * Resolve `fromBlock` using the same MIN(finalized, lastEvent) rule as the
+     * NFT canonical service. When no events exist for this position, search
+     * the factory for the vault's birth block.
+     */
+    private async resolveFromBlock(
+        client: PublicClient,
+        evmConfig: EvmConfig,
+        chainId: number,
+        vaultAddress: string,
+        factoryAddress: string | undefined,
+        lastEvent: UniswapV3StakingPositionLedgerEvent | null,
+    ): Promise<bigint> {
+        if (!lastEvent) {
+            if (!factoryAddress) {
+                throw new Error(
+                    `resolveFromBlock: no prior event for position ${this.positionId} ` +
+                    `and no factoryAddress provided to find the vault's birth block`,
+                );
+            }
+            const birthBlock = await this.findVaultBirthBlock(client, factoryAddress, vaultAddress);
+            if (birthBlock === null) {
+                throw new Error(
+                    `resolveFromBlock: VaultCreated event not found for vault ${vaultAddress} ` +
+                    `in factory ${factoryAddress}`,
+                );
+            }
+            return birthBlock;
+        }
+
+        // With a prior event, resume at MIN(finalizedBlock, lastEvent.blockNumber).
+        const finalityConfig = evmConfig.getFinalityConfig(chainId);
+        let finalizedBlockNumber: bigint;
+        if (finalityConfig.type === 'blockTag') {
+            const finalizedBlock = await client.getBlock({ blockTag: 'finalized' });
+            finalizedBlockNumber = finalizedBlock.number;
+        } else {
+            const currentBlock = await client.getBlockNumber();
+            finalizedBlockNumber = currentBlock - BigInt(finalityConfig.minBlockHeight);
+        }
+        const lastEventBlock = lastEvent.typedConfig.blockNumber;
+        return finalizedBlockNumber < lastEventBlock ? finalizedBlockNumber : lastEventBlock;
+    }
+
+    /**
+     * Find the block where the factory deployed this vault clone.
+     * Filters `VaultCreated` events by the indexed `vault` topic.
+     */
+    private async findVaultBirthBlock(
+        client: PublicClient,
+        factoryAddress: string,
+        vaultAddress: string,
+    ): Promise<bigint | null> {
+        const logs = await client.getLogs({
+            address: factoryAddress as Address,
+            event: VAULT_CREATED_EVENT,
+            args: { vault: vaultAddress as Address },
+            fromBlock: 0n,
+            toBlock: 'latest',
+        });
+        if (logs.length === 0) return null;
+        // First match wins; clones are 1:1 so there should be exactly one.
+        return logs[0]!.blockNumber!;
+    }
+
+    /**
+     * Fetch all 7 staking-vault event types over [fromBlock, toBlock] in parallel
+     * and merge into a single `StakingRawLogInput[]` sorted by (blockNumber, logIndex).
+     */
+    private async fetchStakingVaultLogs(
+        client: PublicClient,
+        vaultAddress: string,
+        fromBlock: bigint,
+        toBlock: bigint | 'latest',
+    ): Promise<StakingRawLogInput[]> {
+        const common = {
+            address: vaultAddress as Address,
+            fromBlock,
+            toBlock,
+        };
+
+        const [stake, yieldTargetSet, partialBpsSet, swap, unstake, claim, flashCloseInit] = await Promise.all([
+            client.getLogs({ ...common, event: STAKING_VAULT_PARSED_EVENTS.STAKE }),
+            client.getLogs({ ...common, event: STAKING_VAULT_PARSED_EVENTS.YIELD_TARGET_SET }),
+            client.getLogs({ ...common, event: STAKING_VAULT_PARSED_EVENTS.PARTIAL_UNSTAKE_BPS_SET }),
+            client.getLogs({ ...common, event: STAKING_VAULT_PARSED_EVENTS.SWAP }),
+            client.getLogs({ ...common, event: STAKING_VAULT_PARSED_EVENTS.UNSTAKE }),
+            client.getLogs({ ...common, event: STAKING_VAULT_PARSED_EVENTS.CLAIM_REWARDS }),
+            client.getLogs({ ...common, event: STAKING_VAULT_PARSED_EVENTS.FLASH_CLOSE_INITIATED }),
+        ]);
+
+        const allLogs = [...stake, ...yieldTargetSet, ...partialBpsSet, ...swap, ...unstake, ...claim, ...flashCloseInit];
+        allLogs.sort((a, b) => {
+            const blockDiff = Number(a.blockNumber! - b.blockNumber!);
+            if (blockDiff !== 0) return blockDiff;
+            return a.logIndex! - b.logIndex!;
+        });
+
+        return allLogs.map((log) => ({
+            address: log.address,
+            topics: log.topics as unknown as string[],
+            data: log.data,
+            blockNumber: log.blockNumber!,
+            blockHash: log.blockHash!,
+            transactionHash: log.transactionHash!,
+            transactionIndex: log.transactionIndex!,
+            logIndex: log.logIndex!,
+            removed: (log as { removed?: boolean }).removed ?? false,
+        }));
+    }
+
+    /**
+     * Populate `StakingLogChainContext` for a log via NFPM and vault reads.
+     * Returns `null` if the event type does not require chain context
+     * (markers, standalone Unstake/ClaimRewards).
+     *
+     * Per-block deduplication is intentionally NOT done here — premature at
+     * staking volumes per the SPEC discussion; the NFT canonical service does
+     * not dedup either. Revisit if a single position ever sees N>10 events
+     * in a single block in production.
+     */
+    private async populateChainContext(
+        client: PublicClient,
+        vaultAddress: string,
+        underlyingTokenId: number,
+        log: StakingRawLogInput,
+    ): Promise<StakingLogChainContext | null> {
+        const topic0 = log.topics[0]?.toLowerCase();
+        const blockNumber = typeof log.blockNumber === 'string'
+            ? BigInt(log.blockNumber)
+            : log.blockNumber;
+        const blockBefore = blockNumber - 1n;
+        const tokenIdBigInt = BigInt(underlyingTokenId);
+        const nfpm = getPositionManagerAddress(await this.resolveChainIdFromClient(client));
+
+        if (topic0 === STAKING_VAULT_EVENT_SIGNATURES.STAKE.toLowerCase()) {
+            const [stateIdx, liquidityAfter] = await Promise.all([
+                client.readContract({
+                    address: vaultAddress as Address,
+                    abi: STAKING_VAULT_READ_ABI,
+                    functionName: 'state',
+                    args: [],
+                    blockNumber: blockBefore,
+                }) as Promise<number>,
+                this.readNfpmLiquidity(client, nfpm, tokenIdBigInt, blockNumber),
+            ]);
+            return {
+                vaultStateBefore: stakingStateFromIndex(Number(stateIdx)),
+                liquidityAfter,
+            };
+        }
+
+        if (topic0 === STAKING_VAULT_EVENT_SIGNATURES.SWAP.toLowerCase()) {
+            const [
+                stakedBaseBefore, stakedQuoteBefore,
+                rewardBufferBaseBefore, rewardBufferQuoteBefore,
+                rewardBufferBaseAfter,  rewardBufferQuoteAfter,
+                liquidityAfter,
+            ] = await Promise.all([
+                this.readVaultUint(client, vaultAddress, 'stakedBase', blockBefore),
+                this.readVaultUint(client, vaultAddress, 'stakedQuote', blockBefore),
+                this.readVaultUint(client, vaultAddress, 'rewardBufferBase', blockBefore),
+                this.readVaultUint(client, vaultAddress, 'rewardBufferQuote', blockBefore),
+                this.readVaultUint(client, vaultAddress, 'rewardBufferBase', blockNumber),
+                this.readVaultUint(client, vaultAddress, 'rewardBufferQuote', blockNumber),
+                this.readNfpmLiquidity(client, nfpm, tokenIdBigInt, blockNumber),
+            ]);
+            return {
+                stakedBaseBefore,
+                stakedQuoteBefore,
+                rewardBufferBaseDelta: rewardBufferBaseAfter - rewardBufferBaseBefore,
+                rewardBufferQuoteDelta: rewardBufferQuoteAfter - rewardBufferQuoteBefore,
+                liquidityAfter,
+            };
+        }
+
+        if (topic0 === STAKING_VAULT_EVENT_SIGNATURES.FLASH_CLOSE_INITIATED.toLowerCase()) {
+            const liquidityAfter = await this.readNfpmLiquidity(
+                client, nfpm, tokenIdBigInt, blockNumber,
+            );
+            return { liquidityAfter };
+        }
+
+        // Markers + Unstake + ClaimRewards: no chain context needed.
+        return null;
+    }
+
+    /**
+     * Resolve the chainId from a PublicClient. Used only by populateChainContext
+     * to pick the correct NFPM address — the client is already chain-bound.
+     */
+    private async resolveChainIdFromClient(client: PublicClient): Promise<number> {
+        // Cheaper than `await client.getChainId()` because viem caches it on the client.
+        const chain = client.chain;
+        if (chain?.id) return chain.id;
+        return await client.getChainId();
+    }
+
+    /** Read a uint256 view function from the staking vault at a block. */
+    private async readVaultUint(
+        client: PublicClient,
+        vaultAddress: string,
+        functionName: 'stakedBase' | 'stakedQuote' | 'rewardBufferBase' | 'rewardBufferQuote',
+        blockNumber: bigint,
+    ): Promise<bigint> {
+        const result = await client.readContract({
+            address: vaultAddress as Address,
+            abi: STAKING_VAULT_READ_ABI,
+            functionName,
+            args: [],
+            blockNumber,
+        });
+        return result as bigint;
+    }
+
+    /** Read the underlying NFT's liquidity from the NFPM at a block. */
+    private async readNfpmLiquidity(
+        client: PublicClient,
+        nfpmAddress: Address,
+        tokenId: bigint,
+        blockNumber: bigint,
+    ): Promise<bigint> {
+        const data = await client.readContract({
+            address: nfpmAddress,
+            abi: UNISWAP_V3_POSITION_MANAGER_ABI,
+            functionName: 'positions',
+            args: [tokenId],
+            blockNumber,
+        });
+        // positions() returns a 12-tuple; liquidity is at index 7.
+        const tuple = data as readonly [
+            bigint, Address, Address, Address, number, number, number,
+            bigint, bigint, bigint, bigint, bigint,
+        ];
+        return tuple[7];
+    }
+
+    /**
+     * Publish domain events for a completed import.
+     *
+     * Order matches the NFT canonical (`refreshAllPositionLogs` lines 1655–1785):
+     * 1. Revert events (per blockHash) for every event in `allDeletedEvents`.
+     * 2. Insert events for every newly persisted ledger row:
+     *    - STAKING_DEPOSIT  → position.liquidity.increased
+     *    - STAKING_DISPOSE  → position.liquidity.decreased
+     *    - Markers          → no publish
+     *
+     * Routing keys are auto-built by `buildPositionRoutingKey` from
+     * `position.positionHash` (yields `uniswapv3-staking` as the position-type
+     * segment). Both event types use the existing `PositionLedgerEventPayload` /
+     * `PositionLiquidityRevertedPayload` contracts so PR3's consumer is uniform.
+     */
+    private async publishImportEvents(
+        position: UniswapV3StakingPosition,
+        importResult: StakingImportLogsResult,
+        dbTx?: PrismaTransactionClient,
+    ): Promise<void> {
+        const publisher = getDomainEventPublisher();
+
+        // 1. Reverts grouped by blockHash.
+        if (importResult.allDeletedEvents.length > 0) {
+            const blockHashCounts = new Map<string, number>();
+            for (const event of importResult.allDeletedEvents) {
+                const bh = event.typedConfig.blockHash;
+                blockHashCounts.set(bh, (blockHashCounts.get(bh) ?? 0) + 1);
+            }
+            for (const [blockHash, deletedCount] of blockHashCounts) {
+                await publisher.createAndPublish<PositionLiquidityRevertedPayload>(
+                    {
+                        type: 'position.liquidity.reverted',
+                        entityId: position.id,
+                        entityType: 'position',
+                        userId: position.userId,
+                        payload: {
+                            positionId: position.id,
+                            positionHash: position.positionHash,
+                            blockHash,
+                            deletedCount,
+                            revertedAt: new Date().toISOString(),
+                        },
+                        source: 'business-logic',
+                    },
+                    dbTx,
+                );
+            }
+        }
+
+        // 2. Inserts.
+        for (const result of importResult.perLogResults) {
+            if (result.action !== 'inserted') continue;
+
+            const { eventType, blockTimestamp } = result.eventDetail;
+            let domainEventType:
+                | 'position.liquidity.increased'
+                | 'position.liquidity.decreased'
+                | null = null;
+            if (eventType === 'STAKING_DEPOSIT') {
+                domainEventType = 'position.liquidity.increased';
+            } else if (eventType === 'STAKING_DISPOSE') {
+                domainEventType = 'position.liquidity.decreased';
+            }
+            // Markers (STAKING_YIELD_TARGET_SET / STAKING_PENDING_BPS_SET) → no publish.
+            if (!domainEventType) continue;
+
+            await publisher.createAndPublish<PositionLedgerEventPayload>(
+                {
+                    type: domainEventType,
+                    entityId: position.id,
+                    entityType: 'position',
+                    userId: position.userId,
+                    payload: {
+                        positionId: position.id,
+                        positionHash: position.positionHash,
+                        ledgerInputHash: result.inputHash,
+                        eventTimestamp: blockTimestamp.toISOString(),
+                    },
+                    source: 'business-logic',
+                },
+                dbTx,
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

PR2 of 5 for SPEC-0003b. Adds chain ingestion **inside** `UniswapV3StakingLedgerService` (no WebSocket subscriber, no `OnchainDataSubscribers` row — per the architecture shift posted in #63). Stacked on PR1 (#64).

Canonical reference: `UniswapV3LedgerService` + `UniswapV3PositionService.refreshAllPositionLogs`. Differences for staking are noted inline in code.

## What changed

### New methods on `UniswapV3StakingLedgerService`

- **`syncFromChain(position, evmConfig, poolPriceService, opts?, dbTx?)`** — main entry. Resolves block range → pulls all 7 vault events in parallel via `client.getLogs` → populates per-log `StakingLogChainContext` via NFPM and vault contract reads → hands off to PR1's `importLogsForPosition` → publishes domain events.
- **`fetchStakingVaultLogs`** — 7 parallel `client.getLogs` calls (one per event signature in `STAKING_VAULT_EVENT_SIGNATURES`), merge + sort by `(blockNumber, logIndex)`.
- **`populateChainContext`** — Stake: reads `vault.state()` at block-1 + NFPM `positions(tokenId).liquidity` at block. Swap: reads `stakedBase`/`stakedQuote` at block-1 and `rewardBufferBase`/`Quote` at block-1 and block (for the delta) plus NFPM liquidity at block. FlashCloseInitiated: NFPM liquidity at block. Markers / Unstake / ClaimRewards: no chain context. Per-block dedup deferred — the NFT canonical does not dedup either.
- **`resolveFromBlock`** — with prior event: `MIN(finalizedBlock, lastEvent.blockNumber)` per `evmConfig.getFinalityConfig(chainId)`. Without prior event: factory `VaultCreated(args.vault=...)` lookup (analog of NFT `findNftMintBlock`).
- **`publishImportEvents`** — revert events first (grouped by `blockHash`), then insert events in chain order. `STAKING_DEPOSIT` → `position.liquidity.increased`, `STAKING_DISPOSE` → `position.liquidity.decreased`, markers → no publish. Routing keys auto-built by `buildPositionRoutingKey` from `position.positionHash`.

### Refinements applied per maintainer review

1. **Docstring on `StakingLogChainContext`** updated — now reads "Populated by `syncFromChain` via NFPM and vault contract reads" (the type is no longer deferred to a subscriber).
2. **Per-block read dedup**: deferred (NFT canonical doesn't dedup either, premature at staking volumes).
3. **Test #9 — FlashClose end-to-end via `syncFromChain`**: synthesized `FlashCloseInitiated` + same-tx `Unstake` + `ClaimRewards` through `syncFromChain` produces exactly one `STAKING_DISPOSE` row with `source: 'flashClose'` + exactly one `position.liquidity.decreased` event (Unstake/ClaimRewards don't leak through).

## Tests

10 new tests bringing the suite from 16 → 26:

1. `syncFromChain` happy path: Stake + Swap → 2 ledger rows + 2 publishes (one increased, one decreased)
2. `fetchStakingVaultLogs` issues exactly 7 parallel `getLogs` calls (one per event signature)
3. `populateChainContext` for Stake reads `vault.state` at block-1 + NFPM `positions(tokenId)` at block
4. `populateChainContext` for Swap reads `stakedBase`/`stakedQuote` at block-1 + buffer deltas + NFPM at block
5. `resolveFromBlock` with no prior event uses factory `VaultCreated` lookup
6. `resolveFromBlock` with prior event uses `MIN(finalized, lastEvent.block)` (both branches)
7. Reorg: `removed: true` log → `position.liquidity.reverted` publish
8. Marker (`YieldTargetSet`) inserts a ledger row but does NOT publish
9. Idempotency at sync level (rerun adds no rows nor publishes)
10. FlashClose end-to-end via `syncFromChain` (refinement #3)

Mocks: `vi.mock('../../events/index.js')` replaces `getDomainEventPublisher` with a stub. Stubbed `client` provides `getLogs` / `readContract` / `getBlock` / `getBlockNumber` / `chain`. No real RPC, no real RabbitMQ.

## Acceptance criteria from §12 covered by this PR

- §12.2 (ledger correctness, end-to-end) — **fully** at the chain-import boundary now
- §12.5 (idempotency) — **fully** at sync level
- §12.6 (reorg safety) — **fully** with revert event emission verified
- New: domain-event correctness — every ledger event that warrants a domain event produces exactly one publish call with the correct routing key + payload

## Out of scope (deferred)

- `TokenLot`/`TokenLotDisposal`, journal entries, `staking-share` token upsert → **PR3** (consumes the domain events emitted here)
- `UniswapV3StakingPositionService` (CRUD, refresh-all, archive) → **PR4** (will call `syncFromChain` directly)
- REST endpoints → **PR4**
- MCP tools → **PR5**

Refs #63

## Test plan
- [x] `pnpm typecheck` — all 14 packages pass
- [x] `pnpm --filter @midcurve/services test:run` — 164 tests pass (26 in the staking suite, +10 new)
- [x] No real RPC / RabbitMQ deps — tests are deterministic

🤖 Generated with [Claude Code](https://claude.com/claude-code)