### PR TITLE
feat: add UniswapV3StakingPositionService (SPEC-0003b PR4a)

### DIFF
--- a/packages/midcurve-services/src/services/position/index.ts
+++ b/packages/midcurve-services/src/services/position/index.ts
@@ -15,5 +15,8 @@ export type {
 export { UniswapV3VaultPositionService } from './uniswapv3-vault-position-service.js';
 export type { UniswapV3VaultPositionServiceDependencies } from './uniswapv3-vault-position-service.js';
 
+export { UniswapV3StakingPositionService } from './uniswapv3-staking-position-service.js';
+export type { UniswapV3StakingPositionServiceDependencies } from './uniswapv3-staking-position-service.js';
+
 export { PositionArchiveService } from './position-archive-service.js';
 export type { PositionArchiveServiceDependencies } from './position-archive-service.js';

--- a/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.test.ts
+++ b/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.test.ts
@@ -490,20 +490,23 @@ describe('UniswapV3StakingPositionService', () => {
     });
 
     // -------------------------------------------------------------------------
-    // 6. refresh — always orchestrates ledger sync + state refresh (NO updatedAt cache)
+    // 6. refresh — no updatedAt short-circuit (would catch a regression that
+    //    re-introduces the 15-second cache).
     // -------------------------------------------------------------------------
-    it('refresh — always calls syncFromChain + refreshOnChainState (no updatedAt short-circuit)', async () => {
-        // Position was just updated 1ms ago — would be a cache hit if we had a 15s cache.
+    it('refresh — two back-to-back calls both invoke syncFromChain (no updatedAt cache)', async () => {
+        // Position was updated 1ms ago — a hypothetical 15s cache would short-circuit.
         const recentRow = makePositionRow({ updatedAt: new Date(Date.now() - 1) });
         prismaMock.position.findFirst.mockResolvedValue(recentRow);
 
         const { service } = makeService({});
         await service.refresh(POSITION_ID);
+        await service.refresh(POSITION_ID);
 
-        // refreshAllPositionLogs called → syncFromChain called
-        expect(mockLedgerInstance.syncFromChain).toHaveBeenCalledTimes(1);
-        // refreshOnChainState ran → position.update called
-        expect(prismaMock.position.update).toHaveBeenCalled();
+        // The invariant: refresh always pulls fresh chain state. A regression
+        // that re-introduces the 15s cache would yield only 1 call here.
+        expect(mockLedgerInstance.syncFromChain).toHaveBeenCalledTimes(2);
+        // refreshOnChainState ran on each call → position.update called twice.
+        expect(prismaMock.position.update).toHaveBeenCalledTimes(2);
     });
 
     // -------------------------------------------------------------------------
@@ -579,34 +582,39 @@ describe('UniswapV3StakingPositionService', () => {
     });
 
     // -------------------------------------------------------------------------
-    // 11. reset — journal-rebuild boundary: same liquidity.{increased,decreased}
-    //     publish call set as the original import.
+    // 11. reset — journal-rebuild contract.
+    //
+    // ⚠️ Test boundary limitation: `syncFromChain` is mocked, so this test
+    // CANNOT directly verify the publisher call set after reset matches the
+    // original import (the planned "same `ledgerInputHash` set, same count,
+    // same chain order" assertion is impossible across a mocked package
+    // boundary). What we CAN verify here:
+    //   - `deleteAll` was invoked exactly once.
+    //   - `syncFromChain` was invoked exactly once for the rebuild.
+    //   - No `position.liquidity.reverted` events were emitted from reset
+    //     itself (refinement #3).
+    //
+    // Re-emission CORRECTNESS — that PR2's `syncFromChain` re-publishes the
+    // same `position.liquidity.{increased,decreased}` events as the original
+    // import — is verified at PR2's `syncFromChain` test layer (the staking
+    // ledger service's tests). PR3's rule consumes those events deterministically
+    // via its idempotency check (`journalService.isProcessed`), so a correct
+    // re-emission from PR2 plus the FK cascade from `deleteAll` yields a
+    // correct journal rebuild end-to-end.
     // -------------------------------------------------------------------------
-    it('reset — re-publishes the same liquidity.{increased,decreased} events as the original import', async () => {
+    it('reset — invokes deleteAll + syncFromChain exactly once each, no revert events', async () => {
         prismaMock.position.findFirst.mockResolvedValue(makePositionRow());
         const { service } = makeService({});
 
-        // First import: syncFromChain pretend-publishes 1 increased + 1 decreased.
-        // We capture the events by counting publisher calls of the right types.
-        // After PR2's syncFromChain runs, those publishes are emitted by the
-        // ledger service internally — but here we mock syncFromChain to be a
-        // no-op and instead assert that reset calls syncFromChain (which would
-        // re-emit the events identically).
         await service.refresh(POSITION_ID);
         const initialSyncCalls = mockLedgerInstance.syncFromChain.mock.calls.length;
 
         await service.reset(POSITION_ID);
 
-        // After reset: ledger deleteAll + a fresh syncFromChain call. The fresh
-        // syncFromChain pulls the same on-chain history → re-emits the same
-        // liquidity.{increased,decreased} events. We verify the boundary: the
-        // ledger service is invoked exactly once more for the rebuild.
         expect(mockLedgerInstance.syncFromChain.mock.calls.length).toBe(initialSyncCalls + 1);
         expect(mockLedgerInstance.deleteAll).toHaveBeenCalledTimes(1);
 
-        // Ensure no `position.liquidity.reverted` was emitted by reset itself
-        // (refinement #3 boundary: PR3 rebuild relies on the increase/decrease
-        // re-emission from PR2's syncFromChain, not on revert noise from reset).
+        // Refinement #3: reset must NOT emit `position.liquidity.reverted`.
         const revertCount = mockCreateAndPublish.mock.calls.filter(
             (c) => c[0].type === 'position.liquidity.reverted',
         ).length;

--- a/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.test.ts
+++ b/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.test.ts
@@ -1,0 +1,676 @@
+/**
+ * UniswapV3StakingPositionService — unit tests
+ *
+ * SPEC-0003b PR4a acceptance:
+ *  - discover: validates the vault address (`INVALID_VAULT_CONTRACT` on chain
+ *    read failure), creates Position row, calls syncFromChain, refreshes state.
+ *  - discoverWalletPositions: factory lookup + `VaultCreated(owner=...)` scan;
+ *    chains with no registered factory contribute `{ found: 0 }` gracefully.
+ *  - refresh: always does a fresh chain pull (NO 15-second updatedAt cache).
+ *  - reset: wipes ledger, does NOT emit revert events, reimports via
+ *    syncFromChain. Journal-rebuild boundary assertion at the publisher.
+ *  - refreshOnChainState: `Staked → Settled` transition emits position.closed.
+ *  - delete: emits position.deleted, transactional.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// MODULE MOCKS — hoisted so vi.mock factories can reference them.
+// =============================================================================
+
+const { prismaMock, mockCreateAndPublish, mockLedgerInstance } = vi.hoisted(() => ({
+    prismaMock: {
+        position: {
+            findFirst: vi.fn(),
+            create: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+        },
+        positionLedgerEvent: {
+            findFirst: vi.fn(),
+        },
+        token: { findUnique: vi.fn() },
+        $transaction: vi.fn(),
+    },
+    mockCreateAndPublish: vi.fn(async () => 'evt_id'),
+    mockLedgerInstance: {
+        syncFromChain: vi.fn(async () => ({ perLogResults: [], allDeletedEvents: [] })),
+        deleteAll: vi.fn(async () => undefined),
+        recalculateAggregates: vi.fn(async () => ({
+            liquidityAfter: 0n,
+            costBasisAfter: 0n,
+            realizedPnlAfter: 0n,
+            collectedYieldAfter: 0n,
+            realizedCashflowAfter: 0n,
+        })),
+    },
+}));
+
+vi.mock('@midcurve/database', () => ({
+    prisma: prismaMock,
+    PrismaClient: class {},
+}));
+
+vi.mock('../../events/index.js', async (importOriginal) => {
+    const original: object = await (importOriginal as () => Promise<object>)();
+    return {
+        ...original,
+        getDomainEventPublisher: vi.fn(() => ({
+            createAndPublish: mockCreateAndPublish,
+        })),
+    };
+});
+
+vi.mock('../position-ledger/uniswapv3-staking-ledger-service.js', () => ({
+    UniswapV3StakingLedgerService: vi.fn(() => mockLedgerInstance),
+}));
+
+import { UniswapV3StakingPositionService } from './uniswapv3-staking-position-service.js';
+
+// =============================================================================
+// FIXTURES
+// =============================================================================
+
+const POSITION_ID = 'pos_staking_test';
+const USER_ID = 'user_test';
+const CHAIN_ID = 42161;
+// All addresses are pre-checksummed (EIP-55) so the service's `normalizeAddress`
+// call returns them unchanged — keeps test assertions identity-comparable.
+const VAULT_ADDRESS = '0xA1A1a1a1A1A1A1A1A1a1a1a1a1a1A1A1a1A1a1a1';
+const FACTORY_ADDRESS = '0x2Cc277Cd2CF5d78F18f0627a1DA2aA48b7C57EB1';
+const POOL_ADDRESS = '0xc3c3c3c3c3c3c3c3c3C3C3c3C3C3C3c3C3C3c3c3';
+const OWNER_ADDRESS = '0xb2b2b2b2b2B2b2B2B2b2b2B2B2b2B2B2b2b2b2b2';
+const TOKEN0 = '0xaAAAaaAA00000000000000000000000000000000';
+const TOKEN1 = '0xBbbBBbBB00000000000000000000000000000000';
+const POSITION_HASH = `uniswapv3-staking/${CHAIN_ID}/${VAULT_ADDRESS}`;
+
+const SQRT_PRICE_1_TO_1 = 2n ** 96n;
+
+function makePositionRow(overrides: Record<string, unknown> = {}) {
+    return {
+        id: POSITION_ID,
+        userId: USER_ID,
+        protocol: 'uniswapv3-staking',
+        type: 'LP_CONCENTRATED',
+        positionHash: POSITION_HASH,
+        ownerWallet: `evm:${OWNER_ADDRESS}`,
+        config: {
+            chainId: CHAIN_ID,
+            vaultAddress: VAULT_ADDRESS,
+            factoryAddress: FACTORY_ADDRESS,
+            ownerAddress: OWNER_ADDRESS,
+            underlyingTokenId: 42,
+            isToken0Quote: false,
+            poolAddress: POOL_ADDRESS,
+            token0Address: TOKEN0,
+            token1Address: TOKEN1,
+            feeBps: 3000,
+            tickSpacing: 60,
+            tickLower: -100,
+            tickUpper: 100,
+            priceRangeLower: '0',
+            priceRangeUpper: '0',
+        },
+        state: {
+            vaultState: 'Staked',
+            stakedBase: '0',
+            stakedQuote: '0',
+            yieldTarget: '0',
+            pendingBps: 0,
+            unstakeBufferBase: '0',
+            unstakeBufferQuote: '0',
+            rewardBufferBase: '0',
+            rewardBufferQuote: '0',
+            liquidity: '1000000',
+            isOwnedByUser: true,
+            unclaimedYieldBase: '0',
+            unclaimedYieldQuote: '0',
+            sqrtPriceX96: SQRT_PRICE_1_TO_1.toString(),
+            currentTick: 0,
+            poolLiquidity: '0',
+            feeGrowthGlobal0: '0',
+            feeGrowthGlobal1: '0',
+        },
+        currentValue: 0n,
+        costBasis: 0n,
+        realizedPnl: 0n,
+        unrealizedPnl: 0n,
+        realizedCashflow: 0n,
+        unrealizedCashflow: 0n,
+        collectedYield: 0n,
+        unclaimedYield: 0n,
+        lastYieldClaimedAt: new Date(),
+        baseApr: null,
+        rewardApr: null,
+        totalApr: null,
+        positionOpenedAt: new Date('2026-04-01T00:00:00Z'),
+        archivedAt: null,
+        isArchived: false,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        ...overrides,
+    };
+}
+
+function makeTokenRow(address: string) {
+    return {
+        id: `tok_${address.slice(2, 10)}`,
+        tokenType: 'erc20',
+        name: 'Test Token',
+        symbol: 'TEST',
+        decimals: 6,
+        tokenHash: `erc20/${CHAIN_ID}/${address}`,
+        config: { chainId: CHAIN_ID, address },
+        coingeckoId: null,
+        marketCap: null,
+        logoUrl: null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+    };
+}
+
+interface VaultReadOverrides {
+    state?: number;
+    stakedBase?: bigint;
+    stakedQuote?: bigint;
+    yieldTarget?: bigint;
+    partialUnstakeBps?: number;
+    unstakeBufferBase?: bigint;
+    unstakeBufferQuote?: bigint;
+    rewardBufferBase?: bigint;
+    rewardBufferQuote?: bigint;
+    owner?: string;
+    pool?: string;
+    tokenId?: bigint;
+    token0?: string;
+    token1?: string;
+    isToken0Quote?: boolean;
+    positionManager?: string;
+    tickLower?: number;
+    tickUpper?: number;
+}
+
+function makeMockClient(opts: {
+    vaultReads?: VaultReadOverrides;
+    nfpmLiquidity?: bigint;
+    vaultCreatedLogs?: Array<{
+        args: { owner?: string; vault?: string };
+        blockNumber: bigint;
+    }>;
+    stakeLogs?: Array<{ blockNumber: bigint }>;
+}) {
+    const reads = {
+        state: opts.vaultReads?.state ?? 1, // Staked
+        stakedBase: opts.vaultReads?.stakedBase ?? 1000n,
+        stakedQuote: opts.vaultReads?.stakedQuote ?? 500n,
+        yieldTarget: opts.vaultReads?.yieldTarget ?? 100n,
+        partialUnstakeBps: opts.vaultReads?.partialUnstakeBps ?? 0,
+        unstakeBufferBase: opts.vaultReads?.unstakeBufferBase ?? 0n,
+        unstakeBufferQuote: opts.vaultReads?.unstakeBufferQuote ?? 0n,
+        rewardBufferBase: opts.vaultReads?.rewardBufferBase ?? 0n,
+        rewardBufferQuote: opts.vaultReads?.rewardBufferQuote ?? 0n,
+        owner: opts.vaultReads?.owner ?? OWNER_ADDRESS,
+        pool: opts.vaultReads?.pool ?? POOL_ADDRESS,
+        tokenId: opts.vaultReads?.tokenId ?? 42n,
+        token0: opts.vaultReads?.token0 ?? TOKEN0,
+        token1: opts.vaultReads?.token1 ?? TOKEN1,
+        isToken0Quote: opts.vaultReads?.isToken0Quote ?? false,
+        positionManager: opts.vaultReads?.positionManager ?? '0xC36442b4a4522E871399CD717aBDD847Ab11FE88',
+        tickLower: opts.vaultReads?.tickLower ?? -100,
+        tickUpper: opts.vaultReads?.tickUpper ?? 100,
+    };
+    const liquidity = opts.nfpmLiquidity ?? 1_000_000n;
+
+    return {
+        chain: { id: CHAIN_ID },
+        getChainId: vi.fn(async () => CHAIN_ID),
+        getBlockNumber: vi.fn(async () => 1_000_000n),
+        getBlock: vi.fn(async () => ({ number: 1_000_000n, timestamp: 1700000000n })),
+        readContract: vi.fn(async (params: { functionName: string }) => {
+            const fn = params.functionName;
+            if (fn === 'positions') {
+                return [
+                    0n, '0x0000000000000000000000000000000000000000',
+                    TOKEN0, TOKEN1, 3000, -100, 100,
+                    liquidity, 0n, 0n, 0n, 0n,
+                ];
+            }
+            const value = (reads as Record<string, unknown>)[fn];
+            if (value === undefined) {
+                throw new Error(`Unmocked readContract: ${fn}`);
+            }
+            return value;
+        }),
+        getLogs: vi.fn(async (params: { event?: { name: string }; args?: Record<string, unknown> }) => {
+            const eventName = params.event?.name;
+            if (eventName === 'VaultCreated') return opts.vaultCreatedLogs ?? [];
+            if (eventName === 'Stake') return opts.stakeLogs ?? [];
+            return [];
+        }),
+    };
+}
+
+function makeMockEvmConfig(client: ReturnType<typeof makeMockClient>) {
+    return {
+        getPublicClient: vi.fn(() => client),
+        getFinalityConfig: vi.fn(() => ({ type: 'blockTag' as const })),
+        getSupportedChainIds: vi.fn(() => [CHAIN_ID]),
+    } as any;
+}
+
+function makeMockSharedContractService(opts: { factoryAddress?: string | null }) {
+    return {
+        findLatestByChainAndName: vi.fn(async () =>
+            opts.factoryAddress === null
+                ? null
+                : { config: { address: opts.factoryAddress ?? FACTORY_ADDRESS, chainId: CHAIN_ID } },
+        ),
+    } as any;
+}
+
+function makeMockEvmBlockService() {
+    return {
+        getCurrentBlockNumber: vi.fn(async () => 1_000_000n),
+        getLastFinalizedBlockNumber: vi.fn(async () => 1_000_000n),
+    } as any;
+}
+
+function makeMockCacheService() {
+    const store = new Map<string, unknown>();
+    return {
+        get: vi.fn(async (key: string) => store.get(key) ?? null),
+        set: vi.fn(async (key: string, value: unknown) => {
+            store.set(key, value);
+        }),
+        _store: store,
+    } as any;
+}
+
+function makeMockPoolService() {
+    return {
+        discover: vi.fn(async () => ({
+            typedConfig: { tickSpacing: 60 },
+        })),
+        fetchPoolState: vi.fn(async () => ({
+            sqrtPriceX96: SQRT_PRICE_1_TO_1,
+            currentTick: 0,
+            liquidity: 0n,
+            feeGrowthGlobal0: 0n,
+            feeGrowthGlobal1: 0n,
+        })),
+    } as any;
+}
+
+function makeMockErc20Service() {
+    return {
+        discover: vi.fn(async ({ address }: { address: string }) => ({
+            id: `tok_${address.slice(2, 10)}`,
+            address,
+            decimals: 6,
+            symbol: 'TEST',
+        })),
+    } as any;
+}
+
+interface ServiceFactoryOpts {
+    factoryAddress?: string | null;
+    vaultReads?: VaultReadOverrides;
+    nfpmLiquidity?: bigint;
+    vaultCreatedLogs?: Parameters<typeof makeMockClient>[0]['vaultCreatedLogs'];
+    stakeLogs?: Parameters<typeof makeMockClient>[0]['stakeLogs'];
+}
+
+function makeService(opts: ServiceFactoryOpts = {}) {
+    const client = makeMockClient(opts);
+    const evmConfig = makeMockEvmConfig(client);
+    const sharedContractService = makeMockSharedContractService({
+        factoryAddress: opts.factoryAddress,
+    });
+    const evmBlockService = makeMockEvmBlockService();
+    const cacheService = makeMockCacheService();
+    const poolService = makeMockPoolService();
+    const erc20TokenService = makeMockErc20Service();
+    // Mock poolPriceService — never actually called because syncFromChain is mocked,
+    // but the service constructor would otherwise try to instantiate the real one
+    // (which requires EvmConfig.getInstance() to be initialized).
+    const poolPriceService = { discover: vi.fn() } as any;
+
+    const service = new UniswapV3StakingPositionService({
+        evmConfig,
+        sharedContractService,
+        evmBlockService,
+        cacheService,
+        poolService,
+        erc20TokenService,
+        poolPriceService,
+    });
+
+    return { service, client, evmConfig, sharedContractService, cacheService, poolService };
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe('UniswapV3StakingPositionService', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Reset hoisted mocks (vi.clearAllMocks doesn't reach them)
+        mockCreateAndPublish.mockReset().mockResolvedValue('evt_id');
+        mockLedgerInstance.syncFromChain.mockReset().mockResolvedValue({
+            perLogResults: [], allDeletedEvents: [],
+        });
+        mockLedgerInstance.deleteAll.mockReset().mockResolvedValue(undefined);
+        mockLedgerInstance.recalculateAggregates.mockReset().mockResolvedValue({
+            liquidityAfter: 0n,
+            costBasisAfter: 0n,
+            realizedPnlAfter: 0n,
+            collectedYieldAfter: 0n,
+            realizedCashflowAfter: 0n,
+        });
+        prismaMock.position.findFirst.mockReset();
+        prismaMock.position.create.mockReset();
+        prismaMock.position.update.mockReset().mockResolvedValue(makePositionRow());
+        prismaMock.position.delete.mockReset();
+        prismaMock.positionLedgerEvent.findFirst.mockReset().mockResolvedValue(null);
+        prismaMock.token.findUnique.mockReset().mockImplementation(async (q: any) => {
+            const hash = q.where.tokenHash as string;
+            const addr = hash.split('/').pop()!;
+            return makeTokenRow(addr);
+        });
+        prismaMock.$transaction.mockReset().mockImplementation(async (fn: any) => fn(prismaMock));
+    });
+
+    // -------------------------------------------------------------------------
+    // 1. discover happy path
+    // -------------------------------------------------------------------------
+    it('discover — happy path: creates Position, syncs ledger, returns position', async () => {
+        const { service } = makeService({
+            stakeLogs: [{ blockNumber: 100n }],
+        });
+        prismaMock.position.findFirst
+            .mockResolvedValueOnce(null) // findByPositionHash for existing check
+            .mockResolvedValue(makePositionRow()); // subsequent findById in refresh
+
+        prismaMock.position.create.mockResolvedValue(makePositionRow());
+
+        const result = await service.discover(USER_ID, {
+            chainId: CHAIN_ID,
+            vaultAddress: VAULT_ADDRESS,
+        });
+
+        expect(prismaMock.position.create).toHaveBeenCalledTimes(1);
+        const createArgs = prismaMock.position.create.mock.calls[0]![0];
+        expect(createArgs.data.protocol).toBe('uniswapv3-staking');
+        expect(createArgs.data.type).toBe('LP_CONCENTRATED');
+        expect(createArgs.data.positionHash).toBe(POSITION_HASH);
+
+        // syncFromChain called by refresh path
+        expect(mockLedgerInstance.syncFromChain).toHaveBeenCalled();
+        const syncArgs = mockLedgerInstance.syncFromChain.mock.calls[0]!;
+        expect(syncArgs[3].factoryAddress).toBe(FACTORY_ADDRESS);
+
+        // No `position.created` emitted from the service — that's the API route's job (PR4b).
+        const types = mockCreateAndPublish.mock.calls.map((c) => c[0].type);
+        expect(types).not.toContain('position.created');
+
+        expect(result.id).toBe(POSITION_ID);
+    });
+
+    // -------------------------------------------------------------------------
+    // 2. discover — INVALID_VAULT_CONTRACT
+    // -------------------------------------------------------------------------
+    it('discover — chain reads fail → throws INVALID_VAULT_CONTRACT', async () => {
+        const { service, client } = makeService({});
+        prismaMock.position.findFirst.mockResolvedValue(null);
+        client.readContract.mockImplementationOnce(async () => {
+            throw new Error('execution reverted');
+        });
+
+        await expect(
+            service.discover(USER_ID, { chainId: CHAIN_ID, vaultAddress: VAULT_ADDRESS }),
+        ).rejects.toThrow(/INVALID_VAULT_CONTRACT/);
+    });
+
+    // -------------------------------------------------------------------------
+    // 3. discoverWalletPositions — chain with no factory
+    // -------------------------------------------------------------------------
+    it('discoverWalletPositions — chain with no factory contributes { found: 0 } gracefully', async () => {
+        const { service } = makeService({ factoryAddress: null });
+
+        const result = await service.discoverWalletPositions(USER_ID, OWNER_ADDRESS, [CHAIN_ID]);
+
+        expect(result).toEqual({ found: 0, imported: 0, skipped: 0, errors: 0 });
+    });
+
+    // -------------------------------------------------------------------------
+    // 4. discoverWalletPositions — getLogs uses fromBlock 0n + owner filter
+    // -------------------------------------------------------------------------
+    it('discoverWalletPositions — VaultCreated getLogs filtered by owner=walletAddress, fromBlock=0n', async () => {
+        const { service, client } = makeService({
+            vaultCreatedLogs: [], // no matches → no imports needed
+        });
+
+        await service.discoverWalletPositions(USER_ID, OWNER_ADDRESS, [CHAIN_ID]);
+
+        expect(client.getLogs).toHaveBeenCalledTimes(1);
+        const args = client.getLogs.mock.calls[0]![0];
+        expect(args.address).toBe(FACTORY_ADDRESS);
+        expect(args.event.name).toBe('VaultCreated');
+        expect(args.args.owner.toLowerCase()).toBe(OWNER_ADDRESS.toLowerCase());
+        expect(args.fromBlock).toBe(0n);
+    });
+
+    // -------------------------------------------------------------------------
+    // 5. discoverWalletPositions — chain with matching VaultCreated log
+    // -------------------------------------------------------------------------
+    it('discoverWalletPositions — matching VaultCreated log triggers discover()', async () => {
+        const { service } = makeService({
+            vaultCreatedLogs: [{
+                args: { owner: OWNER_ADDRESS, vault: VAULT_ADDRESS },
+                blockNumber: 50n,
+            }],
+            stakeLogs: [{ blockNumber: 100n }],
+        });
+        prismaMock.position.findFirst
+            // First call: outer findByPositionHash to check existence → null
+            .mockResolvedValueOnce(null)
+            // Second call: inner findByPositionHash inside discover() → null
+            .mockResolvedValueOnce(null)
+            // Subsequent: findById calls inside refresh path
+            .mockResolvedValue(makePositionRow());
+        prismaMock.position.create.mockResolvedValue(makePositionRow());
+
+        const result = await service.discoverWalletPositions(USER_ID, OWNER_ADDRESS, [CHAIN_ID]);
+
+        expect(result.found).toBe(1);
+        expect(result.imported).toBe(1);
+        expect(prismaMock.position.create).toHaveBeenCalledTimes(1);
+    });
+
+    // -------------------------------------------------------------------------
+    // 6. refresh — always orchestrates ledger sync + state refresh (NO updatedAt cache)
+    // -------------------------------------------------------------------------
+    it('refresh — always calls syncFromChain + refreshOnChainState (no updatedAt short-circuit)', async () => {
+        // Position was just updated 1ms ago — would be a cache hit if we had a 15s cache.
+        const recentRow = makePositionRow({ updatedAt: new Date(Date.now() - 1) });
+        prismaMock.position.findFirst.mockResolvedValue(recentRow);
+
+        const { service } = makeService({});
+        await service.refresh(POSITION_ID);
+
+        // refreshAllPositionLogs called → syncFromChain called
+        expect(mockLedgerInstance.syncFromChain).toHaveBeenCalledTimes(1);
+        // refreshOnChainState ran → position.update called
+        expect(prismaMock.position.update).toHaveBeenCalled();
+    });
+
+    // -------------------------------------------------------------------------
+    // 7. refreshOnChainState — Staked → Settled emits position.closed
+    // -------------------------------------------------------------------------
+    it('refreshOnChainState — Staked → Settled transition emits position.closed once', async () => {
+        // DB state = 'Staked'; chain state = 'Settled' (state index 3)
+        prismaMock.position.findFirst.mockResolvedValue(makePositionRow());
+        const { service } = makeService({
+            vaultReads: { state: 3 /* Settled */ },
+        });
+
+        await service.refresh(POSITION_ID);
+
+        const closedCalls = mockCreateAndPublish.mock.calls.filter(
+            (c) => c[0].type === 'position.closed',
+        );
+        expect(closedCalls).toHaveLength(1);
+        expect(closedCalls[0]![0].payload.positionHash).toBe(POSITION_HASH);
+    });
+
+    // -------------------------------------------------------------------------
+    // 8. refreshOnChainState — Staked → Staked does NOT emit position.closed
+    // -------------------------------------------------------------------------
+    it('refreshOnChainState — no transition does NOT emit position.closed', async () => {
+        prismaMock.position.findFirst.mockResolvedValue(makePositionRow());
+        const { service } = makeService({
+            vaultReads: { state: 1 /* Staked */ },
+        });
+
+        await service.refresh(POSITION_ID);
+
+        const closedCalls = mockCreateAndPublish.mock.calls.filter(
+            (c) => c[0].type === 'position.closed',
+        );
+        expect(closedCalls).toHaveLength(0);
+    });
+
+    // -------------------------------------------------------------------------
+    // 9. refreshOnChainState — block-keyed cache hit returns without contract reads
+    // -------------------------------------------------------------------------
+    it('refreshOnChainState — second call at same block hits the cache (no extra readContract calls)', async () => {
+        prismaMock.position.findFirst.mockResolvedValue(makePositionRow());
+        const { service, client } = makeService({});
+
+        await service.refresh(POSITION_ID);
+        const firstCallCount = client.readContract.mock.calls.length;
+
+        await service.refresh(POSITION_ID);
+        const secondCallCount = client.readContract.mock.calls.length;
+
+        // Second call hits the cache → no new readContract calls.
+        expect(secondCallCount).toBe(firstCallCount);
+    });
+
+    // -------------------------------------------------------------------------
+    // 10. reset — wipes ledger, does NOT emit revert events
+    // -------------------------------------------------------------------------
+    it('reset — wipes ledger and does NOT emit position.liquidity.reverted (per refinement #3)', async () => {
+        prismaMock.position.findFirst.mockResolvedValue(makePositionRow());
+        const { service } = makeService({});
+
+        await service.reset(POSITION_ID);
+
+        expect(mockLedgerInstance.deleteAll).toHaveBeenCalledTimes(1);
+        // Reimport ran via syncFromChain
+        expect(mockLedgerInstance.syncFromChain).toHaveBeenCalled();
+        // No revert events emitted from reset (FK cascade is the source of truth)
+        const revertCalls = mockCreateAndPublish.mock.calls.filter(
+            (c) => c[0].type === 'position.liquidity.reverted',
+        );
+        expect(revertCalls).toHaveLength(0);
+    });
+
+    // -------------------------------------------------------------------------
+    // 11. reset — journal-rebuild boundary: same liquidity.{increased,decreased}
+    //     publish call set as the original import.
+    // -------------------------------------------------------------------------
+    it('reset — re-publishes the same liquidity.{increased,decreased} events as the original import', async () => {
+        prismaMock.position.findFirst.mockResolvedValue(makePositionRow());
+        const { service } = makeService({});
+
+        // First import: syncFromChain pretend-publishes 1 increased + 1 decreased.
+        // We capture the events by counting publisher calls of the right types.
+        // After PR2's syncFromChain runs, those publishes are emitted by the
+        // ledger service internally — but here we mock syncFromChain to be a
+        // no-op and instead assert that reset calls syncFromChain (which would
+        // re-emit the events identically).
+        await service.refresh(POSITION_ID);
+        const initialSyncCalls = mockLedgerInstance.syncFromChain.mock.calls.length;
+
+        await service.reset(POSITION_ID);
+
+        // After reset: ledger deleteAll + a fresh syncFromChain call. The fresh
+        // syncFromChain pulls the same on-chain history → re-emits the same
+        // liquidity.{increased,decreased} events. We verify the boundary: the
+        // ledger service is invoked exactly once more for the rebuild.
+        expect(mockLedgerInstance.syncFromChain.mock.calls.length).toBe(initialSyncCalls + 1);
+        expect(mockLedgerInstance.deleteAll).toHaveBeenCalledTimes(1);
+
+        // Ensure no `position.liquidity.reverted` was emitted by reset itself
+        // (refinement #3 boundary: PR3 rebuild relies on the increase/decrease
+        // re-emission from PR2's syncFromChain, not on revert noise from reset).
+        const revertCount = mockCreateAndPublish.mock.calls.filter(
+            (c) => c[0].type === 'position.liquidity.reverted',
+        ).length;
+        expect(revertCount).toBe(0);
+    });
+
+    // -------------------------------------------------------------------------
+    // 12. delete — emits position.deleted, transactional
+    // -------------------------------------------------------------------------
+    it('delete — emits position.deleted in a transaction', async () => {
+        prismaMock.position.findFirst.mockResolvedValue(makePositionRow());
+        const { service } = makeService({});
+
+        await service.delete(POSITION_ID);
+
+        expect(prismaMock.$transaction).toHaveBeenCalledTimes(1);
+        expect(prismaMock.position.delete).toHaveBeenCalledTimes(1);
+
+        const deleteCalls = mockCreateAndPublish.mock.calls.filter(
+            (c) => c[0].type === 'position.deleted',
+        );
+        expect(deleteCalls).toHaveLength(1);
+        expect(deleteCalls[0]![0].payload.positionId).toBe(POSITION_ID);
+    });
+
+    // -------------------------------------------------------------------------
+    // 13. fetchMetrics — non-persisted snapshot
+    // -------------------------------------------------------------------------
+    it('fetchMetrics — returns snapshot with vault state + ledger aggregates', async () => {
+        prismaMock.position.findFirst.mockResolvedValue(makePositionRow());
+        mockLedgerInstance.recalculateAggregates.mockResolvedValue({
+            liquidityAfter: 0n,
+            costBasisAfter: 1500n,
+            realizedPnlAfter: 100n,
+            collectedYieldAfter: 50n,
+            realizedCashflowAfter: 0n,
+        });
+
+        const { service } = makeService({
+            vaultReads: { state: 1, yieldTarget: 200n, partialUnstakeBps: 0 },
+        });
+        const metrics = await service.fetchMetrics(POSITION_ID);
+
+        expect(metrics.costBasis).toBe(1500n);
+        expect(metrics.realizedPnl).toBe(100n);
+        expect(metrics.collectedYield).toBe(50n);
+        expect(metrics.vaultState).toBe('Staked');
+        expect(metrics.yieldTarget).toBe(200n);
+        expect(metrics.pendingBps).toBe(0);
+        expect(metrics.isOwnedByUser).toBe(true);
+    });
+
+    // -------------------------------------------------------------------------
+    // 14. findByPositionHash — DB lookup with positionHash + protocol filter
+    // -------------------------------------------------------------------------
+    it('findByPositionHash — uses positionHash + protocol filter', async () => {
+        prismaMock.position.findFirst.mockResolvedValue(makePositionRow());
+        const { service } = makeService({});
+
+        const result = await service.findByPositionHash(USER_ID, POSITION_HASH);
+
+        expect(result?.id).toBe(POSITION_ID);
+        expect(prismaMock.position.findFirst).toHaveBeenCalledWith({
+            where: { userId: USER_ID, positionHash: POSITION_HASH, protocol: 'uniswapv3-staking' },
+        });
+    });
+});

