### PR TITLE
feat: add staking-vault journal-posting rule (SPEC-0003b PR3)

### DIFF
--- a/apps/midcurve-business-logic/package.json
+++ b/apps/midcurve-business-logic/package.json
@@ -9,7 +9,9 @@
     "build": "tsup",
     "start": "node --env-file=../../.env dist/index.js",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest",
+    "test:run": "vitest run"
   },
   "dependencies": {
     "@midcurve/database": "workspace:^",
@@ -28,7 +30,9 @@
     "pino-pretty": "^13.1.2",
     "tsup": "^8.5.0",
     "tsx": "^4.19.0",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^3.2.4",
+    "vitest-mock-extended": "^3.1.0"
   },
   "engines": {
     "node": ">=20"

--- a/apps/midcurve-business-logic/src/rules/accounting/uniswapv3-staking/index.ts
+++ b/apps/midcurve-business-logic/src/rules/accounting/uniswapv3-staking/index.ts
@@ -1,0 +1,5 @@
+/**
+ * UniswapV3 Staking Vault Accounting Rules
+ */
+
+export { UniswapV3StakingPostJournalEntriesRule } from './uniswapv3-staking-post-journal-entries';

--- a/apps/midcurve-business-logic/src/rules/accounting/uniswapv3-staking/uniswapv3-staking-post-journal-entries.test.ts
+++ b/apps/midcurve-business-logic/src/rules/accounting/uniswapv3-staking/uniswapv3-staking-post-journal-entries.test.ts
@@ -1,0 +1,649 @@
+/**
+ * UniswapV3StakingPostJournalEntriesRule — unit tests
+ *
+ * SPEC-0003b PR3 acceptance:
+ *  - STAKING_DEPOSIT → lot create + DR 1000 / CR 3000
+ *  - STAKING_DISPOSE → 5–6 line balanced entry per lot under Model A
+ *    (yield → CR 4000 Fee Income, principal-floor PnL → 4100/5000)
+ *  - Lot disposal called with `proceedsReporting = principal-only` (Model A boundary)
+ *  - Idempotency at the rule layer
+ *  - Reorg + delete handlers are no-ops (FK cascade is the source of truth)
+ *  - position.closed posts a zero-out correction against 4300
+ *  - Routing key constants smoke test
+ *
+ * No live RabbitMQ, no live Prisma. Module-level mocks replace the singletons
+ * used by the rule.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// MODULE MOCKS
+// =============================================================================
+
+// Mock prisma client used by the rule for direct DB reads.
+// Hoisted so it's available before vi.mock's hoisted factory runs.
+const { prismaMock } = vi.hoisted(() => ({
+    prismaMock: {
+        position: { findUnique: vi.fn() },
+        positionLedgerEvent: { findFirst: vi.fn(), findMany: vi.fn() },
+        token: { upsert: vi.fn(), findUnique: vi.fn() },
+        userSettings: { findUnique: vi.fn() },
+    },
+}));
+vi.mock('@midcurve/database', () => ({
+    prisma: prismaMock,
+}));
+
+import {
+    JournalService,
+    TokenLotService,
+    type DomainEvent,
+    type PositionEventType,
+    type PositionLifecyclePayload,
+    type PositionLedgerEventPayload,
+    type PositionLiquidityRevertedPayload,
+} from '@midcurve/services';
+import { ACCOUNT_CODES } from '@midcurve/shared';
+import { UniswapV3StakingPostJournalEntriesRule } from './uniswapv3-staking-post-journal-entries';
+
+// =============================================================================
+// FIXTURES
+// =============================================================================
+
+const POSITION_ID = 'pos_staking_test';
+const USER_ID = 'user_test';
+const CHAIN_ID = 42161;
+const VAULT_ADDRESS = '0xA1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1A1';
+const FACTORY_ADDRESS = '0xFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFAFA';
+const POOL_ADDRESS = '0xC3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3C3';
+const TOKEN0 = '0xAAAAaaaa00000000000000000000000000000000';
+const TOKEN1 = '0xBBBBbbbb00000000000000000000000000000000';
+const POSITION_HASH = `uniswapv3-staking/${CHAIN_ID}/${VAULT_ADDRESS}`;
+const TOKEN_HASH = `staking-share/${CHAIN_ID}/${VAULT_ADDRESS}`;
+const REPORTING_CURRENCY = 'USD';
+// Exchange rate scaled 10^8: 1 token = 1 USD
+const SPOT_RATE = (1n * 10n ** 8n).toString();
+const QUOTE_TOKEN_DECIMALS = 6; // USDC-like
+const DECIMALS_SCALE = 10n ** BigInt(QUOTE_TOKEN_DECIMALS);
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+function makeDomainEvent<T>(
+    type: PositionEventType,
+    payload: T,
+    overrides: { id?: string; timestamp?: string } = {},
+): DomainEvent<T> {
+    return {
+        id: overrides.id ?? `evt_${type}_${Date.now()}_${Math.random()}`,
+        type,
+        entityId: POSITION_ID,
+        entityType: 'position',
+        userId: USER_ID,
+        payload,
+        timestamp: overrides.timestamp ?? new Date('2026-04-01T00:00:00Z').toISOString(),
+        source: 'business-logic',
+    } as unknown as DomainEvent<T>;
+}
+
+function makeLedgerEventPayload(ledgerInputHash: string, eventTimestamp = '2026-04-01T00:00:00Z'): PositionLedgerEventPayload {
+    return {
+        positionId: POSITION_ID,
+        positionHash: POSITION_HASH,
+        ledgerInputHash,
+        eventTimestamp,
+    };
+}
+
+function makeLifecyclePayload(): PositionLifecyclePayload {
+    return {
+        positionId: POSITION_ID,
+        positionHash: POSITION_HASH,
+    } as unknown as PositionLifecyclePayload;
+}
+
+interface ConfigurePrismaOpts {
+    /** Optional override for the position config; defaults to the standard staking config. */
+    positionConfig?: Record<string, unknown>;
+    /** Optional override for the position state; defaults to `{ isOwnedByUser: true }`. */
+    positionState?: Record<string, unknown>;
+    /** ledger event row to return from findFirst */
+    ledgerEvent?: {
+        id: string;
+        deltaCostBasis: string;
+        tokenValue: string;
+        deltaPnl: string;
+        config: Record<string, unknown>;
+    };
+}
+
+function configurePrismaMocks(opts: ConfigurePrismaOpts = {}): void {
+    const positionConfig = opts.positionConfig ?? {
+        chainId: CHAIN_ID,
+        vaultAddress: VAULT_ADDRESS,
+        factoryAddress: FACTORY_ADDRESS,
+        poolAddress: POOL_ADDRESS,
+        token0Address: TOKEN0,
+        token1Address: TOKEN1,
+        isToken0Quote: false,
+        feeBps: 3000,
+        tickSpacing: 60,
+        tickLower: -100,
+        tickUpper: 100,
+    };
+    const positionState = opts.positionState ?? { isOwnedByUser: true };
+
+    prismaMock.position.findUnique.mockImplementation(async ({ select }: { select?: Record<string, boolean | object> }) => {
+        const base = { id: POSITION_ID, userId: USER_ID, protocol: 'uniswapv3-staking', config: positionConfig, state: positionState };
+        if (select?.user) return { ...base, user: { reportingCurrency: REPORTING_CURRENCY } };
+        return base;
+    });
+
+    if (opts.ledgerEvent) {
+        prismaMock.positionLedgerEvent.findFirst.mockResolvedValue(opts.ledgerEvent);
+    } else {
+        prismaMock.positionLedgerEvent.findFirst.mockResolvedValue(null);
+    }
+    prismaMock.positionLedgerEvent.findMany.mockResolvedValue([]);
+
+    prismaMock.token.upsert.mockResolvedValue({ id: 'tok_staking_share', tokenHash: TOKEN_HASH });
+    prismaMock.token.findUnique.mockImplementation(async () => ({
+        decimals: QUOTE_TOKEN_DECIMALS, coingeckoId: null,
+    }));
+    prismaMock.userSettings.findUnique.mockResolvedValue({ settings: { costBasisMethod: 'fifo' } });
+}
+
+interface MockServices {
+    journal: {
+        isProcessed: ReturnType<typeof vi.fn>;
+        createEntry: ReturnType<typeof vi.fn>;
+        getAccountBalance: ReturnType<typeof vi.fn>;
+        getAccountBalanceReporting: ReturnType<typeof vi.fn>;
+    };
+    tokenLot: {
+        getOpenLots: ReturnType<typeof vi.fn>;
+        createLot: ReturnType<typeof vi.fn>;
+        disposeLots: ReturnType<typeof vi.fn>;
+    };
+}
+
+function installServiceMocks(): MockServices {
+    const journal = {
+        isProcessed: vi.fn(async () => false),
+        createEntry: vi.fn(async () => 'entry_id'),
+        getAccountBalance: vi.fn(async () => 0n),
+        getAccountBalanceReporting: vi.fn(async () => 0n),
+    };
+    const tokenLot = {
+        getOpenLots: vi.fn(async () => []),
+        createLot: vi.fn(async () => 'lot_id'),
+        disposeLots: vi.fn(),
+    };
+
+    const journalSingleton = JournalService.getInstance();
+    Object.assign(journalSingleton, journal);
+    const lotSingleton = TokenLotService.getInstance();
+    Object.assign(lotSingleton, tokenLot);
+
+    // No CoinGeckoClient mock: prismaMock returns `coingeckoId: null` for tokens,
+    // so the rule's getReportingContext never reaches the CoinGecko path.
+
+    return { journal, tokenLot };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe('UniswapV3StakingPostJournalEntriesRule', () => {
+    let rule: UniswapV3StakingPostJournalEntriesRule;
+    let mocks: MockServices;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        rule = new UniswapV3StakingPostJournalEntriesRule();
+        mocks = installServiceMocks();
+        configurePrismaMocks();
+    });
+
+    // -------------------------------------------------------------------------
+    // 1. Routing pattern smoke test
+    // -------------------------------------------------------------------------
+    it('binds queue name + routing pattern', () => {
+        expect(UniswapV3StakingPostJournalEntriesRule.queueName).toBe(
+            'business-logic.uniswapv3-staking-post-journal-entries',
+        );
+        expect(UniswapV3StakingPostJournalEntriesRule.routingPattern).toBe(
+            'positions.*.uniswapv3-staking',
+        );
+    });
+
+    // -------------------------------------------------------------------------
+    // 2. handleLiquidityIncreased — STAKING_DEPOSIT happy path
+    // -------------------------------------------------------------------------
+    it('STAKING_DEPOSIT → creates lot + DR 1000 / CR 3000 entry', async () => {
+        configurePrismaMocks({
+            ledgerEvent: {
+                id: 'le_dep1',
+                deltaCostBasis: '1500000000', // 1500 USDC at 10^6
+                tokenValue: '1500000000',
+                deltaPnl: '0',
+                config: {
+                    deltaL: '1000000',
+                    liquidityAfter: '1000000',
+                    principalQuoteValue: '0',
+                    yieldQuoteValue: '0',
+                },
+            },
+        });
+
+        const event = makeDomainEvent(
+            'position.liquidity.increased',
+            makeLedgerEventPayload('hash_dep1'),
+        );
+        await rule.routeEvent(event, 'position.liquidity.increased');
+
+        // Lot created with the right transfer event + quantity
+        expect(mocks.tokenLot.createLot).toHaveBeenCalledTimes(1);
+        const lotArgs = mocks.tokenLot.createLot.mock.calls[0]![0];
+        expect(lotArgs.transferEvent).toBe('STAKING_DEPOSIT');
+        expect(lotArgs.quantity).toBe('1000000');
+        expect(lotArgs.tokenHash).toBe(TOKEN_HASH);
+
+        // Single balanced journal entry: DR 1000 / CR 3000
+        expect(mocks.journal.createEntry).toHaveBeenCalledTimes(1);
+        const [, lines] = mocks.journal.createEntry.mock.calls[0]!;
+        expect(lines).toHaveLength(2);
+        const debit = lines.find((l: { side: string }) => l.side === 'debit')!;
+        const credit = lines.find((l: { side: string }) => l.side === 'credit')!;
+        expect(debit.accountCode).toBe(ACCOUNT_CODES.LP_POSITION_AT_COST);
+        expect(debit.amountQuote).toBe('1500000000');
+        expect(credit.accountCode).toBe(ACCOUNT_CODES.CONTRIBUTED_CAPITAL);
+        expect(credit.amountQuote).toBe('1500000000');
+    });
+
+    // -------------------------------------------------------------------------
+    // 3. Token upsert produces correct staking-share hash + metadata
+    // -------------------------------------------------------------------------
+    it('token upsert uses staking-share hash with correct metadata', async () => {
+        configurePrismaMocks({
+            ledgerEvent: {
+                id: 'le_dep1',
+                deltaCostBasis: '1000000000',
+                tokenValue: '1000000000',
+                deltaPnl: '0',
+                config: { deltaL: '1000000', liquidityAfter: '1000000' },
+            },
+        });
+
+        await rule.routeEvent(
+            makeDomainEvent('position.liquidity.increased', makeLedgerEventPayload('hash1')),
+            'position.liquidity.increased',
+        );
+
+        expect(prismaMock.token.upsert).toHaveBeenCalledTimes(1);
+        const args = prismaMock.token.upsert.mock.calls[0]![0];
+        expect(args.where.tokenHash).toBe(TOKEN_HASH);
+        expect(args.create.tokenType).toBe('staking-share');
+        expect(args.create.symbol).toBe('MSV-STK');
+        expect(args.create.decimals).toBe(0);
+        expect(args.create.config).toEqual({
+            chainId: CHAIN_ID, vaultAddress: VAULT_ADDRESS, protocol: 'uniswapv3-staking',
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // 4. STAKING_DISPOSE — Model A boundary: proceedsReporting = principal-only
+    // -------------------------------------------------------------------------
+    it('STAKING_DISPOSE — disposeLots called with proceedsReporting = principal × spotRate / scale (Model A boundary)', async () => {
+        // 100% dispose. principal = 1500, yield = 200 (in quote-token units, scaled 10^6)
+        configurePrismaMocks({
+            ledgerEvent: {
+                id: 'le_dis1',
+                deltaCostBasis: '-1500000000',
+                tokenValue: '1700000000',
+                deltaPnl: '0',
+                config: {
+                    deltaL: '-1000000',
+                    liquidityAfter: '0',
+                    principalQuoteValue: '1500000000', // 1500 USDC
+                    yieldQuoteValue: '200000000',      // 200 USDC
+                },
+            },
+        });
+        mocks.tokenLot.disposeLots.mockResolvedValue({
+            disposals: [{
+                id: 'd1', lotId: 'lot1',
+                quantityDisposed: '1000000',
+                proceedsReporting: ((1500n * 10n ** 8n * 10n ** 8n) / DECIMALS_SCALE).toString(),
+                costBasisAllocated: ((1500n * 10n ** 8n * 10n ** 8n) / DECIMALS_SCALE).toString(),
+                realizedPnl: '0',
+            }],
+            totalQuantityDisposed: 1000000n,
+            totalCostBasisAllocated: 0n,
+            totalRealizedPnl: 0n,
+        });
+
+        await rule.routeEvent(
+            makeDomainEvent('position.liquidity.decreased', makeLedgerEventPayload('hash_dis1')),
+            'position.liquidity.decreased',
+        );
+
+        expect(mocks.tokenLot.disposeLots).toHaveBeenCalledTimes(1);
+        const disposeArgs = mocks.tokenLot.disposeLots.mock.calls[0]![0];
+        // Model A boundary: proceedsReporting comes from PRINCIPAL only,
+        // not principal+yield. principalQuoteValue is already in quote units
+        // (1500 × 10^6 USDC), so reporting = principal × rate / scale =
+        // 1500e6 × 1e8 / 1e6 = 1500e8.
+        const principalQuote = 1500_000000n;          // 1500 USDC at 6 decimals
+        const expectedProceeds = ((principalQuote * BigInt(SPOT_RATE)) / DECIMALS_SCALE).toString();
+        expect(disposeArgs.proceedsReporting).toBe(expectedProceeds);
+        // Sanity guard: not principal+yield (this is the Model A boundary).
+        const yieldQuote = 200_000000n;
+        const wrongProceeds = (((principalQuote + yieldQuote) * BigInt(SPOT_RATE)) / DECIMALS_SCALE).toString();
+        expect(disposeArgs.proceedsReporting).not.toBe(wrongProceeds);
+        expect(disposeArgs.transferEvent).toBe('STAKING_DISPOSE');
+        expect(disposeArgs.quantityToDispose).toBe('1000000');
+    });
+
+    // -------------------------------------------------------------------------
+    // 5. STAKING_DISPOSE — full entry shape (DR 3100, CR 1000, CR 4000, CR 4100)
+    // -------------------------------------------------------------------------
+    it('STAKING_DISPOSE — entry has DR 3100=principal+yield, CR 1000=cost, CR 4000=yield, CR 4100=pnl', async () => {
+        // 100% dispose with principal-floor gain. cost basis = 1000, principal = 1200, yield = 200.
+        configurePrismaMocks({
+            ledgerEvent: {
+                id: 'le_dis2',
+                deltaCostBasis: '-1000000000', // -1000 (cost basis disposed)
+                tokenValue: '1400000000',
+                deltaPnl: '200000000',
+                config: {
+                    deltaL: '-1000000',
+                    liquidityAfter: '0',
+                    principalQuoteValue: '1200000000', // 1200 (gain over cost)
+                    yieldQuoteValue: '200000000',      // 200
+                },
+            },
+        });
+        mocks.tokenLot.disposeLots.mockResolvedValue({
+            disposals: [{
+                id: 'd1', lotId: 'lot1',
+                quantityDisposed: '1000000',
+                proceedsReporting: ((1200n * 10n ** 8n * 10n ** 8n) / DECIMALS_SCALE).toString(),
+                costBasisAllocated: ((1000n * 10n ** 8n * 10n ** 8n) / DECIMALS_SCALE).toString(),
+                realizedPnl: ((200n * 10n ** 8n * 10n ** 8n) / DECIMALS_SCALE).toString(),
+            }],
+            totalQuantityDisposed: 1000000n,
+            totalCostBasisAllocated: 0n,
+            totalRealizedPnl: 0n,
+        });
+
+        await rule.routeEvent(
+            makeDomainEvent('position.liquidity.decreased', makeLedgerEventPayload('hash_dis2')),
+            'position.liquidity.decreased',
+        );
+
+        expect(mocks.journal.createEntry).toHaveBeenCalledTimes(1);
+        const [, lines] = mocks.journal.createEntry.mock.calls[0]!;
+
+        const byCode = (code: number) =>
+            lines.filter((l: { accountCode: number }) => l.accountCode === code);
+
+        const debit3100 = byCode(ACCOUNT_CODES.CAPITAL_RETURNED).find((l: { side: string }) => l.side === 'debit')!;
+        expect(debit3100.amountQuote).toBe('1400000000'); // principal 1200 + yield 200
+
+        const credit1000 = byCode(ACCOUNT_CODES.LP_POSITION_AT_COST).find((l: { side: string }) => l.side === 'credit')!;
+        expect(credit1000.amountQuote).toBe('1000000000');
+
+        const credit4000 = byCode(ACCOUNT_CODES.FEE_INCOME).find((l: { side: string }) => l.side === 'credit')!;
+        expect(credit4000.amountQuote).toBe('200000000');
+
+        const credit4100 = byCode(ACCOUNT_CODES.REALIZED_GAINS).find((l: { side: string }) => l.side === 'credit')!;
+        expect(credit4100.amountQuote).toBe('200000000');
+
+        // Sum balance check (in quote units only — FX line has amountQuote=0)
+        const sumDebit = lines
+            .filter((l: { side: string; amountQuote: string }) => l.side === 'debit')
+            .reduce((acc: bigint, l: { amountQuote: string }) => acc + BigInt(l.amountQuote), 0n);
+        const sumCredit = lines
+            .filter((l: { side: string; amountQuote: string }) => l.side === 'credit')
+            .reduce((acc: bigint, l: { amountQuote: string }) => acc + BigInt(l.amountQuote), 0n);
+        expect(sumDebit).toBe(sumCredit);
+    });
+
+    // -------------------------------------------------------------------------
+    // 6. STAKING_DISPOSE — multi-lot proportional split + remainder allocation
+    // -------------------------------------------------------------------------
+    it('STAKING_DISPOSE — multi-lot dispose: proportional splits sum to ledger totals', async () => {
+        configurePrismaMocks({
+            ledgerEvent: {
+                id: 'le_dis3',
+                deltaCostBasis: '-1000000000',
+                tokenValue: '1300000000',
+                deltaPnl: '0',
+                config: {
+                    deltaL: '-1000000',
+                    liquidityAfter: '0',
+                    principalQuoteValue: '1100000000', // gain
+                    yieldQuoteValue: '200000000',
+                },
+            },
+        });
+        mocks.tokenLot.disposeLots.mockResolvedValue({
+            disposals: [
+                {
+                    id: 'd1', lotId: 'lot1',
+                    quantityDisposed: '300001', // odd to exercise remainder
+                    proceedsReporting: '0',
+                    costBasisAllocated: '300000000',
+                    realizedPnl: '0',
+                },
+                {
+                    id: 'd2', lotId: 'lot2',
+                    quantityDisposed: '699999',
+                    proceedsReporting: '0',
+                    costBasisAllocated: '700000000',
+                    realizedPnl: '0',
+                },
+            ],
+            totalQuantityDisposed: 1000000n,
+            totalCostBasisAllocated: 0n,
+            totalRealizedPnl: 0n,
+        });
+
+        await rule.routeEvent(
+            makeDomainEvent('position.liquidity.decreased', makeLedgerEventPayload('hash_dis3')),
+            'position.liquidity.decreased',
+        );
+
+        // Two journal entries — one per lot
+        expect(mocks.journal.createEntry).toHaveBeenCalledTimes(2);
+
+        // Sum the proportional principal + yield + costBasis across both entries.
+        // They should reconcile EXACTLY with the ledger event totals (last lot gets remainder).
+        let totalPrincipalProceeds = 0n;
+        let totalYield = 0n;
+        let totalCostBasis = 0n;
+        for (const call of mocks.journal.createEntry.mock.calls) {
+            const lines = call[1] as Array<{ accountCode: number; side: string; amountQuote: string }>;
+            const dr3100 = lines.find((l) => l.accountCode === ACCOUNT_CODES.CAPITAL_RETURNED);
+            const cr4000 = lines.find((l) => l.accountCode === ACCOUNT_CODES.FEE_INCOME);
+            const cr1000 = lines.find((l) => l.accountCode === ACCOUNT_CODES.LP_POSITION_AT_COST);
+            // dr3100 = principal+yield; isolate principal by subtracting yield
+            const yieldAmount = cr4000 ? BigInt(cr4000.amountQuote) : 0n;
+            const totalProceeds = dr3100 ? BigInt(dr3100.amountQuote) : 0n;
+            const principal = totalProceeds - yieldAmount;
+            totalPrincipalProceeds += principal;
+            totalYield += yieldAmount;
+            totalCostBasis += cr1000 ? BigInt(cr1000.amountQuote) : 0n;
+        }
+        expect(totalPrincipalProceeds).toBe(1100000000n);
+        expect(totalYield).toBe(200000000n);
+        expect(totalCostBasis).toBe(1000000000n);
+    });
+
+    // -------------------------------------------------------------------------
+    // 7. Model A: yield-only, flat principal → CR 4000 only, no CR 4100 / DR 5000
+    // -------------------------------------------------------------------------
+    it('Model A — yield-only, flat principal: entry has CR 4000 but no realized P&L line', async () => {
+        configurePrismaMocks({
+            ledgerEvent: {
+                id: 'le_dis4',
+                deltaCostBasis: '-1000000000',
+                tokenValue: '1200000000',
+                deltaPnl: '0',
+                config: {
+                    deltaL: '-1000000', liquidityAfter: '0',
+                    principalQuoteValue: '1000000000', // == cost basis → no PnL
+                    yieldQuoteValue: '200000000',      // pure yield
+                },
+            },
+        });
+        mocks.tokenLot.disposeLots.mockResolvedValue({
+            disposals: [{
+                id: 'd1', lotId: 'lot1', quantityDisposed: '1000000',
+                proceedsReporting: '0', costBasisAllocated: '1000000000', realizedPnl: '0',
+            }],
+            totalQuantityDisposed: 1000000n, totalCostBasisAllocated: 0n, totalRealizedPnl: 0n,
+        });
+
+        await rule.routeEvent(
+            makeDomainEvent('position.liquidity.decreased', makeLedgerEventPayload('hash_dis4')),
+            'position.liquidity.decreased',
+        );
+
+        const [, lines] = mocks.journal.createEntry.mock.calls[0]!;
+        // Model A: yield is recognized but no realized PnL line because principal == cost
+        expect(lines.some((l: { accountCode: number }) => l.accountCode === ACCOUNT_CODES.FEE_INCOME)).toBe(true);
+        expect(lines.some((l: { accountCode: number }) => l.accountCode === ACCOUNT_CODES.REALIZED_GAINS)).toBe(false);
+        expect(lines.some((l: { accountCode: number }) => l.accountCode === ACCOUNT_CODES.REALIZED_LOSSES)).toBe(false);
+    });
+
+    // -------------------------------------------------------------------------
+    // 8. Model A: principal-floor gain, zero yield → CR 4100, no CR 4000
+    // -------------------------------------------------------------------------
+    it('Model A — principal-floor gain, zero yield: entry has CR 4100 but no Fee Income line', async () => {
+        configurePrismaMocks({
+            ledgerEvent: {
+                id: 'le_dis5',
+                deltaCostBasis: '-1000000000',
+                tokenValue: '1200000000',
+                deltaPnl: '200000000',
+                config: {
+                    deltaL: '-1000000', liquidityAfter: '0',
+                    principalQuoteValue: '1200000000', // gain over cost
+                    yieldQuoteValue: '0',              // no yield
+                },
+            },
+        });
+        mocks.tokenLot.disposeLots.mockResolvedValue({
+            disposals: [{
+                id: 'd1', lotId: 'lot1', quantityDisposed: '1000000',
+                proceedsReporting: '0', costBasisAllocated: '1000000000', realizedPnl: '0',
+            }],
+            totalQuantityDisposed: 1000000n, totalCostBasisAllocated: 0n, totalRealizedPnl: 0n,
+        });
+
+        await rule.routeEvent(
+            makeDomainEvent('position.liquidity.decreased', makeLedgerEventPayload('hash_dis5')),
+            'position.liquidity.decreased',
+        );
+
+        const [, lines] = mocks.journal.createEntry.mock.calls[0]!;
+        expect(lines.some((l: { accountCode: number }) => l.accountCode === ACCOUNT_CODES.REALIZED_GAINS)).toBe(true);
+        expect(lines.some((l: { accountCode: number }) => l.accountCode === ACCOUNT_CODES.FEE_INCOME)).toBe(false);
+    });
+
+    // -------------------------------------------------------------------------
+    // 9. handleLiquidityReverted — no-op
+    // -------------------------------------------------------------------------
+    it('position.liquidity.reverted — no service calls (FK cascade is the source of truth)', async () => {
+        await rule.routeEvent(
+            makeDomainEvent('position.liquidity.reverted', {
+                positionId: POSITION_ID,
+                positionHash: POSITION_HASH,
+                blockHash: '0xblkA',
+                deletedCount: 1,
+                revertedAt: new Date().toISOString(),
+            } as PositionLiquidityRevertedPayload),
+            'position.liquidity.reverted',
+        );
+
+        expect(mocks.journal.createEntry).not.toHaveBeenCalled();
+        expect(mocks.tokenLot.createLot).not.toHaveBeenCalled();
+        expect(mocks.tokenLot.disposeLots).not.toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // 10. handlePositionClosed — zero-out correction against 4300
+    // -------------------------------------------------------------------------
+    it('position.closed — non-zero remainder is zeroed against FX_GAIN_LOSS', async () => {
+        // Pretend the 1000 account still has +500 (over-debited): we should CR 1000 / DR 4300
+        mocks.journal.getAccountBalance.mockResolvedValue(500_000n);
+        mocks.journal.getAccountBalanceReporting.mockResolvedValue(500_00000000n); // 500 USD scaled 10^8
+
+        await rule.routeEvent(
+            makeDomainEvent('position.closed', makeLifecyclePayload()),
+            'position.closed',
+        );
+
+        expect(mocks.journal.createEntry).toHaveBeenCalledTimes(1);
+        const [, lines] = mocks.journal.createEntry.mock.calls[0]!;
+        const cr1000 = lines.find(
+            (l: { accountCode: number; side: string }) =>
+                l.accountCode === ACCOUNT_CODES.LP_POSITION_AT_COST && l.side === 'credit',
+        );
+        const dr4300 = lines.find(
+            (l: { accountCode: number; side: string }) =>
+                l.accountCode === ACCOUNT_CODES.FX_GAIN_LOSS && l.side === 'debit',
+        );
+        expect(cr1000).toBeDefined();
+        expect(dr4300).toBeDefined();
+        expect(cr1000!.amountQuote).toBe('500000');
+    });
+
+    // -------------------------------------------------------------------------
+    // 11. handlePositionDeleted — no-op
+    // -------------------------------------------------------------------------
+    it('position.deleted — no service calls (FK cascade)', async () => {
+        await rule.routeEvent(
+            makeDomainEvent('position.deleted', makeLifecyclePayload()),
+            'position.deleted',
+        );
+
+        expect(mocks.journal.createEntry).not.toHaveBeenCalled();
+        expect(mocks.tokenLot.createLot).not.toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // 12. Idempotency at the rule layer
+    // -------------------------------------------------------------------------
+    it('idempotency — second invocation with same domainEventId is a no-op', async () => {
+        configurePrismaMocks({
+            ledgerEvent: {
+                id: 'le_dep_idem',
+                deltaCostBasis: '1500000000',
+                tokenValue: '1500000000',
+                deltaPnl: '0',
+                config: { deltaL: '1000000', liquidityAfter: '1000000' },
+            },
+        });
+
+        // First call: handler proceeds normally.
+        const event = makeDomainEvent(
+            'position.liquidity.increased',
+            makeLedgerEventPayload('hash_idem'),
+            { id: 'evt_idem' },
+        );
+        await rule.routeEvent(event, 'position.liquidity.increased');
+        expect(mocks.journal.createEntry).toHaveBeenCalledTimes(1);
+
+        // Second call: isProcessed returns true → handler short-circuits.
+        mocks.journal.isProcessed.mockResolvedValueOnce(true);
+        await rule.routeEvent(event, 'position.liquidity.increased');
+        expect(mocks.journal.createEntry).toHaveBeenCalledTimes(1); // still 1, no new entry
+        expect(mocks.tokenLot.createLot).toHaveBeenCalledTimes(1);   // no new lot either
+    });
+});

--- a/apps/midcurve-business-logic/src/rules/accounting/uniswapv3-staking/uniswapv3-staking-post-journal-entries.ts
+++ b/apps/midcurve-business-logic/src/rules/accounting/uniswapv3-staking/uniswapv3-staking-post-journal-entries.ts
@@ -1,0 +1,907 @@
+/**
+ * UniswapV3StakingPostJournalEntriesRule
+ *
+ * Subscribes to UniswapV3StakingVault position domain events emitted by
+ * `UniswapV3StakingLedgerService.syncFromChain` (PR2), maintains TokenLot
+ * rows, and creates double-entry JournalEntry rows under **Model A**:
+ * yield is recognized as Fee Income (4000), NOT realized PnL (4100/5000).
+ *
+ * Acquisition events (create lots + DR 1000 / CR 3000):
+ * - position.created             → backfill lots + entries from ledger history
+ * - position.liquidity.increased → STAKING_DEPOSIT lot + entry
+ *
+ * Disposal events (consume lots + DR 3100 / CR 1000 / CR 4000 / CR or DR 4100/5000 / FX):
+ * - position.liquidity.decreased → STAKING_DISPOSE: 5–6 line balanced entry per lot
+ *
+ * Lifecycle / reorg:
+ * - position.closed              → cost basis correction (zero 1000 vs 4300)
+ * - position.deleted             → no-op (FK cascade)
+ * - position.liquidity.reverted  → no-op (FK cascade — reverted ledger events
+ *                                   were already deleted upstream by the ledger
+ *                                   service before this event fires)
+ *
+ * Per SPEC §8.5, staking has no transferred.in/out (vaults are owner-bound,
+ * non-transferable), no fees.collected (yield is folded into dispose), no
+ * burned (vaults reach Settled state, not burned).
+ */
+
+import type { ConsumeMessage } from 'amqplib';
+import { prisma } from '@midcurve/database';
+import {
+    setupConsumerQueue,
+    CoinGeckoClient,
+    findClosestPrice,
+    TokenLotService,
+    JournalService,
+    JournalLineBuilder,
+    createLotSelector,
+    type DomainEvent,
+    type PositionEventType,
+    type PositionLifecyclePayload,
+    type PositionLedgerEventPayload,
+    type PositionLiquidityRevertedPayload,
+    type DisposalResult,
+} from '@midcurve/services';
+import {
+    createErc20TokenHash,
+    createStakingShareTokenHash,
+    ACCOUNT_CODES,
+    type JournalLineInput,
+    type CostBasisMethod,
+    DEFAULT_USER_SETTINGS,
+} from '@midcurve/shared';
+import { BusinessRule } from '../../base';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const QUEUE_NAME = 'business-logic.uniswapv3-staking-post-journal-entries';
+const ROUTING_PATTERN = 'positions.*.uniswapv3-staking';
+const FLOAT_TO_BIGINT_SCALE = 1e8;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+interface ReportingContext {
+    reportingCurrency: string;
+    exchangeRate: string;
+    quoteTokenDecimals: number;
+    /** Vault-scoped instrument ref per SPEC §8.3 — `uniswapv3-staking/{chainId}/{vaultAddress}` */
+    instrumentRef: string;
+}
+
+interface PositionTokenContext {
+    tokenId: string;
+    tokenHash: string;
+}
+
+// =============================================================================
+// Rule Implementation
+// =============================================================================
+
+export class UniswapV3StakingPostJournalEntriesRule extends BusinessRule {
+    readonly ruleName = 'uniswapv3-staking-post-journal-entries';
+    readonly ruleDescription =
+        'Maintains token lots and journal entries from UniswapV3StakingVault position domain events (Model A — yield → Fee Income)';
+
+    private consumerTag: string | null = null;
+    private readonly tokenLotService: TokenLotService;
+    private readonly journalService: JournalService;
+
+    constructor() {
+        super();
+        this.tokenLotService = TokenLotService.getInstance();
+        this.journalService = JournalService.getInstance();
+    }
+
+    /** Smoke-testable accessors so tests can verify the routing-key constants. */
+    static get queueName(): string {
+        return QUEUE_NAME;
+    }
+
+    static get routingPattern(): string {
+        return ROUTING_PATTERN;
+    }
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    protected async onStartup(): Promise<void> {
+        if (!this.channel) throw new Error('No channel available');
+
+        await setupConsumerQueue(this.channel, QUEUE_NAME, ROUTING_PATTERN);
+        await this.channel.prefetch(1);
+
+        const result = await this.channel.consume(
+            QUEUE_NAME,
+            (msg) => this.handleMessage(msg),
+            { noAck: false },
+        );
+
+        this.consumerTag = result.consumerTag;
+        this.logger.info(
+            { queueName: QUEUE_NAME, routingPattern: ROUTING_PATTERN },
+            'Subscribed to UniswapV3 staking-vault position events',
+        );
+    }
+
+    protected async onShutdown(): Promise<void> {
+        if (this.consumerTag && this.channel) {
+            await this.channel.cancel(this.consumerTag);
+            this.consumerTag = null;
+        }
+    }
+
+    // =========================================================================
+    // Message Routing
+    // =========================================================================
+
+    private async handleMessage(msg: ConsumeMessage | null): Promise<void> {
+        if (!msg || !this.channel) return;
+
+        try {
+            const event = JSON.parse(msg.content.toString()) as DomainEvent;
+            const eventType = event.type as PositionEventType;
+
+            this.logger.info(
+                { eventId: event.id, eventType, entityId: event.entityId },
+                'Processing staking-vault position event',
+            );
+
+            await this.routeEvent(event, eventType);
+            this.channel.ack(msg);
+        } catch (error) {
+            this.logger.error(
+                { error: error instanceof Error ? error.message : String(error) },
+                'Error processing staking-vault position event',
+            );
+            this.channel.nack(msg, false, false);
+        }
+    }
+
+    /** Routes a domain event to the appropriate handler. Public so tests can drive it. */
+    public async routeEvent(
+        event: DomainEvent,
+        eventType: PositionEventType,
+    ): Promise<void> {
+        switch (eventType) {
+            case 'position.created':
+                return this.handlePositionCreated(event as DomainEvent<PositionLifecyclePayload>);
+            case 'position.liquidity.increased':
+                return this.handleLiquidityIncreased(event as DomainEvent<PositionLedgerEventPayload>);
+            case 'position.liquidity.decreased':
+                return this.handleLiquidityDecreased(event as DomainEvent<PositionLedgerEventPayload>);
+            case 'position.closed':
+                return this.handlePositionClosed(event as DomainEvent<PositionLifecyclePayload>);
+            case 'position.deleted':
+                return this.handlePositionDeleted(event as DomainEvent<PositionLifecyclePayload>);
+            case 'position.liquidity.reverted':
+                return this.handleLiquidityReverted(event as DomainEvent<PositionLiquidityRevertedPayload>);
+            // Staking has no transferred.in/out, no fees.collected, no burned (per SPEC §8.5).
+            case 'position.transferred.in':
+            case 'position.transferred.out':
+            case 'position.fees.collected':
+            case 'position.burned':
+                this.logger.debug(
+                    { eventType },
+                    'Event type not applicable to uniswapv3-staking, skipping',
+                );
+                return;
+            default:
+                this.logger.warn({ eventType }, 'Unknown position event type, skipping');
+        }
+    }
+
+    // =========================================================================
+    // Acquisition: STAKING_DEPOSIT
+    // =========================================================================
+
+    /**
+     * `position.created` → replay all STAKING_DEPOSIT and STAKING_DISPOSE
+     * ledger events in chain order. Idempotent via per-event composite hash.
+     */
+    private async handlePositionCreated(
+        event: DomainEvent<PositionLifecyclePayload>,
+    ): Promise<void> {
+        const { positionId, positionHash } = event.payload;
+
+        const position = await prisma.position.findUnique({
+            where: { id: positionId },
+            select: { id: true, userId: true, protocol: true, config: true, state: true },
+        });
+        if (!position) {
+            this.logger.warn({ positionId }, 'Position not found for position.created');
+            return;
+        }
+
+        // Ownership guard — staking vaults are bound to their owner; if the user
+        // no longer owns the wallet (e.g. wallet removed), skip backfill.
+        const positionState = position.state as Record<string, unknown>;
+        if (positionState.isOwnedByUser === false) {
+            this.logger.info({ positionHash }, 'Skipping backfill — staking vault not owned by user');
+            return;
+        }
+
+        const tokenCtx = await this.resolvePositionToken(positionId);
+        if (!tokenCtx) return;
+
+        // Idempotency: if any lots already exist for this position, treat as
+        // already backfilled.
+        const existingLots = await this.tokenLotService.getOpenLots(position.userId, tokenCtx.tokenHash);
+        if (existingLots.length > 0) {
+            this.logger.info({ positionHash }, 'Lots already exist for staking vault, skipping backfill');
+            return;
+        }
+
+        const costBasisMethod = await this.getUserCostBasisMethod(position.userId);
+        const lotSelector = createLotSelector(costBasisMethod);
+
+        const ledgerEvents = await prisma.positionLedgerEvent.findMany({
+            where: {
+                positionId,
+                eventType: { in: ['STAKING_DEPOSIT', 'STAKING_DISPOSE'] },
+                isIgnored: false,
+            },
+            select: {
+                id: true, eventType: true, inputHash: true, timestamp: true,
+                tokenValue: true, deltaCostBasis: true, deltaPnl: true, config: true,
+            },
+            orderBy: { timestamp: 'asc' },
+        });
+
+        if (ledgerEvents.length === 0) return;
+
+        const positionConfig = position.config as Record<string, unknown>;
+        const chainId = positionConfig.chainId as number;
+        const vaultAddress = positionConfig.vaultAddress as string;
+        const positionRef = positionHash;
+        const instrumentRef = `uniswapv3-staking/${chainId}/${vaultAddress}`;
+
+        const { reportingCurrency, quoteTokenDecimals, quoteCoingeckoId } =
+            await this.getQuoteTokenInfo(positionId);
+
+        // Fetch historic price time series spanning the full event range.
+        let priceTimeSeries: [number, number][] = [];
+        if (quoteCoingeckoId) {
+            const firstTs = Math.floor(ledgerEvents[0]!.timestamp.getTime() / 1000);
+            const lastTs = Math.floor(ledgerEvents[ledgerEvents.length - 1]!.timestamp.getTime() / 1000);
+            const chartData = await CoinGeckoClient.getInstance().getMarketChartRange(
+                quoteCoingeckoId, firstTs - 3600, lastTs + 3600,
+            );
+            priceTimeSeries = chartData.prices;
+        }
+
+        for (const le of ledgerEvents) {
+            const config = le.config as Record<string, unknown>;
+            const deltaL = config.deltaL as string;
+            if (!deltaL || deltaL === '0') continue;
+
+            const eventRate = computeHistoricRate(quoteCoingeckoId, priceTimeSeries, le.timestamp);
+            const eventRateStr = eventRate.toString();
+
+            const domainEventId = `${event.id}:${le.inputHash}`;
+            if (await this.journalService.isProcessed(domainEventId)) continue;
+
+            if (le.eventType === 'STAKING_DEPOSIT') {
+                if (le.deltaCostBasis === '0') continue;
+                const costBasisAbsolute = computeReportingAmount(
+                    le.deltaCostBasis, eventRateStr, quoteTokenDecimals,
+                );
+
+                const lotId = await this.tokenLotService.createLot({
+                    userId: position.userId,
+                    tokenId: tokenCtx.tokenId,
+                    tokenHash: tokenCtx.tokenHash,
+                    quantity: deltaL,
+                    costBasisAbsolute,
+                    acquiredAt: le.timestamp,
+                    acquisitionEventId: le.inputHash,
+                    positionLedgerEventId: le.id,
+                    transferEvent: 'STAKING_DEPOSIT',
+                });
+
+                await this.createAcquisitionEntry(
+                    position.userId, domainEventId,
+                    'position.liquidity.increased',
+                    le.id, le.timestamp, le.deltaCostBasis,
+                    lotId, positionRef, instrumentRef,
+                    reportingCurrency, eventRateStr, quoteTokenDecimals,
+                );
+            } else if (le.eventType === 'STAKING_DISPOSE') {
+                const principalQuoteValue = (config.principalQuoteValue as string) ?? '0';
+                const yieldQuoteValue = (config.yieldQuoteValue as string) ?? '0';
+                // Model A: only principal flows through the disposal mechanism.
+                const proceedsReporting = computeReportingAmount(
+                    principalQuoteValue, eventRateStr, quoteTokenDecimals,
+                );
+
+                // STAKING_DISPOSE deltaL is signed negative — quantityToDispose is its absolute value.
+                const quantityToDispose = absBigint(deltaL);
+
+                const result = await this.tokenLotService.disposeLots({
+                    userId: position.userId,
+                    tokenHash: tokenCtx.tokenHash,
+                    quantityToDispose,
+                    proceedsReporting,
+                    disposedAt: le.timestamp,
+                    disposalEventId: le.inputHash,
+                    positionLedgerEventId: le.id,
+                    transferEvent: 'STAKING_DISPOSE',
+                    lotSelector,
+                });
+
+                await this.createDisposalEntries(
+                    position.userId, domainEventId,
+                    'position.liquidity.decreased',
+                    le.id, le.timestamp,
+                    le.deltaCostBasis, principalQuoteValue, yieldQuoteValue,
+                    result, positionRef, instrumentRef,
+                    reportingCurrency, eventRateStr, quoteTokenDecimals,
+                );
+            }
+        }
+
+        this.logger.info(
+            { positionHash, eventsProcessed: ledgerEvents.length },
+            'Token lots and journal entries backfilled from staking-vault ledger history',
+        );
+    }
+
+    /**
+     * `position.liquidity.increased` (STAKING_DEPOSIT) → create one lot,
+     * post one balanced entry: DR 1000 / CR 3000.
+     */
+    private async handleLiquidityIncreased(
+        event: DomainEvent<PositionLedgerEventPayload>,
+    ): Promise<void> {
+        if (await this.journalService.isProcessed(event.id)) return;
+
+        const { positionId, positionHash, ledgerInputHash } = event.payload;
+        const userId = await this.getPositionUserId(positionId);
+
+        const ledgerEvent = await this.findLedgerEventByInputHash(positionId, ledgerInputHash);
+        if (!ledgerEvent) {
+            this.logger.warn({ positionId, ledgerInputHash }, 'No ledger event found for STAKING_DEPOSIT');
+            return;
+        }
+
+        const config = ledgerEvent.config as Record<string, unknown>;
+        const deltaL = config.deltaL as string;
+        if (!deltaL || deltaL === '0') return;
+
+        const deltaCostBasis = ledgerEvent.deltaCostBasis;
+        if (deltaCostBasis === '0') return;
+
+        const ctx = await this.getReportingContext(positionId);
+        const tokenCtx = await this.resolvePositionToken(positionId);
+        if (!tokenCtx) return;
+
+        const costBasisAbsolute = computeReportingAmount(
+            deltaCostBasis, ctx.exchangeRate, ctx.quoteTokenDecimals,
+        );
+
+        const lotId = await this.tokenLotService.createLot({
+            userId,
+            tokenId: tokenCtx.tokenId,
+            tokenHash: tokenCtx.tokenHash,
+            quantity: deltaL,
+            costBasisAbsolute,
+            acquiredAt: new Date(event.payload.eventTimestamp),
+            acquisitionEventId: ledgerInputHash,
+            positionLedgerEventId: ledgerEvent.id,
+            transferEvent: 'STAKING_DEPOSIT',
+        });
+
+        await this.createAcquisitionEntry(
+            userId, event.id, event.type,
+            ledgerEvent.id, new Date(event.payload.eventTimestamp), deltaCostBasis,
+            lotId, positionHash, ctx.instrumentRef,
+            ctx.reportingCurrency, ctx.exchangeRate, ctx.quoteTokenDecimals,
+        );
+    }
+
+    // =========================================================================
+    // Disposal: STAKING_DISPOSE — Model A divergence
+    // =========================================================================
+
+    /**
+     * `position.liquidity.decreased` (STAKING_DISPOSE) → consume lots and
+     * post a balanced 5–6 line entry per disposed lot.
+     *
+     * Follows SPEC-0003b §8.4 rev. b — balanced disposal entry
+     * (DR 3100 = principal + yield). Yield is recognized as Fee Income (4000),
+     * NOT folded into realized PnL — that's the Model A invariant.
+     */
+    private async handleLiquidityDecreased(
+        event: DomainEvent<PositionLedgerEventPayload>,
+    ): Promise<void> {
+        if (await this.journalService.isProcessed(event.id)) return;
+
+        const { positionId, positionHash, ledgerInputHash } = event.payload;
+        const userId = await this.getPositionUserId(positionId);
+
+        const ledgerEvent = await this.findLedgerEventByInputHash(positionId, ledgerInputHash);
+        if (!ledgerEvent) {
+            this.logger.warn({ positionId, ledgerInputHash }, 'No ledger event found for STAKING_DISPOSE');
+            return;
+        }
+
+        const config = ledgerEvent.config as Record<string, unknown>;
+        const deltaL = config.deltaL as string;
+        if (!deltaL || deltaL === '0') return;
+
+        const principalQuoteValue = (config.principalQuoteValue as string) ?? '0';
+        const yieldQuoteValue = (config.yieldQuoteValue as string) ?? '0';
+
+        const ctx = await this.getReportingContext(positionId);
+        const tokenCtx = await this.resolvePositionToken(positionId);
+        if (!tokenCtx) return;
+
+        const costBasisMethod = await this.getUserCostBasisMethod(userId);
+        const lotSelector = createLotSelector(costBasisMethod);
+
+        // Model A boundary: pass principal-only as proceeds so per-lot
+        // realizedPnl reflects principal vs cost basis, not yield.
+        const proceedsReporting = computeReportingAmount(
+            principalQuoteValue, ctx.exchangeRate, ctx.quoteTokenDecimals,
+        );
+
+        const quantityToDispose = absBigint(deltaL);
+
+        const result = await this.tokenLotService.disposeLots({
+            userId,
+            tokenHash: tokenCtx.tokenHash,
+            quantityToDispose,
+            proceedsReporting,
+            disposedAt: new Date(event.payload.eventTimestamp),
+            disposalEventId: ledgerInputHash,
+            positionLedgerEventId: ledgerEvent.id,
+            transferEvent: 'STAKING_DISPOSE',
+            lotSelector,
+        });
+
+        await this.createDisposalEntries(
+            userId, event.id, event.type,
+            ledgerEvent.id, new Date(event.payload.eventTimestamp),
+            ledgerEvent.deltaCostBasis, principalQuoteValue, yieldQuoteValue,
+            result, positionHash, ctx.instrumentRef,
+            ctx.reportingCurrency, ctx.exchangeRate, ctx.quoteTokenDecimals,
+        );
+    }
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    /**
+     * `position.closed` → zero out remaining cost basis on the 1000 account
+     * against 4300 (FX_GAIN_LOSS). Mirrors NFT/Vault pattern verbatim.
+     */
+    private async handlePositionClosed(
+        event: DomainEvent<PositionLifecyclePayload>,
+    ): Promise<void> {
+        const { positionId, positionHash } = event.payload;
+        const positionRef = positionHash;
+
+        const correctionEventId = `${event.id}:cost-basis-correction`;
+        if (await this.journalService.isProcessed(correctionEventId)) return;
+
+        const cbQuote = await this.journalService.getAccountBalance(
+            ACCOUNT_CODES.LP_POSITION_AT_COST, positionRef,
+        );
+        const cbReporting = await this.journalService.getAccountBalanceReporting(
+            ACCOUNT_CODES.LP_POSITION_AT_COST, positionRef,
+        );
+
+        if (cbQuote === 0n && cbReporting === 0n) return;
+
+        const userId = await this.getPositionUserId(positionId);
+        const ctx = await this.getReportingContext(positionId);
+        const absQuote = absBigintValue(cbQuote).toString();
+        const absReporting = absBigintValue(cbReporting).toString();
+        const isOverCredited = cbQuote < 0n || (cbQuote === 0n && cbReporting < 0n);
+
+        const lines: JournalLineInput[] = isOverCredited
+            ? [
+                {
+                    accountCode: ACCOUNT_CODES.LP_POSITION_AT_COST, side: 'debit',
+                    amountQuote: absQuote, amountReporting: absReporting,
+                    reportingCurrency: ctx.reportingCurrency, exchangeRate: ctx.exchangeRate,
+                    positionRef, instrumentRef: ctx.instrumentRef,
+                },
+                {
+                    accountCode: ACCOUNT_CODES.FX_GAIN_LOSS, side: 'credit',
+                    amountQuote: absQuote, amountReporting: absReporting,
+                    reportingCurrency: ctx.reportingCurrency, exchangeRate: ctx.exchangeRate,
+                    positionRef, instrumentRef: ctx.instrumentRef,
+                },
+            ]
+            : [
+                {
+                    accountCode: ACCOUNT_CODES.LP_POSITION_AT_COST, side: 'credit',
+                    amountQuote: absQuote, amountReporting: absReporting,
+                    reportingCurrency: ctx.reportingCurrency, exchangeRate: ctx.exchangeRate,
+                    positionRef, instrumentRef: ctx.instrumentRef,
+                },
+                {
+                    accountCode: ACCOUNT_CODES.FX_GAIN_LOSS, side: 'debit',
+                    amountQuote: absQuote, amountReporting: absReporting,
+                    reportingCurrency: ctx.reportingCurrency, exchangeRate: ctx.exchangeRate,
+                    positionRef, instrumentRef: ctx.instrumentRef,
+                },
+            ];
+
+        await this.journalService.createEntry(
+            {
+                userId,
+                domainEventId: correctionEventId,
+                domainEventType: event.type,
+                entryDate: new Date(event.timestamp),
+                description: `Staking-vault cost basis correction: ${positionRef}`,
+            },
+            lines,
+        );
+    }
+
+    /** `position.deleted` → no-op. FK cascade cleans up lots/disposals/entries. */
+    private async handlePositionDeleted(
+        event: DomainEvent<PositionLifecyclePayload>,
+    ): Promise<void> {
+        this.logger.info(
+            { positionHash: event.payload.positionHash },
+            'Staking-vault position deleted — lots, disposals, and journal entries cascade-deleted via FK',
+        );
+    }
+
+    /**
+     * `position.liquidity.reverted` → no-op. The reverted PositionLedgerEvent
+     * row was already deleted upstream by `UniswapV3StakingLedgerService`,
+     * which cascades to TokenLot / TokenLotDisposal / JournalEntry via FK.
+     */
+    private async handleLiquidityReverted(
+        event: DomainEvent<PositionLiquidityRevertedPayload>,
+    ): Promise<void> {
+        this.logger.info(
+            { positionHash: event.payload.positionHash, blockHash: event.payload.blockHash },
+            'Staking-vault liquidity reverted — lots, disposals, and journal entries cascade-deleted via FK',
+        );
+    }
+
+    // =========================================================================
+    // Journal Entry Builders
+    // =========================================================================
+
+    private async createAcquisitionEntry(
+        userId: string, domainEventId: string, domainEventType: string,
+        positionLedgerEventId: string, entryDate: Date, deltaCostBasis: string,
+        tokenLotId: string, positionRef: string, instrumentRef: string,
+        reportingCurrency: string, exchangeRate: string, quoteTokenDecimals: number,
+    ): Promise<void> {
+        const lines = new JournalLineBuilder()
+            .withReporting(reportingCurrency, exchangeRate, quoteTokenDecimals)
+            .debit(ACCOUNT_CODES.LP_POSITION_AT_COST, deltaCostBasis, positionRef, instrumentRef)
+            .credit(ACCOUNT_CODES.CONTRIBUTED_CAPITAL, deltaCostBasis, positionRef, instrumentRef)
+            .build();
+
+        await this.journalService.createEntry(
+            {
+                userId, domainEventId, domainEventType, positionLedgerEventId, entryDate,
+                tokenLotId, description: `Staking-vault acquisition: ${positionRef}`,
+            },
+            lines,
+        );
+    }
+
+    /**
+     * Build one balanced disposal entry per disposed lot (Model A).
+     *
+     * Follows SPEC-0003b §8.4 rev. b — balanced disposal entry
+     * (DR 3100 = principal + yield). Yield → Fee Income (4000), realized
+     * PnL is principal-vs-cost-basis only.
+     *
+     *     DR 3100 Capital Returned    = proportionalPrincipal + proportionalYield
+     *     CR 1000 LP Position at Cost = proportionalCostBasis
+     *     CR 4000 Fee Income          = proportionalYield                  // Model A
+     *     IF proportionalPnl > 0: CR 4100 Realized Gains
+     *     IF proportionalPnl < 0: DR 5000 Realized Losses
+     *     FX adjustment line if fxDiff != 0 (against 4300, amountQuote=0)
+     *
+     * Proportional split is by quantity; the last lot gets the remainder so
+     * the per-lot sums reconcile exactly with the ledger event totals.
+     */
+    private async createDisposalEntries(
+        userId: string, domainEventId: string, domainEventType: string,
+        positionLedgerEventId: string, entryDate: Date,
+        ledgerDeltaCostBasis: string,
+        ledgerPrincipalQuoteValue: string,
+        ledgerYieldQuoteValue: string,
+        result: DisposalResult,
+        positionRef: string, instrumentRef: string,
+        reportingCurrency: string, exchangeRate: string, quoteTokenDecimals: number,
+    ): Promise<void> {
+        const totalQtyDisposed = result.totalQuantityDisposed;
+        const absDeltaCostBasis = BigInt(absBigint(ledgerDeltaCostBasis));
+        const totalPrincipal = BigInt(ledgerPrincipalQuoteValue);
+        const totalYield = BigInt(ledgerYieldQuoteValue);
+        const decimalsScale = 10n ** BigInt(quoteTokenDecimals);
+        const spotRate = BigInt(exchangeRate);
+
+        let costBasisDistributed = 0n;
+        let principalDistributed = 0n;
+        let yieldDistributed = 0n;
+
+        for (let i = 0; i < result.disposals.length; i++) {
+            const d = result.disposals[i]!;
+            const isLast = i === result.disposals.length - 1;
+            const qty = BigInt(d.quantityDisposed);
+
+            const proportionalCostBasis = isLast
+                ? absDeltaCostBasis - costBasisDistributed
+                : (qty * absDeltaCostBasis) / totalQtyDisposed;
+            const proportionalPrincipal = isLast
+                ? totalPrincipal - principalDistributed
+                : (qty * totalPrincipal) / totalQtyDisposed;
+            const proportionalYield = isLast
+                ? totalYield - yieldDistributed
+                : (qty * totalYield) / totalQtyDisposed;
+            const proportionalPnl = proportionalPrincipal - proportionalCostBasis;
+
+            costBasisDistributed += proportionalCostBasis;
+            principalDistributed += proportionalPrincipal;
+            yieldDistributed += proportionalYield;
+
+            const builder = new JournalLineBuilder()
+                .withReporting(reportingCurrency, exchangeRate, quoteTokenDecimals);
+
+            // DR 3100 = principal + yield (full proceeds returned to wallet).
+            const totalProceeds = proportionalPrincipal + proportionalYield;
+            if (totalProceeds > 0n) {
+                builder.debit(ACCOUNT_CODES.CAPITAL_RETURNED, totalProceeds.toString(), positionRef, instrumentRef);
+            }
+
+            // CR 1000 = lot cost basis.
+            if (proportionalCostBasis > 0n) {
+                builder.credit(ACCOUNT_CODES.LP_POSITION_AT_COST, proportionalCostBasis.toString(), positionRef, instrumentRef);
+            }
+
+            // CR 4000 = yield (Model A: fee income, NOT realized PnL).
+            if (proportionalYield > 0n) {
+                builder.credit(ACCOUNT_CODES.FEE_INCOME, proportionalYield.toString(), positionRef, instrumentRef);
+            }
+
+            // CR 4100 / DR 5000 — principal-vs-cost-basis realized PnL.
+            if (proportionalPnl > 0n) {
+                builder.credit(ACCOUNT_CODES.REALIZED_GAINS, proportionalPnl.toString(), positionRef, instrumentRef);
+            } else if (proportionalPnl < 0n) {
+                builder.debit(ACCOUNT_CODES.REALIZED_LOSSES, (-proportionalPnl).toString(), positionRef, instrumentRef);
+            }
+
+            const lines = builder.build();
+
+            // Override the cost-basis line's amountReporting with the lot's
+            // actual cost basis (FX historical), then book any drift to 4300.
+            const cbLine = lines.find((l) => l.accountCode === ACCOUNT_CODES.LP_POSITION_AT_COST);
+            if (cbLine) {
+                const cbAtSpot = (proportionalCostBasis * spotRate) / decimalsScale;
+                const lotCostBasis = BigInt(d.costBasisAllocated);
+                cbLine.amountReporting = lotCostBasis.toString();
+
+                const fxDiff = cbAtSpot - lotCostBasis;
+                if (fxDiff !== 0n) {
+                    lines.push({
+                        accountCode: ACCOUNT_CODES.FX_GAIN_LOSS,
+                        side: fxDiff > 0n ? 'credit' : 'debit',
+                        amountQuote: '0',
+                        amountReporting: (fxDiff < 0n ? -fxDiff : fxDiff).toString(),
+                        reportingCurrency,
+                        exchangeRate,
+                        positionRef,
+                        instrumentRef,
+                    });
+                }
+            }
+
+            await this.journalService.createEntry(
+                {
+                    userId,
+                    domainEventId: `${domainEventId}:${d.id}`,
+                    domainEventType,
+                    positionLedgerEventId,
+                    entryDate,
+                    tokenLotDisposalId: d.id,
+                    description: `Staking-vault disposal: ${positionRef}`,
+                },
+                lines,
+            );
+        }
+    }
+
+    // =========================================================================
+    // Token Resolution
+    // =========================================================================
+
+    /**
+     * Resolve (or upsert) the staking-share token for this position.
+     * Vaults are owner-bound 1:1, so the vaultAddress alone disambiguates.
+     */
+    private async resolvePositionToken(positionId: string): Promise<PositionTokenContext | null> {
+        const position = await prisma.position.findUnique({
+            where: { id: positionId },
+            select: { config: true },
+        });
+        if (!position) return null;
+
+        const config = position.config as Record<string, unknown>;
+        const chainId = config.chainId as number;
+        const vaultAddress = config.vaultAddress as string;
+        const tokenHash = createStakingShareTokenHash(chainId, vaultAddress);
+
+        const token = await prisma.token.upsert({
+            where: { tokenHash },
+            update: {},
+            create: {
+                tokenType: 'staking-share',
+                name: `Midcurve Staking Vault (${vaultAddress.slice(0, 6)}…${vaultAddress.slice(-4)})`,
+                symbol: 'MSV-STK',
+                decimals: 0,
+                tokenHash,
+                config: { chainId, vaultAddress, protocol: 'uniswapv3-staking' },
+            },
+            select: { id: true, tokenHash: true },
+        });
+
+        return { tokenId: token.id, tokenHash: token.tokenHash };
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private async findLedgerEventByInputHash(positionId: string, inputHash: string) {
+        return prisma.positionLedgerEvent.findFirst({
+            where: { positionId, inputHash },
+            select: {
+                id: true, deltaCostBasis: true, costBasisAfter: true,
+                deltaPnl: true, pnlAfter: true, deltaCollectedYield: true,
+                collectedYieldAfter: true, tokenValue: true, config: true,
+            },
+        });
+    }
+
+    private async getPositionUserId(positionId: string): Promise<string> {
+        const position = await prisma.position.findUnique({
+            where: { id: positionId },
+            select: { userId: true },
+        });
+        if (!position) throw new Error(`Position not found: ${positionId}`);
+        return position.userId;
+    }
+
+    private async getUserCostBasisMethod(userId: string): Promise<CostBasisMethod> {
+        const settings = await prisma.userSettings.findUnique({
+            where: { userId },
+            select: { settings: true },
+        });
+        if (!settings) return DEFAULT_USER_SETTINGS.costBasisMethod;
+        const data = settings.settings as Record<string, unknown>;
+        return (data.costBasisMethod as CostBasisMethod) ?? DEFAULT_USER_SETTINGS.costBasisMethod;
+    }
+
+    private async getQuoteTokenInfo(positionId: string) {
+        const position = await prisma.position.findUnique({
+            where: { id: positionId },
+            select: { config: true, user: { select: { reportingCurrency: true } } },
+        });
+        if (!position) throw new Error(`Position not found: ${positionId}`);
+
+        const config = position.config as Record<string, unknown>;
+        const chainId = config.chainId as number;
+        const isToken0Quote = config.isToken0Quote as boolean;
+        const quoteAddress = isToken0Quote
+            ? (config.token0Address as string)
+            : (config.token1Address as string);
+
+        const quoteToken = await prisma.token.findUnique({
+            where: { tokenHash: createErc20TokenHash(chainId, quoteAddress) },
+            select: { decimals: true, coingeckoId: true },
+        });
+        if (!quoteToken) throw new Error(`Quote token not found for ${quoteAddress} on chain ${chainId}`);
+
+        return {
+            reportingCurrency: position.user.reportingCurrency,
+            quoteTokenDecimals: quoteToken.decimals,
+            quoteCoingeckoId: quoteToken.coingeckoId,
+        };
+    }
+
+    private async getReportingContext(positionId: string): Promise<ReportingContext> {
+        const position = await prisma.position.findUnique({
+            where: { id: positionId },
+            select: {
+                protocol: true, config: true,
+                user: { select: { reportingCurrency: true } },
+            },
+        });
+        if (!position) throw new Error(`Position not found: ${positionId}`);
+
+        const positionConfig = position.config as Record<string, unknown>;
+        const token0Address = positionConfig.token0Address as string;
+        const token1Address = positionConfig.token1Address as string;
+        const chainId = positionConfig.chainId as number;
+        const vaultAddress = positionConfig.vaultAddress as string;
+
+        const [token0Row, token1Row] = await Promise.all([
+            prisma.token.findUnique({
+                where: { tokenHash: createErc20TokenHash(chainId, token0Address) },
+                select: { decimals: true, coingeckoId: true },
+            }),
+            prisma.token.findUnique({
+                where: { tokenHash: createErc20TokenHash(chainId, token1Address) },
+                select: { decimals: true, coingeckoId: true },
+            }),
+        ]);
+        if (!token0Row) throw new Error(`Token not found for address ${token0Address} on chain ${chainId}`);
+        if (!token1Row) throw new Error(`Token not found for address ${token1Address} on chain ${chainId}`);
+
+        const isToken0Quote = positionConfig.isToken0Quote as boolean;
+        const quoteToken = isToken0Quote ? token0Row : token1Row;
+        const reportingCurrency = position.user.reportingCurrency;
+        const reportingCurrencyUsdPrice = 1.0;
+
+        let quoteTokenUsdPrice = 1.0;
+        if (quoteToken.coingeckoId) {
+            const prices = await CoinGeckoClient.getInstance().getSimplePrices([quoteToken.coingeckoId]);
+            quoteTokenUsdPrice = prices[quoteToken.coingeckoId]?.usd ?? 1.0;
+        }
+
+        const rate = quoteTokenUsdPrice / reportingCurrencyUsdPrice;
+        const exchangeRate = BigInt(Math.round(rate * FLOAT_TO_BIGINT_SCALE));
+
+        return {
+            reportingCurrency,
+            exchangeRate: exchangeRate.toString(),
+            quoteTokenDecimals: quoteToken.decimals,
+            instrumentRef: `uniswapv3-staking/${chainId}/${vaultAddress}`,
+        };
+    }
+}
+
+// =============================================================================
+// Utility Functions
+// =============================================================================
+
+function absBigint(value: string): string {
+    const n = BigInt(value);
+    return (n < 0n ? -n : n).toString();
+}
+
+function absBigintValue(value: bigint): bigint {
+    return value < 0n ? -value : value;
+}
+
+function computeReportingAmount(
+    amountQuote: string, exchangeRate: string, quoteTokenDecimals: number,
+): string {
+    const amount = BigInt(amountQuote);
+    const rate = BigInt(exchangeRate);
+    const scale = 10n ** BigInt(quoteTokenDecimals);
+    const absAmount = amount < 0n ? -amount : amount;
+    return ((absAmount * rate) / scale).toString();
+}
+
+function computeHistoricRate(
+    quoteCoingeckoId: string | null,
+    priceTimeSeries: [number, number][],
+    eventTimestamp: Date,
+): bigint {
+    let quoteTokenUsdPrice = 1.0;
+    if (quoteCoingeckoId && priceTimeSeries.length > 0) {
+        quoteTokenUsdPrice = findClosestPrice(priceTimeSeries, eventTimestamp.getTime());
+    }
+    const reportingCurrencyUsdPrice = 1.0;
+    const rate = quoteTokenUsdPrice / reportingCurrencyUsdPrice;
+    return BigInt(Math.round(rate * FLOAT_TO_BIGINT_SCALE));
+}

--- a/apps/midcurve-business-logic/src/rules/index.ts
+++ b/apps/midcurve-business-logic/src/rules/index.ts
@@ -53,6 +53,7 @@ export * from './close-orders';
 // Accounting rules (double-entry journal system, protocol-specific)
 export { UniswapV3PostJournalEntriesRule, UniswapV3ReconcileCostBasisRule, UniswapV3ReevaluateOnWalletChangeRule } from './accounting/uniswapv3';
 export { UniswapV3VaultPostJournalEntriesRule } from './accounting/uniswapv3-vault';
+export { UniswapV3StakingPostJournalEntriesRule } from './accounting/uniswapv3-staking';
 
 // Automation rules
 export { RefuelOperatorRule } from './automation/refuel-operator';

--- a/apps/midcurve-business-logic/src/workers/index.ts
+++ b/apps/midcurve-business-logic/src/workers/index.ts
@@ -22,6 +22,7 @@ import {
   UniswapV3ReconcileCostBasisRule,
   UniswapV3ReevaluateOnWalletChangeRule,
   UniswapV3VaultPostJournalEntriesRule,
+  UniswapV3StakingPostJournalEntriesRule,
   RefuelOperatorRule,
   type BusinessRuleStatus,
 } from '../rules';
@@ -76,6 +77,9 @@ export class RuleManager {
 
     // UniswapV3 accounting rules — Vault positions
     this.registry.register(new UniswapV3VaultPostJournalEntriesRule());
+
+    // UniswapV3 accounting rules — Staking-vault positions (SPEC-0003b)
+    this.registry.register(new UniswapV3StakingPostJournalEntriesRule());
 
     // Automation rules
     // Operator gas refueling from treasury WETH

--- a/apps/midcurve-business-logic/vitest.config.ts
+++ b/apps/midcurve-business-logic/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/packages/midcurve-shared/src/types/accounting/token-lot.ts
+++ b/packages/midcurve-shared/src/types/accounting/token-lot.ts
@@ -22,7 +22,9 @@ export type TokenLotTransferEvent =
   | 'VAULT_MINT'
   | 'VAULT_BURN'
   | 'DEPOSIT_TO_PROTOCOL'
-  | 'WITHDRAWAL_FROM_PROTOCOL';
+  | 'WITHDRAWAL_FROM_PROTOCOL'
+  | 'STAKING_DEPOSIT'
+  | 'STAKING_DISPOSE';
 
 /**
  * Transfer events that create new token lots (acquisitions).
@@ -31,7 +33,8 @@ export type AcquisitionTransferEvent =
   | 'INCREASE_POSITION'
   | 'TRANSFER_IN'
   | 'VAULT_MINT'
-  | 'WITHDRAWAL_FROM_PROTOCOL';
+  | 'WITHDRAWAL_FROM_PROTOCOL'
+  | 'STAKING_DEPOSIT';
 
 /**
  * Transfer events that consume existing token lots (disposals).
@@ -40,4 +43,5 @@ export type DisposalTransferEvent =
   | 'DECREASE_POSITION'
   | 'TRANSFER_OUT'
   | 'VAULT_BURN'
-  | 'DEPOSIT_TO_PROTOCOL';
+  | 'DEPOSIT_TO_PROTOCOL'
+  | 'STAKING_DISPOSE';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,12 @@ importers:
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+      vitest-mock-extended:
+        specifier: ^3.1.0
+        version: 3.1.0(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))
 
   apps/midcurve-contracts:
     dependencies:
@@ -12593,7 +12599,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.1(jiti@2.6.1))
@@ -12636,7 +12642,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -12651,36 +12657,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.1(jiti@2.6.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.1(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
@@ -12698,7 +12679,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12727,7 +12708,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -15657,6 +15638,12 @@ snapshots:
       ts-essentials: 10.1.1(typescript@5.9.3)
       typescript: 5.9.3
       vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)
+
+  vitest-mock-extended@3.1.0(typescript@5.9.3)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)):
+    dependencies:
+      ts-essentials: 10.1.1(typescript@5.9.3)
+      typescript: 5.9.3
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6):
     dependencies:


### PR DESCRIPTION
## Summary

PR3 of 5 for SPEC-0003b. Adds `UniswapV3StakingPostJournalEntriesRule`, which consumes the `position.liquidity.{increased,decreased,reverted}` domain events PR2 publishes for `uniswapv3-staking` positions and turns them into `TokenLot` rows + balanced `JournalEntry`s.

## Model A — confirmed §8.4 rev. b interpretation

Per the maintainer's confirmation in the issue thread, the original SPEC §8.4 had an imbalance bug. **This PR implements the corrected balanced shape**: single entry per disposed lot with `DR 3100 = principal + yield`, plus a `CR 4000` line that peels yield out as Fee Income.

```
DR 3100 Capital Returned     = proportionalPrincipal + proportionalYield
CR 1000 LP Position at Cost  = proportionalCostBasis
CR 4000 Fee Income           = proportionalYield                ← Model A
IF proportionalPnl > 0: CR 4100 Realized Gains
IF proportionalPnl < 0: DR 5000 Realized Losses
optional FX adjustment line against 4300 (amountQuote=0)
```

The Model A invariant lives at the disposal boundary: `TokenLotService.disposeLots` is called with `proceedsReporting = principal × spotRate / scale` (principal-only), so per-lot `realizedPnl` reflects principal-vs-cost-basis only — yield never enters the PnL accounting.

Inline comment in `handleLiquidityDecreased` references SPEC-0003b §8.4 rev. b for traceability per maintainer's request.

## Files

**Add:**
- `apps/midcurve-business-logic/src/rules/accounting/uniswapv3-staking/uniswapv3-staking-post-journal-entries.ts` (~640 LoC)
- `apps/midcurve-business-logic/src/rules/accounting/uniswapv3-staking/uniswapv3-staking-post-journal-entries.test.ts` (12 tests — first test suite for any journal-posting rule in this app)
- `apps/midcurve-business-logic/src/rules/accounting/uniswapv3-staking/index.ts`
- `apps/midcurve-business-logic/vitest.config.ts` (first vitest config in business-logic)

**Modify:**
- `apps/midcurve-business-logic/src/rules/index.ts` — export `UniswapV3StakingPostJournalEntriesRule`
- `apps/midcurve-business-logic/src/workers/index.ts` — register the rule alongside NFT and Vault
- `apps/midcurve-business-logic/package.json` — add `vitest` + `vitest-mock-extended` devDeps and `test`/`test:run` scripts
- `packages/midcurve-shared/src/types/accounting/token-lot.ts` — extend `TokenLotTransferEvent`, `AcquisitionTransferEvent`, `DisposalTransferEvent` unions with `STAKING_DEPOSIT` / `STAKING_DISPOSE` (the Prisma enum already had them from PR1)

## Dispatch table (staking subset per SPEC §8.5)

| Event type | Handler | Notes |
|---|---|---|
| `position.created` | `handlePositionCreated` | Backfill: replays all STAKING_DEPOSIT/STAKING_DISPOSE in chain order |
| `position.liquidity.increased` | `handleLiquidityIncreased` | STAKING_DEPOSIT lot + DR 1000 / CR 3000 |
| `position.liquidity.decreased` | `handleLiquidityDecreased` | Model A divergence (above) |
| `position.liquidity.reverted` | `handleLiquidityReverted` | No-op — FK cascade |
| `position.closed` | `handlePositionClosed` | Cost-basis correction (1000 vs 4300) |
| `position.deleted` | `handlePositionDeleted` | No-op — FK cascade |

No `position.fees.collected` (yield is folded into dispose), no `position.transferred.in/out` (vaults are owner-bound, non-transferable), no `position.burned` (vaults reach Settled state).

## Tests (12)

Mocks: `vi.hoisted` + `vi.mock('@midcurve/database', ...)` for prisma; method override on `JournalService.getInstance()` and `TokenLotService.getInstance()` singletons. No live DB, no live RabbitMQ.

1. Routing pattern constants (`positions.*.uniswapv3-staking`)
2. STAKING_DEPOSIT happy path — lot + DR 1000 / CR 3000
3. Token upsert produces `staking-share` hash + correct metadata (`MSV-STK`, decimals=0)
4. **STAKING_DISPOSE — Model A boundary**: explicit assertion that `disposeLots` was called with `proceedsReporting = principal × spotRate / scale`, NOT principal+yield
5. STAKING_DISPOSE entry shape — DR 3100 = principal+yield, CR 1000 = cost, CR 4000 = yield, CR 4100 = pnl; debit total == credit total
6. Multi-lot disposal — proportional splits sum exactly to ledger event totals (last lot gets remainder)
7. Model A invariant: yield-only flat principal → CR 4000 only, no realized PnL line
8. Model A invariant: principal-floor gain zero yield → CR 4100, no Fee Income line
9. `position.liquidity.reverted` — no service calls (FK cascade)
10. `position.closed` — non-zero remainder zeroed against FX_GAIN_LOSS
11. `position.deleted` — no service calls (FK cascade)
12. Idempotency — second invocation with same `domainEventId` is a no-op

## Acceptance criteria from §12 covered

- §12.3 (journal balance) — **fully** (every entry passes `JournalLineBuilder.build()`, which throws on imbalance; tests assert amounts and balance)
- §12.4 (Model A invariant) — **fully** at the journal layer (tests 7 + 8 on top of PR1's coverage at the ledger layer)
- §12.5 (idempotency) — **fully** at the rule layer (test 12)
- §12.6 (reorg safety) — **fully** (revert handler exercised + FK cascade is the source of truth, test 9)

## Out of scope (next PRs)

- `UniswapV3StakingPositionService` (CRUD, refresh-all, archive) → **PR4**
- REST endpoints (discover, import, refresh, accounting view, APR view) → **PR4**
- MCP tools → **PR5**

Refs #63

## Test plan
- [x] `pnpm typecheck` — all 14 packages pass
- [x] `pnpm --filter @midcurve/business-logic test:run` — 12 tests pass
- [x] `pnpm --filter @midcurve/services test:run` — 164 tests pass (no regressions)
- [x] `pnpm --filter @midcurve/shared test:run` — 127 tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)