--- a/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.ts
+++ b/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.ts
@@ -1,0 +1,1012 @@
+/**
+ * UniswapV3 Staking Position Service
+ *
+ * Service layer for `UniswapV3StakingVault` positions (SPEC-0003b).
+ *
+ * Architecture mirrors `UniswapV3VaultPositionService` (closer-in-spirit
+ * canonical: clone-based, factory-deployed) with these staking-specific
+ * design points:
+ *
+ * - Vaults are owner-bound 1:1, so `vaultAddress` alone disambiguates.
+ *   `positionHash` format is `uniswapv3-staking/{chainId}/{vaultAddress}`.
+ * - `refresh()` always does a fresh chain pull — NO 15-second cache (per
+ *   PR4 plan refinement #1: stale-row caching causes silent UI bugs after
+ *   user txs like stake/topUp/unstake/claim/flashClose).
+ * - `reset()` does NOT emit `position.liquidity.reverted` events (per PR4
+ *   plan refinement #3: FK cascade is the documented cleanup path; the
+ *   immediate re-import via `syncFromChain` re-emits all liquidity events
+ *   for PR3's rule to rebuild from scratch).
+ * - On-chain state reads are cached with a block-keyed 60s TTL via
+ *   `CacheService` (`staking-onchain:v1:{chainId}:{vault}:{blockNumber}`).
+ * - PR2's `UniswapV3StakingLedgerService.syncFromChain` does the heavy
+ *   lifting — this service is a thin orchestration layer.
+ * - `position.created` is NOT emitted here; the `/discover` API route
+ *   in PR4b emits it after calling `service.discover()`. Mirrors the
+ *   NFT/Vault convention.
+ */
+
+import { prisma as prismaClient, PrismaClient } from '@midcurve/database';
+import {
+    UniswapV3StakingPosition,
+    UniswapV3StakingPositionConfig,
+    stakingPositionStateToJSON,
+    normalizeAddress,
+    SharedContractNameEnum,
+    tickToPrice,
+    createErc20TokenHash,
+    createEvmOwnerWallet,
+    calculatePositionValue,
+    Erc20Token,
+} from '@midcurve/shared';
+import type {
+    UniswapV3StakingPositionRow,
+    UniswapV3StakingPositionConfigData,
+    UniswapV3StakingPositionState,
+    UniswapV3StakingPositionConfigJSON,
+    UniswapV3StakingPositionMetrics,
+    StakingState,
+    TokenInterface,
+} from '@midcurve/shared';
+import type { Address } from 'viem';
+import { parseAbiItem } from 'viem';
+import { createServiceLogger } from '../../logging/index.js';
+import type { ServiceLogger } from '../../logging/index.js';
+import { getDomainEventPublisher } from '../../events/index.js';
+import type {
+    DomainEventPublisher,
+    PositionLifecyclePayload,
+} from '../../events/index.js';
+import { EvmConfig } from '../../config/evm.js';
+import { UNISWAP_V3_POSITION_MANAGER_ABI } from '../../config/uniswapv3.js';
+import { UniswapV3PoolService } from '../pool/uniswapv3-pool-service.js';
+import type { PrismaTransactionClient } from '../../clients/prisma/index.js';
+import { EvmBlockService } from '../block/evm-block-service.js';
+import { UniswapV3PoolPriceService } from '../pool-price/uniswapv3-pool-price-service.js';
+import { UniswapV3StakingLedgerService } from '../position-ledger/uniswapv3-staking-ledger-service.js';
+import { CacheService } from '../cache/index.js';
+import { SharedContractService } from '../automation/shared-contract-service.js';
+import { Erc20TokenService } from '../token/erc20-token-service.js';
+import { calculateTokenValueInQuote } from '../../utils/uniswapv3/ledger-calculations.js';
+
+// ============================================================================
+// MINIMAL STAKING-VAULT READ ABI
+// ============================================================================
+
+const STAKING_VAULT_READ_ABI = [
+    { type: 'function', name: 'owner', stateMutability: 'view', inputs: [], outputs: [{ type: 'address' }] },
+    { type: 'function', name: 'pool', stateMutability: 'view', inputs: [], outputs: [{ type: 'address' }] },
+    { type: 'function', name: 'tokenId', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint256' }] },
+    { type: 'function', name: 'token0', stateMutability: 'view', inputs: [], outputs: [{ type: 'address' }] },
+    { type: 'function', name: 'token1', stateMutability: 'view', inputs: [], outputs: [{ type: 'address' }] },
+    { type: 'function', name: 'isToken0Quote', stateMutability: 'view', inputs: [], outputs: [{ type: 'bool' }] },
+    { type: 'function', name: 'positionManager', stateMutability: 'view', inputs: [], outputs: [{ type: 'address' }] },
+    { type: 'function', name: 'tickLower', stateMutability: 'view', inputs: [], outputs: [{ type: 'int24' }] },
+    { type: 'function', name: 'tickUpper', stateMutability: 'view', inputs: [], outputs: [{ type: 'int24' }] },
+    { type: 'function', name: 'state', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint8' }] },
+    { type: 'function', name: 'stakedBase', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint256' }] },
+    { type: 'function', name: 'stakedQuote', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint256' }] },
+    { type: 'function', name: 'yieldTarget', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint256' }] },
+    { type: 'function', name: 'partialUnstakeBps', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint16' }] },
+    { type: 'function', name: 'unstakeBufferBase', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint256' }] },
+    { type: 'function', name: 'unstakeBufferQuote', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint256' }] },
+    { type: 'function', name: 'rewardBufferBase', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint256' }] },
+    { type: 'function', name: 'rewardBufferQuote', stateMutability: 'view', inputs: [], outputs: [{ type: 'uint256' }] },
+] as const;
+
+const STAKING_STATE_BY_INDEX: Record<number, StakingState> = {
+    0: 'Empty',
+    1: 'Staked',
+    2: 'FlashCloseInProgress',
+    3: 'Settled',
+};
+
+function stakingStateFromIndex(idx: number): StakingState {
+    const state = STAKING_STATE_BY_INDEX[idx];
+    if (state === undefined) {
+        throw new Error(`Unknown staking-vault state index: ${idx}`);
+    }
+    return state;
+}
+
+// ============================================================================
+// CACHE TYPES (block-keyed RPC cache for refreshOnChainState)
+// ============================================================================
+
+interface OnChainStakingState {
+    blockNumber: bigint;
+    vaultState: StakingState;
+    stakedBase: bigint;
+    stakedQuote: bigint;
+    yieldTarget: bigint;
+    pendingBps: number;
+    unstakeBufferBase: bigint;
+    unstakeBufferQuote: bigint;
+    rewardBufferBase: bigint;
+    rewardBufferQuote: bigint;
+    liquidity: bigint;
+    sqrtPriceX96: bigint;
+    currentTick: number;
+    poolLiquidity: bigint;
+    feeGrowthGlobal0: bigint;
+    feeGrowthGlobal1: bigint;
+    ownerAddress: string;
+}
+
+interface OnChainStakingStateCached {
+    blockNumber: string;
+    vaultState: StakingState;
+    stakedBase: string;
+    stakedQuote: string;
+    yieldTarget: string;
+    pendingBps: number;
+    unstakeBufferBase: string;
+    unstakeBufferQuote: string;
+    rewardBufferBase: string;
+    rewardBufferQuote: string;
+    liquidity: string;
+    sqrtPriceX96: string;
+    currentTick: number;
+    poolLiquidity: string;
+    feeGrowthGlobal0: string;
+    feeGrowthGlobal1: string;
+    ownerAddress: string;
+}
+
+function serialize(state: OnChainStakingState): OnChainStakingStateCached {
+    return {
+        blockNumber: state.blockNumber.toString(),
+        vaultState: state.vaultState,
+        stakedBase: state.stakedBase.toString(),
+        stakedQuote: state.stakedQuote.toString(),
+        yieldTarget: state.yieldTarget.toString(),
+        pendingBps: state.pendingBps,
+        unstakeBufferBase: state.unstakeBufferBase.toString(),
+        unstakeBufferQuote: state.unstakeBufferQuote.toString(),
+        rewardBufferBase: state.rewardBufferBase.toString(),
+        rewardBufferQuote: state.rewardBufferQuote.toString(),
+        liquidity: state.liquidity.toString(),
+        sqrtPriceX96: state.sqrtPriceX96.toString(),
+        currentTick: state.currentTick,
+        poolLiquidity: state.poolLiquidity.toString(),
+        feeGrowthGlobal0: state.feeGrowthGlobal0.toString(),
+        feeGrowthGlobal1: state.feeGrowthGlobal1.toString(),
+        ownerAddress: state.ownerAddress,
+    };
+}
+
+function deserialize(cached: OnChainStakingStateCached): OnChainStakingState {
+    return {
+        blockNumber: BigInt(cached.blockNumber),
+        vaultState: cached.vaultState,
+        stakedBase: BigInt(cached.stakedBase),
+        stakedQuote: BigInt(cached.stakedQuote),
+        yieldTarget: BigInt(cached.yieldTarget),
+        pendingBps: cached.pendingBps,
+        unstakeBufferBase: BigInt(cached.unstakeBufferBase),
+        unstakeBufferQuote: BigInt(cached.unstakeBufferQuote),
+        rewardBufferBase: BigInt(cached.rewardBufferBase),
+        rewardBufferQuote: BigInt(cached.rewardBufferQuote),
+        liquidity: BigInt(cached.liquidity),
+        sqrtPriceX96: BigInt(cached.sqrtPriceX96),
+        currentTick: cached.currentTick,
+        poolLiquidity: BigInt(cached.poolLiquidity),
+        feeGrowthGlobal0: BigInt(cached.feeGrowthGlobal0),
+        feeGrowthGlobal1: BigInt(cached.feeGrowthGlobal1),
+        ownerAddress: cached.ownerAddress,
+    };
+}
+
+// ============================================================================
+// DEPENDENCIES
+// ============================================================================
+
+export interface UniswapV3StakingPositionServiceDependencies {
+    prisma?: PrismaClient;
+    eventPublisher?: DomainEventPublisher;
+    evmConfig?: EvmConfig;
+    poolService?: UniswapV3PoolService;
+    evmBlockService?: EvmBlockService;
+    poolPriceService?: UniswapV3PoolPriceService;
+    cacheService?: CacheService;
+    sharedContractService?: SharedContractService;
+    erc20TokenService?: Erc20TokenService;
+}
+
+// ============================================================================
+// SERVICE
+// ============================================================================
+
+export class UniswapV3StakingPositionService {
+    private readonly prisma: PrismaClient;
+    private readonly logger: ServiceLogger;
+    private readonly eventPublisher: DomainEventPublisher;
+    private readonly _evmConfig: EvmConfig;
+    private readonly _poolService: UniswapV3PoolService;
+    private readonly _evmBlockService: EvmBlockService;
+    private readonly _poolPriceService: UniswapV3PoolPriceService;
+    private readonly _cacheService: CacheService;
+    private readonly _sharedContractService: SharedContractService;
+    private readonly _erc20TokenService: Erc20TokenService;
+
+    constructor(deps: UniswapV3StakingPositionServiceDependencies = {}) {
+        this.prisma = deps.prisma ?? prismaClient;
+        this.logger = createServiceLogger('uniswapv3-staking-position');
+        this.eventPublisher = deps.eventPublisher ?? getDomainEventPublisher();
+        this._evmConfig = deps.evmConfig ?? EvmConfig.getInstance();
+        this._poolService = deps.poolService ?? new UniswapV3PoolService();
+        this._evmBlockService = deps.evmBlockService ?? new EvmBlockService({ evmConfig: this._evmConfig });
+        this._poolPriceService = deps.poolPriceService ?? new UniswapV3PoolPriceService();
+        this._cacheService = deps.cacheService ?? CacheService.getInstance();
+        this._sharedContractService = deps.sharedContractService ?? new SharedContractService();
+        this._erc20TokenService = deps.erc20TokenService ?? new Erc20TokenService();
+    }
+
+    // =========================================================================
+    // QUERY METHODS
+    // =========================================================================
+
+    async findById(
+        id: string,
+        tx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPosition | null> {
+        const db = tx ?? this.prisma;
+        const row = await db.position.findFirst({
+            where: { id, protocol: 'uniswapv3-staking' },
+        });
+        if (!row) return null;
+        return this.mapToPosition(row as unknown as UniswapV3StakingPositionRow);
+    }
+
+    async findByPositionHash(
+        userId: string,
+        positionHash: string,
+        tx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPosition | null> {
+        const db = tx ?? this.prisma;
+        const row = await db.position.findFirst({
+            where: { userId, positionHash, protocol: 'uniswapv3-staking' },
+        });
+        if (!row) return null;
+        return this.mapToPosition(row as unknown as UniswapV3StakingPositionRow);
+    }
+
+    async delete(id: string): Promise<void> {
+        const position = await this.findById(id);
+        if (!position) return;
+
+        const positionJSON = position.toJSON();
+
+        await this.prisma.$transaction(async (tx) => {
+            await tx.position.delete({ where: { id } });
+
+            await this.eventPublisher.createAndPublish<PositionLifecyclePayload>({
+                type: 'position.deleted',
+                entityType: 'position',
+                entityId: position.id,
+                userId: position.userId,
+                payload: {
+                    positionId: position.id,
+                    positionHash: positionJSON.positionHash,
+                },
+                source: 'api',
+            }, tx);
+        });
+
+        this.logger.info(
+            { positionId: id, vaultAddress: position.vaultAddress },
+            'Staking-vault position deleted',
+        );
+    }
+
+    // =========================================================================
+    // DISCOVER (single-position importer)
+    // =========================================================================
+
+    /**
+     * Discover and import a single staking-vault position. Mirrors the Vault
+     * `discover` semantics; `position.created` is emitted by the API route
+     * caller (PR4b), not here.
+     *
+     * Throws `INVALID_VAULT_CONTRACT` if the address isn't a valid staking
+     * vault on the given chain (the on-chain reads will fail).
+     */
+    async discover(
+        userId: string,
+        params: { chainId: number; vaultAddress: string; quoteTokenAddress?: string },
+        dbTx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPosition> {
+        const { chainId } = params;
+        const vaultAddress = normalizeAddress(params.vaultAddress);
+
+        // Existing position check (idempotent re-import = refresh)
+        const positionHash = UniswapV3StakingPosition.createHash(chainId, vaultAddress);
+        const existing = await this.findByPositionHash(userId, positionHash, dbTx);
+        if (existing) {
+            return this.refresh(existing.id, 'latest', dbTx);
+        }
+
+        const client = this._evmConfig.getPublicClient(chainId);
+
+        // Read all immutable vault config from chain in parallel.
+        let token0Addr: string,
+            token1Addr: string,
+            tokenId: bigint,
+            poolAddr: string,
+            tickLower: number,
+            tickUpper: number,
+            isToken0Quote: boolean,
+            ownerAddr: string,
+            positionManagerAddr: string;
+        try {
+            [token0Addr, token1Addr, tokenId, poolAddr, tickLower, tickUpper, isToken0Quote, ownerAddr, positionManagerAddr] =
+                await Promise.all([
+                    client.readContract({ address: vaultAddress as Address, abi: STAKING_VAULT_READ_ABI, functionName: 'token0', args: [] }),
+                    client.readContract({ address: vaultAddress as Address, abi: STAKING_VAULT_READ_ABI, functionName: 'token1', args: [] }),
+                    client.readContract({ address: vaultAddress as Address, abi: STAKING_VAULT_READ_ABI, functionName: 'tokenId', args: [] }),
+                    client.readContract({ address: vaultAddress as Address, abi: STAKING_VAULT_READ_ABI, functionName: 'pool', args: [] }),
+                    client.readContract({ address: vaultAddress as Address, abi: STAKING_VAULT_READ_ABI, functionName: 'tickLower', args: [] }),
+                    client.readContract({ address: vaultAddress as Address, abi: STAKING_VAULT_READ_ABI, functionName: 'tickUpper', args: [] }),
+                    client.readContract({ address: vaultAddress as Address, abi: STAKING_VAULT_READ_ABI, functionName: 'isToken0Quote', args: [] }),
+                    client.readContract({ address: vaultAddress as Address, abi: STAKING_VAULT_READ_ABI, functionName: 'owner', args: [] }),
+                    client.readContract({ address: vaultAddress as Address, abi: STAKING_VAULT_READ_ABI, functionName: 'positionManager', args: [] }),
+                ]) as [string, string, bigint, string, number, number, boolean, string, string];
+        } catch {
+            throw new Error(
+                `INVALID_VAULT_CONTRACT: ${vaultAddress} is not a valid staking-vault contract on chain ${chainId}`,
+            );
+        }
+
+        // Optional override: caller can force a different quote-token assignment.
+        // Note: SPEC §9.4 says the per-staking-position `switch-quote-token` endpoint
+        // is NOT supported (vault encodes `isToken0Quote` immutably on `stake()`),
+        // but we still let the discover caller pass an override for parity with
+        // the vault service's signature.
+        let resolvedIsToken0Quote = isToken0Quote;
+        if (params.quoteTokenAddress) {
+            resolvedIsToken0Quote =
+                normalizeAddress(params.quoteTokenAddress).toLowerCase() === normalizeAddress(token0Addr).toLowerCase();
+        }
+
+        // Discover tokens + pool concurrently
+        const [token0, token1, pool] = await Promise.all([
+            this._erc20TokenService.discover({ address: normalizeAddress(token0Addr), chainId }),
+            this._erc20TokenService.discover({ address: normalizeAddress(token1Addr), chainId }),
+            this._poolService.discover({ chainId, poolAddress: normalizeAddress(poolAddr) }),
+        ]);
+
+        // Read NFPM liquidity (and fee tier from positions tuple)
+        const positionData = await client.readContract({
+            address: positionManagerAddr as Address,
+            abi: UNISWAP_V3_POSITION_MANAGER_ABI,
+            functionName: 'positions',
+            args: [tokenId],
+        }) as readonly [bigint, string, string, string, number, number, number, bigint, bigint, bigint, bigint, bigint];
+        const fee = positionData[4];
+
+        // Look up factory address from SharedContract registry
+        const factoryRow = await this._sharedContractService.findLatestByChainAndName(
+            chainId,
+            SharedContractNameEnum.UNISWAP_V3_STAKING_VAULT_FACTORY,
+        );
+        const factoryAddress = (factoryRow?.config as { address?: string } | undefined)?.address ?? '';
+
+        // Compute price range bounds in quote-token units
+        const baseTokenAddr = resolvedIsToken0Quote ? token1.address : token0.address;
+        const quoteTokenAddr = resolvedIsToken0Quote ? token0.address : token1.address;
+        const baseDecimals = resolvedIsToken0Quote ? token1.decimals : token0.decimals;
+        const priceRangeLower = tickToPrice(tickLower, baseTokenAddr, quoteTokenAddr, baseDecimals);
+        const priceRangeUpper = tickToPrice(tickUpper, baseTokenAddr, quoteTokenAddr, baseDecimals);
+
+        // Pool state for initial state JSON
+        const poolStateOnDiscover = await this._poolService.fetchPoolState(
+            chainId,
+            normalizeAddress(poolAddr),
+        );
+
+        const configData: UniswapV3StakingPositionConfigData = {
+            chainId,
+            vaultAddress,
+            factoryAddress,
+            ownerAddress: normalizeAddress(ownerAddr),
+            underlyingTokenId: Number(tokenId),
+            isToken0Quote: resolvedIsToken0Quote,
+            poolAddress: normalizeAddress(poolAddr),
+            token0Address: token0.address,
+            token1Address: token1.address,
+            feeBps: fee,
+            tickSpacing: pool.typedConfig.tickSpacing,
+            tickLower,
+            tickUpper,
+            priceRangeLower,
+            priceRangeUpper,
+        };
+
+        // Initial state — `refresh()` will overwrite with fresh chain reads
+        const stateData: UniswapV3StakingPositionState = {
+            vaultState: 'Staked',
+            stakedBase: 0n,
+            stakedQuote: 0n,
+            yieldTarget: 0n,
+            pendingBps: 0,
+            unstakeBufferBase: 0n,
+            unstakeBufferQuote: 0n,
+            rewardBufferBase: 0n,
+            rewardBufferQuote: 0n,
+            liquidity: positionData[7],
+            isOwnedByUser: true,
+            unclaimedYieldBase: 0n,
+            unclaimedYieldQuote: 0n,
+            sqrtPriceX96: poolStateOnDiscover.sqrtPriceX96,
+            currentTick: poolStateOnDiscover.currentTick,
+            poolLiquidity: poolStateOnDiscover.liquidity,
+            feeGrowthGlobal0: poolStateOnDiscover.feeGrowthGlobal0,
+            feeGrowthGlobal1: poolStateOnDiscover.feeGrowthGlobal1,
+        };
+
+        // Vault deploy timestamp = block of the first `Stake` event
+        const stakeEvent = parseAbiItem(
+            'event Stake(address indexed owner, uint256 base, uint256 quote, uint256 yieldTarget, uint256 tokenId)',
+        );
+        const stakeLogs = await client.getLogs({
+            address: vaultAddress as Address,
+            event: stakeEvent,
+            args: { owner: normalizeAddress(ownerAddr) as Address },
+            fromBlock: 0n,
+            toBlock: 'latest',
+        });
+        const firstStakeBlock = stakeLogs[0]?.blockNumber;
+        const positionOpenedAt = firstStakeBlock
+            ? new Date(Number((await client.getBlock({ blockNumber: firstStakeBlock })).timestamp) * 1000)
+            : new Date();
+
+        const position = await this.createPosition(
+            userId, positionHash, configData, stateData, token0, token1, positionOpenedAt, dbTx,
+        );
+
+        // Refresh: imports ledger via syncFromChain (PR2 emits domain events),
+        // then refreshes on-chain state.
+        return this.refresh(position.id, 'latest', dbTx);
+    }
+
+    // =========================================================================
+    // DISCOVER WALLET POSITIONS (factory scan)
+    // =========================================================================
+
+    /**
+     * Scan the factory's `VaultCreated(owner, vault)` events for vaults owned
+     * by `walletAddress` across the supported chains. Per PR4 plan refinement
+     * #2 the wallet-scan logic also lives in the top-level
+     * `POST /positions/discover` route, which calls this method alongside the
+     * NFT/Vault equivalents.
+     *
+     * Per refinement #5, `fromBlock: 0n` is used for the `getLogs` scan
+     * (matches the vault service convention). The factory was just deployed
+     * on Arbitrum so the scan range is small in practice; if RPC limits ever
+     * become a concern, add a `deployBlock` field to `SharedContract.config`
+     * and use it here.
+     */
+    async discoverWalletPositions(
+        userId: string,
+        walletAddress: string,
+        chainIds?: number[],
+    ): Promise<{ found: number; imported: number; skipped: number; errors: number }> {
+        const supportedChains = chainIds ?? this._evmConfig.getSupportedChainIds();
+        const ownerAddress = normalizeAddress(walletAddress);
+        let found = 0;
+        let imported = 0;
+        let skipped = 0;
+        let errors = 0;
+
+        for (const chainId of supportedChains) {
+            const factory = await this._sharedContractService.findLatestByChainAndName(
+                chainId,
+                SharedContractNameEnum.UNISWAP_V3_STAKING_VAULT_FACTORY,
+            );
+            // Refinement: gracefully skip chains with no factory registered.
+            if (!factory) continue;
+
+            const factoryAddress = (factory.config as { address: string }).address;
+            const client = this._evmConfig.getPublicClient(chainId);
+
+            // VaultCreated(address indexed owner, address indexed vault) — filter by owner
+            const vaultCreatedEvent = parseAbiItem(
+                'event VaultCreated(address indexed owner, address indexed vault)',
+            );
+            const logs = await client.getLogs({
+                address: factoryAddress as Address,
+                event: vaultCreatedEvent,
+                args: { owner: ownerAddress as Address },
+                fromBlock: 0n,
+                toBlock: 'latest',
+            });
+
+            const vaultAddresses = new Set<string>();
+            for (const l of logs) {
+                const vault = l.args.vault as Address | undefined;
+                if (vault) vaultAddresses.add(normalizeAddress(vault));
+            }
+
+            found += vaultAddresses.size;
+
+            for (const vaultAddr of vaultAddresses) {
+                const positionHash = UniswapV3StakingPosition.createHash(chainId, vaultAddr);
+                const existing = await this.findByPositionHash(userId, positionHash);
+                if (existing) {
+                    skipped++;
+                    continue;
+                }
+
+                try {
+                    await this.discover(userId, { chainId, vaultAddress: vaultAddr });
+                    imported++;
+                } catch (e) {
+                    this.logger.warn(
+                        { chainId, vaultAddress: vaultAddr, error: e },
+                        'Failed to discover staking-vault position',
+                    );
+                    errors++;
+                }
+            }
+        }
+
+        return { found, imported, skipped, errors };
+    }
+
+    // =========================================================================
+    // REFRESH
+    // =========================================================================
+
+    /**
+     * Pull latest on-chain state and re-sync the ledger.
+     *
+     * **No 15-second cache** (per PR4 plan refinement #1). UI calls `refresh`
+     * after user txs (stake/topUp/unstake/claim/flashClose) and must see the
+     * new state immediately; stale-row caching causes silent UI bugs. The
+     * block-keyed 60s RPC cache inside `refreshOnChainState` stays — it's
+     * keyed by block number so it can't serve stale data for the same block.
+     */
+    async refresh(
+        id: string,
+        blockNumber: number | 'latest' = 'latest',
+        dbTx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPosition> {
+        await this.refreshAllPositionLogs(id, blockNumber, dbTx);
+        return this.refreshOnChainState(id, blockNumber, dbTx);
+    }
+
+    // =========================================================================
+    // RESET
+    // =========================================================================
+
+    /**
+     * Wipe the ledger and reimport from chain. Used when ledger drift is
+     * detected or when manually rebuilding a position's history.
+     *
+     * **Does NOT emit `position.liquidity.reverted` events** (per PR4 plan
+     * refinement #3). Justification:
+     * - `PositionLedgerEvent` deletion cascades through FK to
+     *   `TokenLot` / `TokenLotDisposal` / `JournalEntry`.
+     * - PR3's rule's `handleLiquidityReverted` is a logging no-op (FK cascade
+     *   is the documented cleanup path).
+     * - The immediate `syncFromChain` call below re-emits all
+     *   `position.liquidity.{increased,decreased}` events, which PR3's rule
+     *   consumes to rebuild lots and journal entries from scratch.
+     * - The intermediate revert events would be pure noise.
+     *
+     * Reorg paths in `syncFromChain` (PR2) keep emitting revert events
+     * because there's no immediate re-import there.
+     */
+    async reset(
+        id: string,
+        dbTx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPosition> {
+        const position = await this.findById(id, dbTx);
+        if (!position) throw new Error(`Staking-vault position not found: ${id}`);
+
+        const ledgerService = new UniswapV3StakingLedgerService(
+            { positionId: id },
+            { prisma: this.prisma },
+        );
+
+        // Wipe ledger; FK cascade handles dependent rows.
+        await ledgerService.deleteAll(dbTx);
+
+        // Reimport — emits `position.liquidity.{increased,decreased}` for PR3 to rebuild.
+        await this.refreshAllPositionLogs(id, 'latest', dbTx);
+        return this.refreshOnChainState(id, 'latest', dbTx);
+    }
+
+    // =========================================================================
+    // FETCH METRICS (non-persisted)
+    // =========================================================================
+
+    async fetchMetrics(
+        id: string,
+        blockNumber: number | 'latest' = 'latest',
+        tx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPositionMetrics> {
+        const position = await this.findById(id, tx);
+        if (!position) throw new Error(`Staking-vault position not found: ${id}`);
+
+        const onChain = await this.fetchOnChainState(position, blockNumber);
+        const ledgerService = new UniswapV3StakingLedgerService(
+            { positionId: id },
+            { prisma: this.prisma },
+        );
+        const aggregates = await ledgerService.recalculateAggregates(
+            position.isToken0Quote,
+            tx,
+        );
+
+        const currentValue = calculatePositionValue(
+            onChain.liquidity,
+            onChain.sqrtPriceX96,
+            position.typedConfig.tickLower,
+            position.typedConfig.tickUpper,
+            !position.isToken0Quote,
+        );
+
+        // PR4a limitation: unclaimed-yield split is not exposed by IStakingVault.
+        // We approximate as 0 here; refresh-time computation can use the
+        // currently-accrued NFPM tokensOwed minus principal floor in a follow-up
+        // once the contract exposes a public `quoteCloseAt(uint16 bps)` view.
+        const unclaimedYield = calculateTokenValueInQuote(
+            0n, 0n,
+            onChain.sqrtPriceX96,
+            position.isToken0Quote,
+            position.token0.decimals,
+            position.token1.decimals,
+        );
+
+        const unrealizedPnl = currentValue - aggregates.costBasisAfter;
+
+        // Last yield-claimed = timestamp of the most recent STAKING_DISPOSE event
+        const db = tx ?? this.prisma;
+        const lastDispose = await db.positionLedgerEvent.findFirst({
+            where: { positionId: id, eventType: 'STAKING_DISPOSE' },
+            orderBy: { timestamp: 'desc' },
+            select: { timestamp: true },
+        });
+        const lastYieldClaimedAt = lastDispose?.timestamp ?? position.positionOpenedAt;
+
+        return {
+            currentValue,
+            costBasis: aggregates.costBasisAfter,
+            realizedPnl: aggregates.realizedPnlAfter,
+            unrealizedPnl,
+            collectedYield: aggregates.collectedYieldAfter,
+            unclaimedYield,
+            lastYieldClaimedAt,
+            yieldTarget: onChain.yieldTarget,
+            pendingBps: onChain.pendingBps,
+            vaultState: onChain.vaultState,
+            priceRangeLower: position.priceRangeLower,
+            priceRangeUpper: position.priceRangeUpper,
+            isOwnedByUser: position.typedState.isOwnedByUser ?? true,
+        };
+    }
+
+    // =========================================================================
+    // PRIVATE: REFRESH LEDGER EVENTS (thin wrapper around syncFromChain)
+    // =========================================================================
+
+    private async refreshAllPositionLogs(
+        id: string,
+        blockNumber: number | 'latest' = 'latest',
+        dbTx?: PrismaTransactionClient,
+    ): Promise<void> {
+        const position = await this.findById(id, dbTx);
+        if (!position) throw new Error(`Staking-vault position not found: ${id}`);
+
+        const ledgerService = new UniswapV3StakingLedgerService(
+            { positionId: id },
+            { prisma: this.prisma },
+        );
+
+        // PR2's syncFromChain handles: block-range resolution, log fetching,
+        // chain-context population, ledger import, AND domain event publishing.
+        // The position service is a thin orchestration layer here.
+        await ledgerService.syncFromChain(
+            position,
+            this._evmConfig,
+            this._poolPriceService,
+            {
+                toBlock: blockNumber,
+                factoryAddress: position.typedConfig.factoryAddress,
+            },
+            dbTx,
+        );
+    }
+
+    // =========================================================================
+    // PRIVATE: REFRESH ON-CHAIN STATE
+    // =========================================================================
+
+    private async refreshOnChainState(
+        id: string,
+        blockNumber: number | 'latest' = 'latest',
+        dbTx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPosition> {
+        const position = await this.findById(id, dbTx);
+        if (!position) throw new Error(`Staking-vault position not found: ${id}`);
+
+        const onChain = await this.fetchOnChainState(position, blockNumber);
+
+        // ownership detection — keeps current value if the user no longer owns
+        // the wallet that owns the vault. The wallet-perimeter service can flip
+        // this in a separate pass.
+        const isOwnedByUser = position.typedState.isOwnedByUser ?? true;
+
+        const newState: UniswapV3StakingPositionState = {
+            vaultState: onChain.vaultState,
+            stakedBase: onChain.stakedBase,
+            stakedQuote: onChain.stakedQuote,
+            yieldTarget: onChain.yieldTarget,
+            pendingBps: onChain.pendingBps,
+            unstakeBufferBase: onChain.unstakeBufferBase,
+            unstakeBufferQuote: onChain.unstakeBufferQuote,
+            rewardBufferBase: onChain.rewardBufferBase,
+            rewardBufferQuote: onChain.rewardBufferQuote,
+            liquidity: onChain.liquidity,
+            isOwnedByUser,
+            // PR4a limitation: see fetchMetrics comment.
+            unclaimedYieldBase: 0n,
+            unclaimedYieldQuote: 0n,
+            sqrtPriceX96: onChain.sqrtPriceX96,
+            currentTick: onChain.currentTick,
+            poolLiquidity: onChain.poolLiquidity,
+            feeGrowthGlobal0: onChain.feeGrowthGlobal0,
+            feeGrowthGlobal1: onChain.feeGrowthGlobal1,
+        };
+
+        const currentValue = calculatePositionValue(
+            onChain.liquidity,
+            onChain.sqrtPriceX96,
+            position.typedConfig.tickLower,
+            position.typedConfig.tickUpper,
+            !position.isToken0Quote,
+        );
+
+        const unclaimedYield = 0n; // see comment above
+
+        const ledgerService = new UniswapV3StakingLedgerService(
+            { positionId: id },
+            { prisma: this.prisma },
+        );
+        const aggregates = await ledgerService.recalculateAggregates(
+            position.isToken0Quote,
+            dbTx,
+        );
+
+        const unrealizedPnl = currentValue - aggregates.costBasisAfter;
+
+        // Backfill positionOpenedAt from first ledger event if it differs
+        const db = dbTx ?? this.prisma;
+        const firstEvent = await db.positionLedgerEvent.findFirst({
+            where: { positionId: id },
+            orderBy: { timestamp: 'asc' },
+            select: { timestamp: true },
+        });
+        const correctedOpenedAt = firstEvent?.timestamp ?? position.positionOpenedAt;
+
+        const isClosedTransition =
+            onChain.vaultState === 'Settled' && position.typedState.vaultState !== 'Settled';
+
+        await db.position.update({
+            where: { id },
+            data: {
+                state: stakingPositionStateToJSON(newState) as object,
+                currentValue: currentValue.toString(),
+                costBasis: aggregates.costBasisAfter.toString(),
+                realizedPnl: aggregates.realizedPnlAfter.toString(),
+                unrealizedPnl: unrealizedPnl.toString(),
+                collectedYield: aggregates.collectedYieldAfter.toString(),
+                unclaimedYield: unclaimedYield.toString(),
+                positionOpenedAt: correctedOpenedAt,
+            },
+        });
+
+        if (isClosedTransition) {
+            await this.eventPublisher.createAndPublish<PositionLifecyclePayload>({
+                type: 'position.closed',
+                entityType: 'position',
+                entityId: position.id,
+                userId: position.userId,
+                payload: {
+                    positionId: position.id,
+                    positionHash: position.positionHash,
+                },
+                source: 'ledger-sync',
+            }, dbTx);
+        }
+
+        return (await this.findById(id, dbTx))!;
+    }
+
+    // =========================================================================
+    // PRIVATE: ON-CHAIN STATE FETCH (block-keyed 60s cache)
+    // =========================================================================
+
+    /**
+     * Fetch on-chain staking-vault state with block-number-keyed caching.
+     * Cache key: `staking-onchain:v1:{chainId}:{vault}:{blockNumber}`
+     * TTL: 60 seconds (same-block data is immutable; TTL is just for eviction).
+     *
+     * Per PR4 plan refinement #1, `refresh()` does NOT short-circuit based on
+     * `position.updatedAt` — it always passes through here, where the cache
+     * is keyed by block. A fresh `refresh` always resolves a new block
+     * number when the chain progresses, so the cache can't return stale data.
+     */
+    private async fetchOnChainState(
+        position: UniswapV3StakingPosition,
+        blockNumber: number | 'latest' = 'latest',
+    ): Promise<OnChainStakingState> {
+        const chainId = position.chainId;
+        const vaultAddress = position.vaultAddress;
+        const tokenId = BigInt(position.underlyingTokenId);
+
+        const resolvedBlockNumber = blockNumber === 'latest'
+            ? await this._evmBlockService.getCurrentBlockNumber(chainId)
+            : BigInt(blockNumber);
+
+        const cacheKey = `staking-onchain:v1:${chainId}:${vaultAddress}:${resolvedBlockNumber}`;
+        const cached = await this._cacheService.get<OnChainStakingStateCached>(cacheKey);
+        if (cached) {
+            this.logger.debug(
+                { chainId, vaultAddress, blockNumber: resolvedBlockNumber.toString(), cacheHit: true },
+                'Staking-vault on-chain state cache hit',
+            );
+            return deserialize(cached);
+        }
+
+        const client = this._evmConfig.getPublicClient(chainId);
+
+        // Read all dynamic vault state in parallel.
+        const readVault = (fn: 'state' | 'stakedBase' | 'stakedQuote' | 'yieldTarget'
+            | 'partialUnstakeBps' | 'unstakeBufferBase' | 'unstakeBufferQuote'
+            | 'rewardBufferBase' | 'rewardBufferQuote' | 'positionManager' | 'owner') =>
+            client.readContract({
+                address: vaultAddress as Address,
+                abi: STAKING_VAULT_READ_ABI,
+                functionName: fn,
+                args: [],
+                blockNumber: resolvedBlockNumber,
+            });
+
+        const [
+            stateIdx, stakedBase, stakedQuote, yieldTarget, partialBps,
+            unstakeBase, unstakeQuote, rewardBase, rewardQuote,
+            positionManagerAddr, ownerAddr, poolState,
+        ] = await Promise.all([
+            readVault('state'),
+            readVault('stakedBase'),
+            readVault('stakedQuote'),
+            readVault('yieldTarget'),
+            readVault('partialUnstakeBps'),
+            readVault('unstakeBufferBase'),
+            readVault('unstakeBufferQuote'),
+            readVault('rewardBufferBase'),
+            readVault('rewardBufferQuote'),
+            readVault('positionManager'),
+            readVault('owner'),
+            this._poolService.fetchPoolState(chainId, position.typedConfig.poolAddress, Number(resolvedBlockNumber)),
+        ]) as [
+            number, bigint, bigint, bigint, number,
+            bigint, bigint, bigint, bigint,
+            string, string,
+            Awaited<ReturnType<UniswapV3PoolService['fetchPoolState']>>,
+        ];
+
+        // Read NFPM liquidity at the same block
+        const nfpmData = await client.readContract({
+            address: positionManagerAddr as Address,
+            abi: UNISWAP_V3_POSITION_MANAGER_ABI,
+            functionName: 'positions',
+            args: [tokenId],
+            blockNumber: resolvedBlockNumber,
+        }) as readonly unknown[];
+
+        const state: OnChainStakingState = {
+            blockNumber: resolvedBlockNumber,
+            vaultState: stakingStateFromIndex(Number(stateIdx)),
+            stakedBase, stakedQuote, yieldTarget,
+            pendingBps: Number(partialBps),
+            unstakeBufferBase: unstakeBase,
+            unstakeBufferQuote: unstakeQuote,
+            rewardBufferBase: rewardBase,
+            rewardBufferQuote: rewardQuote,
+            liquidity: nfpmData[7] as bigint,
+            sqrtPriceX96: poolState.sqrtPriceX96,
+            currentTick: poolState.currentTick,
+            poolLiquidity: poolState.liquidity,
+            feeGrowthGlobal0: poolState.feeGrowthGlobal0,
+            feeGrowthGlobal1: poolState.feeGrowthGlobal1,
+            ownerAddress: normalizeAddress(ownerAddr),
+        };
+
+        await this._cacheService.set(cacheKey, serialize(state), 60);
+
+        this.logger.debug(
+            { chainId, vaultAddress, blockNumber: resolvedBlockNumber.toString(), cacheHit: false },
+            'Staking-vault on-chain state fetched and cached',
+        );
+
+        return state;
+    }
+
+    // =========================================================================
+    // PRIVATE: CREATE POSITION (DB row)
+    // =========================================================================
+
+    private async createPosition(
+        userId: string,
+        positionHash: string,
+        configData: UniswapV3StakingPositionConfigData,
+        stateData: UniswapV3StakingPositionState,
+        token0: TokenInterface,
+        token1: TokenInterface,
+        positionOpenedAt: Date,
+        dbTx?: PrismaTransactionClient,
+    ): Promise<UniswapV3StakingPosition> {
+        const db = dbTx ?? this.prisma;
+        const config = new UniswapV3StakingPositionConfig(configData);
+
+        const row = await db.position.create({
+            data: {
+                userId,
+                protocol: 'uniswapv3-staking',
+                type: 'LP_CONCENTRATED',
+                positionHash,
+                ownerWallet: createEvmOwnerWallet(configData.ownerAddress),
+                config: config.toJSON() as object,
+                state: stakingPositionStateToJSON(stateData) as object,
+                currentValue: '0',
+                costBasis: '0',
+                realizedPnl: '0',
+                unrealizedPnl: '0',
+                realizedCashflow: '0',
+                unrealizedCashflow: '0',
+                collectedYield: '0',
+                unclaimedYield: '0',
+                positionOpenedAt,
+                isArchived: false,
+            },
+        });
+
+        return UniswapV3StakingPosition.fromDB(
+            row as unknown as UniswapV3StakingPositionRow,
+            token0,
+            token1,
+        );
+    }
+
+    // =========================================================================
+    // PRIVATE: MAP DB ROW → DOMAIN OBJECT
+    // =========================================================================
+
+    private async mapToPosition(
+        row: UniswapV3StakingPositionRow,
+    ): Promise<UniswapV3StakingPosition> {
+        const configJSON = row.config as unknown as UniswapV3StakingPositionConfigJSON;
+
+        const [token0Row, token1Row] = await Promise.all([
+            this.prisma.token.findUnique({
+                where: { tokenHash: createErc20TokenHash(configJSON.chainId, configJSON.token0Address!) },
+            }),
+            this.prisma.token.findUnique({
+                where: { tokenHash: createErc20TokenHash(configJSON.chainId, configJSON.token1Address!) },
+            }),
+        ]);
+
+        if (!token0Row || !token1Row) {
+            throw new Error(
+                `Tokens not found for staking-vault position ${row.id}: token0=${configJSON.token0Address}, token1=${configJSON.token1Address}`,
+            );
+        }
+
+        const token0 = Erc20Token.fromDB(token0Row as any) as TokenInterface;
+        const token1 = Erc20Token.fromDB(token1Row as any) as TokenInterface;
+
+        return UniswapV3StakingPosition.fromDB(row, token0, token1);
+    }
+}

--- a/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.ts
+++ b/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.ts
@@ -309,10 +309,18 @@ export class UniswapV3StakingPositionService {
      *
      * Throws `INVALID_VAULT_CONTRACT` if the address isn't a valid staking
      * vault on the given chain (the on-chain reads will fail).
+     *
+     * Note: there is no `quoteTokenAddress` override. `isToken0Quote` is
+     * on-chain immutable for staking vaults (encoded at `stake()`), and
+     * PR1's ledger service uses it as ground truth in every disposal
+     * calculation. A caller-supplied override that disagrees with
+     * `vault.isToken0Quote()` would silently corrupt all subsequent PnL
+     * math. This is the staking-specific divergence from
+     * `UniswapV3VaultPositionService.discover`.
      */
     async discover(
         userId: string,
-        params: { chainId: number; vaultAddress: string; quoteTokenAddress?: string },
+        params: { chainId: number; vaultAddress: string },
         dbTx?: PrismaTransactionClient,
     ): Promise<UniswapV3StakingPosition> {
         const { chainId } = params;
@@ -356,17 +364,6 @@ export class UniswapV3StakingPositionService {
             );
         }
 
-        // Optional override: caller can force a different quote-token assignment.
-        // Note: SPEC §9.4 says the per-staking-position `switch-quote-token` endpoint
-        // is NOT supported (vault encodes `isToken0Quote` immutably on `stake()`),
-        // but we still let the discover caller pass an override for parity with
-        // the vault service's signature.
-        let resolvedIsToken0Quote = isToken0Quote;
-        if (params.quoteTokenAddress) {
-            resolvedIsToken0Quote =
-                normalizeAddress(params.quoteTokenAddress).toLowerCase() === normalizeAddress(token0Addr).toLowerCase();
-        }
-
         // Discover tokens + pool concurrently
         const [token0, token1, pool] = await Promise.all([
             this._erc20TokenService.discover({ address: normalizeAddress(token0Addr), chainId }),
@@ -391,9 +388,9 @@ export class UniswapV3StakingPositionService {
         const factoryAddress = (factoryRow?.config as { address?: string } | undefined)?.address ?? '';
 
         // Compute price range bounds in quote-token units
-        const baseTokenAddr = resolvedIsToken0Quote ? token1.address : token0.address;
-        const quoteTokenAddr = resolvedIsToken0Quote ? token0.address : token1.address;
-        const baseDecimals = resolvedIsToken0Quote ? token1.decimals : token0.decimals;
+        const baseTokenAddr = isToken0Quote ? token1.address : token0.address;
+        const quoteTokenAddr = isToken0Quote ? token0.address : token1.address;
+        const baseDecimals = isToken0Quote ? token1.decimals : token0.decimals;
         const priceRangeLower = tickToPrice(tickLower, baseTokenAddr, quoteTokenAddr, baseDecimals);
         const priceRangeUpper = tickToPrice(tickUpper, baseTokenAddr, quoteTokenAddr, baseDecimals);
 
@@ -409,7 +406,7 @@ export class UniswapV3StakingPositionService {
             factoryAddress,
             ownerAddress: normalizeAddress(ownerAddr),
             underlyingTokenId: Number(tokenId),
-            isToken0Quote: resolvedIsToken0Quote,
+            isToken0Quote: isToken0Quote,
             poolAddress: normalizeAddress(poolAddr),
             token0Address: token0.address,
             token1Address: token1.address,

--- a/packages/midcurve-shared/src/types/index.ts
+++ b/packages/midcurve-shared/src/types/index.ts
@@ -152,6 +152,7 @@ export type {
   UniswapV3StakingPositionConfigJSON,
   UniswapV3StakingPositionState,
   UniswapV3StakingPositionStateJSON,
+  UniswapV3StakingPositionMetrics,
   StakingState,
 } from './position/index.js';
 

--- a/packages/midcurve-shared/src/types/position/index.ts
+++ b/packages/midcurve-shared/src/types/position/index.ts
@@ -71,6 +71,7 @@ export {
   type UniswapV3StakingPositionConfigJSON,
   type UniswapV3StakingPositionState,
   type UniswapV3StakingPositionStateJSON,
+  type UniswapV3StakingPositionMetrics,
   type StakingState,
   stakingPositionStateToJSON,
   stakingPositionStateFromJSON,

--- a/packages/midcurve-shared/src/types/position/uniswapv3-staking/index.ts
+++ b/packages/midcurve-shared/src/types/position/uniswapv3-staking/index.ts
@@ -21,3 +21,5 @@ export {
   stakingPositionStateToJSON,
   stakingPositionStateFromJSON,
 } from './uniswapv3-staking-position-state.js';
+
+export { type UniswapV3StakingPositionMetrics } from './uniswapv3-staking-position-metrics.js';

--- a/packages/midcurve-shared/src/types/position/uniswapv3-staking/uniswapv3-staking-position-metrics.ts
+++ b/packages/midcurve-shared/src/types/position/uniswapv3-staking/uniswapv3-staking-position-metrics.ts
@@ -1,0 +1,122 @@
+/**
+ * UniswapV3 Staking Position Metrics
+ *
+ * Calculated metrics for a UniswapV3StakingVault position without database
+ * persistence. Returned by `fetchMetrics()` for read-only inspection
+ * (used by GET endpoint serializers in PR4b).
+ *
+ * Mirrors `UniswapV3VaultPositionMetrics` but with staking-specific fields
+ * (`vaultState`, `yieldTarget`, `pendingBps`).
+ */
+
+/**
+ * UniswapV3StakingPositionMetrics
+ *
+ * Contains calculated position metrics in quote-token terms. All monetary
+ * values are in quote-token units (bigint for precision).
+ *
+ * @example
+ * ```typescript
+ * const metrics = await positionService.fetchMetrics(positionId);
+ * console.log(`Position value: ${metrics.currentValue}`);
+ * console.log(`Vault state: ${metrics.vaultState}`);
+ * console.log(`Yield target: ${metrics.yieldTarget}`);
+ * ```
+ */
+export interface UniswapV3StakingPositionMetrics {
+  // ============================================================================
+  // Value & PnL
+  // ============================================================================
+
+  /**
+   * Current position value in quote-token units.
+   * Calculated from liquidity and current pool price.
+   */
+  currentValue: bigint;
+
+  /**
+   * Cost basis in quote-token units.
+   * Accumulated from STAKING_DEPOSIT ledger events (PR1).
+   */
+  costBasis: bigint;
+
+  /**
+   * Realized PnL in quote-token units.
+   * Model A: principal-vs-cost-basis only. Yield is excluded — see `collectedYield`.
+   */
+  realizedPnl: bigint;
+
+  /**
+   * Unrealized PnL in quote-token units.
+   * Calculated as `currentValue − costBasis`.
+   */
+  unrealizedPnl: bigint;
+
+  // ============================================================================
+  // Yield Metrics (Model A: yield is fee income, not PnL)
+  // ============================================================================
+
+  /**
+   * Total collected yield in quote-token units.
+   * Accumulated from STAKING_DISPOSE ledger events' `yieldQuoteValue` (PR1).
+   */
+  collectedYield: bigint;
+
+  /**
+   * Unclaimed yield in quote-token units.
+   * Computed from `unclaimedYieldBase × P + unclaimedYieldQuote` at the
+   * current pool price.
+   */
+  unclaimedYield: bigint;
+
+  /**
+   * Timestamp of the last STAKING_DISPOSE event.
+   * Falls back to `positionOpenedAt` if no disposals yet.
+   */
+  lastYieldClaimedAt: Date;
+
+  // ============================================================================
+  // Stake Terms
+  // ============================================================================
+
+  /**
+   * Quote-side reward floor specified at stake time (immutable until top-up).
+   * The vault settles only when accumulated yield meets or exceeds this target.
+   */
+  yieldTarget: bigint;
+
+  /**
+   * Pending partial-unstake bps (0..10000).
+   * The bps fraction of the position that will unstake on the next executor swap.
+   */
+  pendingBps: number;
+
+  /**
+   * On-chain vault state.
+   * - `Empty`: pre-stake / post-settlement
+   * - `Staked`: actively staked, accumulating yield
+   * - `FlashCloseInProgress`: mid-flashClose flight (transient, only visible mid-tx)
+   * - `Settled`: fully closed
+   */
+  vaultState: 'Empty' | 'Staked' | 'FlashCloseInProgress' | 'Settled';
+
+  // ============================================================================
+  // Price Range
+  // ============================================================================
+
+  /** Lower bound of the position range in quote-token price. */
+  priceRangeLower: bigint;
+
+  /** Upper bound of the position range in quote-token price. */
+  priceRangeUpper: bigint;
+
+  // ============================================================================
+  // Ownership
+  // ============================================================================
+
+  /**
+   * Whether the underlying vault clone is currently owned by the user.
+   * Determined by checking `vault.owner()` against the user's registered wallets.
+   */
+  isOwnedByUser: boolean;
+}


### PR DESCRIPTION
## Summary

PR4a of 5 for SPEC-0003b. Adds the service layer for `UniswapV3StakingVault` positions; mirrors `UniswapV3VaultPositionService` (closer-in-spirit canonical) and reuses PR2's `syncFromChain` for chain ingestion + domain-event publishing.

PR4b (REST endpoints + serializers + cross-protocol wire-up) will land separately.

## Refinements applied (per maintainer feedback on the PR4 plan)

1. **No 15-second `refresh()` cache.** `refresh()` always does a fresh chain pull. The 60s block-keyed RPC cache stays inside `refreshOnChainState` — it's keyed by block number so it can't serve stale data for the same block.
2. **`reset` drops revert event emission.** FK cascade is the documented cleanup path; PR3's rule's revert handler is a no-op; the immediate `syncFromChain` call re-emits liquidity events that rebuild lots and journal entries from scratch. Inline code comment justifies the divergence from NFT/Vault.
3. **`reset` test boundary assertion** added — verifies the publisher call set after `reset` matches the original import (ledger service called exactly once for rebuild + zero revert events).
4. **`discoverWalletPositions` `fromBlock`** uses `0n` (matches the Vault precedent + PR2's `findVaultBirthBlock` pattern). Per-chain deploy block can be added to `SharedContract.config` in a follow-up if RPC limits become a concern.

## What changed

### `packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.ts` (new, ~870 LoC)

Constructor DI: optional `prisma`, `eventPublisher`, `evmConfig`, `poolService`, `evmBlockService`, `poolPriceService`, `cacheService`, `sharedContractService`, `erc20TokenService`. Singletons for config/publisher; new instances for sub-services. `UniswapV3StakingLedgerService` is instantiated per-call (matches existing pattern).

Public surface:
- `discover(userId, { chainId, vaultAddress, quoteTokenAddress? })` — single-position importer. Owner derived from `vault.owner()` on chain. Throws `INVALID_VAULT_CONTRACT` on chain-read failure. Calls `syncFromChain` via `refresh()` to import history + emit domain events.
- `discoverWalletPositions(userId, walletAddress, chainIds?)` — factory scan. `VaultCreated(owner=walletAddress)` filter, `fromBlock: 0n`. Chains with no registered factory → `{ found: 0 }` gracefully.
- `refresh(id, blockNumber? = 'latest')` — always fresh chain pull. **No `updatedAt` short-circuit.**
- `reset(id)` — wipes ledger via `ledgerService.deleteAll()` then reimports via `syncFromChain`. No revert events emitted.
- `refreshOnChainState` — block-keyed 60s RPC cache. `Staked → Settled` transition emits `position.closed`.
- `delete(id)` — emits `position.deleted` in a transaction.
- `fetchMetrics(id)` — non-persisted snapshot returning `UniswapV3StakingPositionMetrics`.
- `findById`, `findByPositionHash` — standard CRUD.

### `packages/midcurve-shared/src/types/position/uniswapv3-staking/uniswapv3-staking-position-metrics.ts` (new)

`UniswapV3StakingPositionMetrics` — parallel to `UniswapV3VaultPositionMetrics` with staking-specific fields (`vaultState`, `yieldTarget`, `pendingBps`).

## PR4a limitation

`unclaimedYieldBase/Quote` in state is set to `0n`. The contract's `_expectedBalancesAfterPartialClose(uint16)` is internal, so we cannot compute the live yield split without a public view. A SPEC-0003a follow-up can expose `quoteCloseAt(uint16)` or similar; until then, `0n` is a safe default and the rest of the state stays accurate.

## Tests (14)

- `discover` happy path → creates Position row, calls `syncFromChain`, returns position. **Asserts `position.created` is NOT emitted from the service** (matches NFT/Vault convention — emitted by the API route in PR4b).
- `discover` chain reads fail → throws `INVALID_VAULT_CONTRACT`.
- `discoverWalletPositions` chain with no factory → `{ found: 0 }` gracefully.
- `discoverWalletPositions` `getLogs` filtered by `owner=walletAddress` with `fromBlock: 0n`.
- `discoverWalletPositions` matching `VaultCreated` log triggers `discover()`.
- `refresh` always calls `syncFromChain` + `refreshOnChainState` (no `updatedAt` short-circuit) — refinement #1.
- `refreshOnChainState` `Staked → Settled` emits `position.closed` once.
- `refreshOnChainState` no transition → no close event.
- `refreshOnChainState` block-keyed cache hit → no extra readContract calls.
- `reset` wipes ledger, **does NOT emit `position.liquidity.reverted`** — refinement #3.
- `reset` re-publishes the same liquidity events as the original import (boundary assertion at the ledger-service / publisher).
- `delete` emits `position.deleted` in a transaction.
- `fetchMetrics` returns vault-specific snapshot.
- `findByPositionHash` uses positionHash + protocol filter.

Mocks: `vi.hoisted` prismaMock, module mocks for `@midcurve/database`, `../../events`, and the staking ledger service. No live RPC, no live RabbitMQ, no live DB.

## Out of scope (deferred to PR4b)

- REST endpoints under `/positions/uniswapv3-staking/...`
- Wire types + serializer in `@midcurve/api-shared`
- Service factory in `apps/midcurve-api/src/lib/services.ts`
- Cross-protocol updates: extend top-level `/positions/discover` for wallet scan, extend `/positions/refresh-all` for staking dispatch
- List-view smoke test for `state.yieldTarget` / `state.vaultState` pass-through

Refs #63

## Test plan
- [x] `pnpm typecheck` — all 14 packages pass
- [x] `pnpm --filter @midcurve/services test:run` — 178 tests pass (14 new staking position service tests)
- [x] `pnpm --filter @midcurve/business-logic test:run` — 12 tests pass (no regressions)
- [x] `pnpm --filter @midcurve/shared test:run` — 127 tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)