### PR TITLE
fix(#63): SPEC-0003b PR4b — staking-vault REST surface + APR service

### DIFF
--- a/apps/midcurve-api/src/app/api/v1/positions/discover/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/discover/route.ts
@@ -25,7 +25,10 @@ import {
   getDomainEventPublisher,
   type PositionLifecyclePayload,
 } from '@midcurve/services';
-import { getUniswapV3PositionService } from '@/lib/services';
+import {
+  getUniswapV3PositionService,
+  getUniswapV3StakingPositionService,
+} from '@/lib/services';
 import { createPreflightResponse } from '@/lib/cors';
 import { apiLogger, apiLog } from '@/lib/logger';
 import type { Address } from 'viem';
@@ -76,18 +79,29 @@ export async function POST(request: NextRequest): Promise<Response> {
       }
 
       const { chainIds, walletAddress } = validation.data;
+      const targetAddress = (walletAddress ?? user.address) as Address;
 
-      // 2. Run wallet position discovery
-      const result =
-        await getUniswapV3PositionService().discoverWalletPositions(
+      // 2. Run NFT + staking-vault wallet scans in parallel.
+      const [nftResult, stakingResult] = await Promise.all([
+        getUniswapV3PositionService().discoverWalletPositions(
           user.id,
-          (walletAddress ?? user.address) as Address,
+          targetAddress,
           chainIds,
-        );
+        ),
+        getUniswapV3StakingPositionService().discoverWalletPositions(
+          user.id,
+          targetAddress,
+          chainIds,
+        ),
+      ]);
 
       // 3. Publish position.created domain events for downstream processing
       const eventPublisher = getDomainEventPublisher();
-      for (const position of result.positions) {
+      const allNewPositions = [
+        ...nftResult.positions,
+        ...stakingResult.positions,
+      ];
+      for (const position of allNewPositions) {
         await eventPublisher.createAndPublish<PositionLifecyclePayload>({
           type: 'position.created',
           entityType: 'position',
@@ -101,12 +115,12 @@ export async function POST(request: NextRequest): Promise<Response> {
         });
       }
 
-      // 4. Return stats
+      // 4. Return aggregated stats across NFT + staking
       const responseData: DiscoverPositionsData = {
-        found: result.found,
-        imported: result.imported,
-        skipped: result.skipped,
-        errors: result.errors,
+        found: nftResult.found + stakingResult.found,
+        imported: nftResult.imported + stakingResult.imported,
+        skipped: nftResult.skipped + stakingResult.skipped,
+        errors: nftResult.errors + stakingResult.errors,
       };
 
       apiLog.businessOperation(
@@ -115,12 +129,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         'discovered',
         'positions',
         user.id,
-        {
-          found: result.found,
-          imported: result.imported,
-          skipped: result.skipped,
-          errors: result.errors,
-        },
+        { ...responseData },
       );
 
       const response = createSuccessResponse(responseData);

--- a/apps/midcurve-api/src/app/api/v1/positions/refresh-all/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/refresh-all/route.ts
@@ -20,7 +20,11 @@ import {
 import { apiLogger, apiLog } from '@/lib/logger';
 import { createPreflightResponse } from '@/lib/cors';
 import { prisma } from '@/lib/prisma';
-import { getUniswapV3PositionService } from '@/lib/services';
+import {
+  getUniswapV3PositionService,
+  getUniswapV3VaultPositionService,
+  getUniswapV3StakingPositionService,
+} from '@/lib/services';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -46,6 +50,7 @@ export async function POST(request: NextRequest): Promise<Response> {
         },
         select: {
           id: true,
+          protocol: true,
           updatedAt: true,
           config: true,
         },
@@ -79,13 +84,23 @@ export async function POST(request: NextRequest): Promise<Response> {
         );
       }
 
-      // Refresh each position using the existing service
-      const positionService = getUniswapV3PositionService();
+      // Per-protocol dispatch — each protocol has its own refresh path.
       let refreshedCount = 0;
 
-      // Refresh each position sequentially
       for (const p of positions) {
-        await positionService.refresh(p.id);
+        if (p.protocol === 'uniswapv3') {
+          await getUniswapV3PositionService().refresh(p.id);
+        } else if (p.protocol === 'uniswapv3-vault') {
+          await getUniswapV3VaultPositionService().refresh(p.id);
+        } else if (p.protocol === 'uniswapv3-staking') {
+          await getUniswapV3StakingPositionService().refresh(p.id);
+        } else {
+          apiLogger.warn(
+            { requestId, positionId: p.id, protocol: p.protocol },
+            'refresh-all: skipping position with unknown protocol',
+          );
+          continue;
+        }
         refreshedCount++;
       }
 

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/accounting/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/accounting/route.ts
@@ -1,0 +1,106 @@
+/**
+ * Staking Vault Position Accounting Endpoint
+ *
+ * GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/accounting
+ *
+ * Lifetime-to-date, realized-only accounting report (balance sheet, P&L
+ * breakdown, journal audit trail). PR3's journal-posting rule keeps the
+ * staking journal in sync; this endpoint just queries it.
+ *
+ * Authentication: Required.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/middleware/with-auth';
+import { createPreflightResponse } from '@/lib/cors';
+import {
+    createSuccessResponse,
+    createErrorResponse,
+    ApiErrorCode,
+    ErrorCodeToHttpStatus,
+    GetUniswapV3StakingPositionParamsSchema,
+    type PositionAccountingResponse,
+} from '@midcurve/api-shared';
+import { normalizeAddress } from '@midcurve/shared';
+import { apiLogger, apiLog } from '@/lib/logger';
+import { getJournalService, getUniswapV3StakingPositionService } from '@/lib/services';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function OPTIONS(request: NextRequest) {
+    return createPreflightResponse(request.headers.get('origin'));
+}
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ chainId: string; vaultAddress: string }> },
+): Promise<Response> {
+    return withAuth(request, async (user, requestId) => {
+        const startTime = Date.now();
+
+        try {
+            const resolvedParams = await params;
+            const validation = GetUniswapV3StakingPositionParamsSchema.safeParse(resolvedParams);
+
+            if (!validation.success) {
+                apiLog.validationError(apiLogger, requestId, validation.error.errors);
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid path parameters',
+                    validation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const { chainId } = validation.data;
+            const vaultAddress = normalizeAddress(validation.data.vaultAddress);
+            const positionHash = `uniswapv3-staking/${chainId}/${vaultAddress}`;
+
+            const dbPosition = await getUniswapV3StakingPositionService().findByPositionHash(
+                user.id, positionHash,
+            );
+
+            if (!dbPosition) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.POSITION_NOT_FOUND,
+                    'Staking-vault position not found',
+                    `No staking-vault position found for chainId ${chainId} and vaultAddress ${vaultAddress}`,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                });
+            }
+
+            const report: PositionAccountingResponse = await getJournalService()
+                .getPositionAccountingReport(positionHash, user.id);
+
+            apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+            return NextResponse.json(createSuccessResponse(report), {
+                status: 200,
+                headers: { 'Cache-Control': 'private, no-cache' },
+            });
+        } catch (error) {
+            apiLog.methodError(
+                apiLogger,
+                'GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/accounting',
+                error,
+                { requestId },
+            );
+
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.INTERNAL_SERVER_ERROR,
+                'Failed to fetch staking-vault position accounting report',
+                error instanceof Error ? error.message : String(error),
+            );
+            apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+            });
+        }
+    });
+}

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/apr/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/apr/route.ts
@@ -1,0 +1,139 @@
+/**
+ * Staking Vault Position APR Endpoint
+ *
+ * GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/apr
+ *
+ * APR periods are bracketed by `STAKING_DISPOSE` events (vs `COLLECT` for NFT) —
+ * the staking ledger service persists them via `UniswapV3StakingAprService` on
+ * every `recalculateAggregates` pass.
+ *
+ * Authentication: Required.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/middleware/with-auth';
+import { createPreflightResponse } from '@/lib/cors';
+import {
+    createSuccessResponse,
+    createErrorResponse,
+    ApiErrorCode,
+    ErrorCodeToHttpStatus,
+    GetUniswapV3StakingPositionParamsSchema,
+} from '@midcurve/api-shared';
+import type {
+    AprPeriodsResponse,
+    AprPeriodData,
+    AprSummaryData,
+} from '@midcurve/api-shared';
+import { serializeBigInt } from '@/lib/serializers';
+import { apiLogger, apiLog } from '@/lib/logger';
+import {
+    getUniswapV3StakingPositionService,
+    getUniswapV3StakingAprService,
+} from '@/lib/services';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function OPTIONS(request: NextRequest) {
+    return createPreflightResponse(request.headers.get('origin'));
+}
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ chainId: string; vaultAddress: string }> },
+): Promise<Response> {
+    return withAuth(request, async (user, requestId) => {
+        const startTime = Date.now();
+
+        try {
+            const resolvedParams = await params;
+            const validation = GetUniswapV3StakingPositionParamsSchema.safeParse(resolvedParams);
+
+            if (!validation.success) {
+                apiLog.validationError(apiLogger, requestId, validation.error.errors);
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid path parameters',
+                    validation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const { chainId, vaultAddress } = validation.data;
+            const positionHash = `uniswapv3-staking/${chainId}/${vaultAddress}`;
+
+            const dbPosition = await getUniswapV3StakingPositionService().findByPositionHash(
+                user.id, positionHash,
+            );
+
+            if (!dbPosition) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.POSITION_NOT_FOUND,
+                    'Staking-vault position not found',
+                    `No staking-vault position found for chainId ${chainId} and vaultAddress ${vaultAddress}`,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                });
+            }
+
+            const aprService = getUniswapV3StakingAprService(dbPosition.id);
+            const aprPeriods = await aprService.fetchAprPeriods();
+            const aprSummary = await getUniswapV3StakingPositionService().fetchAprSummary(
+                dbPosition.id,
+            );
+
+            const serializedPeriods = serializeBigInt(aprPeriods) as unknown as AprPeriodData[];
+            const serializedSummary = serializeBigInt(aprSummary) as unknown as AprSummaryData;
+
+            const response: AprPeriodsResponse = {
+                ...createSuccessResponse(serializedPeriods),
+                summary: serializedSummary,
+                meta: {
+                    timestamp: new Date().toISOString(),
+                    count: aprPeriods.length,
+                    requestId,
+                },
+            };
+
+            apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+            return NextResponse.json(response, { status: 200 });
+        } catch (error) {
+            apiLog.methodError(
+                apiLogger,
+                'GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/apr',
+                error,
+                { requestId },
+            );
+
+            if (error instanceof Error) {
+                if (error.message.includes('not found') || error.message.includes('does not exist')) {
+                    const errorResponse = createErrorResponse(
+                        ApiErrorCode.POSITION_NOT_FOUND,
+                        'Position not found',
+                        error.message,
+                    );
+                    apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                    return NextResponse.json(errorResponse, {
+                        status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                    });
+                }
+            }
+
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.INTERNAL_SERVER_ERROR,
+                'Failed to fetch staking-vault position APR',
+                error instanceof Error ? error.message : String(error),
+            );
+            apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+            });
+        }
+    });
+}

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/ledger/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/ledger/route.ts
@@ -1,0 +1,132 @@
+/**
+ * Staking Vault Position Ledger Endpoint
+ *
+ * GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/ledger
+ *
+ * Returns the full ledger event chain for the position. Unpaginated for
+ * parity with NFT/Vault — if settled vaults grow event-heavy, paginate all
+ * three protocols together later rather than diverging staking now.
+ *
+ * Authentication: Required.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/middleware/with-auth';
+import { createPreflightResponse } from '@/lib/cors';
+import {
+    createSuccessResponse,
+    createErrorResponse,
+    ApiErrorCode,
+    ErrorCodeToHttpStatus,
+    GetUniswapV3StakingPositionParamsSchema,
+} from '@midcurve/api-shared';
+import type { LedgerEventsResponse, LedgerEventData } from '@midcurve/api-shared';
+import { apiLogger, apiLog } from '@/lib/logger';
+import {
+    getUniswapV3StakingPositionService,
+    getUniswapV3StakingPositionLedgerService,
+} from '@/lib/services';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function OPTIONS(request: NextRequest) {
+    return createPreflightResponse(request.headers.get('origin'));
+}
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ chainId: string; vaultAddress: string }> },
+): Promise<Response> {
+    return withAuth(request, async (user, requestId) => {
+        const startTime = Date.now();
+
+        try {
+            const resolvedParams = await params;
+            const validation = GetUniswapV3StakingPositionParamsSchema.safeParse(resolvedParams);
+
+            if (!validation.success) {
+                apiLog.validationError(apiLogger, requestId, validation.error.errors);
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid path parameters',
+                    validation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const { chainId, vaultAddress } = validation.data;
+            const positionHash = `uniswapv3-staking/${chainId}/${vaultAddress}`;
+
+            const dbPosition = await getUniswapV3StakingPositionService().findByPositionHash(
+                user.id, positionHash,
+            );
+
+            if (!dbPosition) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.POSITION_NOT_FOUND,
+                    'Staking-vault position not found',
+                    `No staking-vault position found for chainId ${chainId} and vaultAddress ${vaultAddress}`,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                });
+            }
+
+            const ledgerEvents = await getUniswapV3StakingPositionLedgerService(
+                dbPosition.id,
+            ).findAll();
+
+            const serializedEvents = ledgerEvents.map(
+                (event: { toJSON: () => unknown }) => event.toJSON(),
+            ) as unknown as LedgerEventData[];
+
+            const response: LedgerEventsResponse = {
+                ...createSuccessResponse(serializedEvents),
+                meta: {
+                    timestamp: new Date().toISOString(),
+                    count: ledgerEvents.length,
+                    requestId,
+                },
+            };
+
+            apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+            return NextResponse.json(response, { status: 200 });
+        } catch (error) {
+            apiLog.methodError(
+                apiLogger,
+                'GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/ledger',
+                error,
+                { requestId },
+            );
+
+            if (error instanceof Error) {
+                if (error.message.includes('not found') || error.message.includes('does not exist')) {
+                    const errorResponse = createErrorResponse(
+                        ApiErrorCode.POSITION_NOT_FOUND,
+                        'Position not found',
+                        error.message,
+                    );
+                    apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                    return NextResponse.json(errorResponse, {
+                        status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                    });
+                }
+            }
+
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.INTERNAL_SERVER_ERROR,
+                'Failed to fetch staking-vault position ledger',
+                error instanceof Error ? error.message : String(error),
+            );
+            apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+            });
+        }
+    });
+}

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/pnl-curve/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/pnl-curve/route.ts
@@ -1,0 +1,192 @@
+/**
+ * Staking Vault Position PnL Curve Endpoint
+ *
+ * GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/pnl-curve
+ *   ?priceMin=<bigint>&priceMax=<bigint>&numPoints=<int>
+ *
+ * Mirrors the NFT shape directly — staking user owns 100% of the underlying
+ * NFT position so no proportional scaling is applied (unlike Vault).
+ *
+ * Authentication: Required.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/middleware/with-auth';
+import { createPreflightResponse } from '@/lib/cors';
+import {
+    createSuccessResponse,
+    createErrorResponse,
+    ApiErrorCode,
+    ErrorCodeToHttpStatus,
+    GetUniswapV3StakingPositionParamsSchema,
+    PositionPnlCurveQuerySchema,
+} from '@midcurve/api-shared';
+import type { PositionPnlCurveResponse } from '@midcurve/api-shared';
+import {
+    generatePnLCurve,
+    pricePerToken0InToken1,
+    pricePerToken1InToken0,
+    type Erc20Token,
+    type UniswapV3Pool,
+} from '@midcurve/shared';
+import { apiLogger, apiLog } from '@/lib/logger';
+import { getUniswapV3StakingPositionService } from '@/lib/services';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function OPTIONS(request: NextRequest) {
+    return createPreflightResponse(request.headers.get('origin'));
+}
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ chainId: string; vaultAddress: string }> },
+): Promise<Response> {
+    return withAuth(request, async (user, requestId) => {
+        const startTime = Date.now();
+
+        try {
+            const resolvedParams = await params;
+            const pathValidation = GetUniswapV3StakingPositionParamsSchema.safeParse(resolvedParams);
+            if (!pathValidation.success) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid path parameters',
+                    pathValidation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const search = new URL(request.url).searchParams;
+            const queryValidation = PositionPnlCurveQuerySchema.safeParse({
+                priceMin: search.get('priceMin') ?? undefined,
+                priceMax: search.get('priceMax') ?? undefined,
+                numPoints: search.get('numPoints') ?? undefined,
+            });
+            if (!queryValidation.success) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid query parameters',
+                    queryValidation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const { chainId, vaultAddress } = pathValidation.data;
+            const positionHash = `uniswapv3-staking/${chainId}/${vaultAddress}`;
+
+            const dbPosition = await getUniswapV3StakingPositionService().findByPositionHash(
+                user.id, positionHash,
+            );
+            if (!dbPosition) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.POSITION_NOT_FOUND,
+                    'Staking-vault position not found',
+                    `No staking-vault position found for chainId ${chainId} and vaultAddress ${vaultAddress}`,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                });
+            }
+
+            const baseIsToken0 = !dbPosition.isToken0Quote;
+            const baseToken = (baseIsToken0 ? dbPosition.pool.token0 : dbPosition.pool.token1) as Erc20Token;
+            const quoteToken = (baseIsToken0 ? dbPosition.pool.token1 : dbPosition.pool.token0) as Erc20Token;
+
+            const pool = dbPosition.pool as UniswapV3Pool;
+            const sqrtPriceX96 = pool.typedState.sqrtPriceX96;
+            const currentPrice = baseIsToken0
+                ? pricePerToken0InToken1(sqrtPriceX96, baseToken.decimals)
+                : pricePerToken1InToken0(sqrtPriceX96, baseToken.decimals);
+
+            const priceMin = queryValidation.data.priceMin
+                ? BigInt(queryValidation.data.priceMin)
+                : (currentPrice * 50n) / 100n;
+            const priceMax = queryValidation.data.priceMax
+                ? BigInt(queryValidation.data.priceMax)
+                : (currentPrice * 150n) / 100n;
+            const numPoints = queryValidation.data.numPoints ?? 100;
+
+            if (priceMin >= priceMax) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'priceMin must be strictly less than priceMax',
+                    { priceMin: priceMin.toString(), priceMax: priceMax.toString() },
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const tickSpacing = pool.typedConfig.tickSpacing;
+
+            const points = generatePnLCurve(
+                dbPosition.liquidity,
+                dbPosition.tickLower,
+                dbPosition.tickUpper,
+                dbPosition.costBasis,
+                baseToken.address,
+                quoteToken.address,
+                baseToken.decimals,
+                tickSpacing,
+                { min: priceMin, max: priceMax },
+                numPoints,
+            );
+
+            const response: PositionPnlCurveResponse = {
+                ...createSuccessResponse({
+                    positionId: dbPosition.id,
+                    liquidity: dbPosition.liquidity.toString(),
+                    costBasis: dbPosition.costBasis.toString(),
+                    tickLower: dbPosition.tickLower,
+                    tickUpper: dbPosition.tickUpper,
+                    baseTokenSymbol: baseToken.symbol,
+                    quoteTokenSymbol: quoteToken.symbol,
+                    baseTokenDecimals: baseToken.decimals,
+                    quoteTokenDecimals: quoteToken.decimals,
+                    currentPrice: currentPrice.toString(),
+                    priceMin: priceMin.toString(),
+                    priceMax: priceMax.toString(),
+                    numPoints: points.length,
+                    curve: points.map((p) => ({
+                        price: p.price.toString(),
+                        positionValue: p.positionValue.toString(),
+                        pnl: p.pnl.toString(),
+                        pnlPercent: p.pnlPercent,
+                        phase: p.phase,
+                    })),
+                }),
+                meta: { timestamp: new Date().toISOString(), requestId },
+            };
+
+            apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+            return NextResponse.json(response, { status: 200 });
+        } catch (error) {
+            apiLog.methodError(
+                apiLogger,
+                'GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/pnl-curve',
+                error,
+                { requestId },
+            );
+
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.INTERNAL_SERVER_ERROR,
+                'Failed to generate staking-vault PnL curve',
+                error instanceof Error ? error.message : String(error),
+            );
+            apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+            });
+        }
+    });
+}

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/refresh/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/refresh/route.ts
@@ -1,0 +1,127 @@
+/**
+ * Staking Vault Position On-Chain Refresh Endpoint
+ *
+ * POST /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/refresh
+ *
+ * Re-reads on-chain state and re-syncs the ledger. NO 15-second updatedAt
+ * cache (per PR4 plan refinement #1) — UI calls this after user txs and
+ * must see fresh state immediately. The 60s block-keyed RPC cache stays.
+ *
+ * Authentication: Required.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/middleware/with-auth';
+import { createPreflightResponse } from '@/lib/cors';
+import {
+    createSuccessResponse,
+    createErrorResponse,
+    ApiErrorCode,
+    ErrorCodeToHttpStatus,
+    GetUniswapV3StakingPositionParamsSchema,
+} from '@midcurve/api-shared';
+import { serializeUniswapV3StakingPosition } from '@/lib/serializers';
+import { apiLogger, apiLog } from '@/lib/logger';
+import { prisma } from '@/lib/prisma';
+import { getUniswapV3StakingPositionService } from '@/lib/services';
+import type { GetUniswapV3StakingPositionResponse } from '@midcurve/api-shared';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+export async function OPTIONS(request: NextRequest): Promise<Response> {
+    return createPreflightResponse(request.headers.get('origin'));
+}
+
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ chainId: string; vaultAddress: string }> },
+): Promise<Response> {
+    return withAuth(request, async (user, requestId) => {
+        const startTime = Date.now();
+
+        try {
+            const resolvedParams = await params;
+            const validation = GetUniswapV3StakingPositionParamsSchema.safeParse(resolvedParams);
+
+            if (!validation.success) {
+                apiLog.validationError(apiLogger, requestId, validation.error.errors);
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid path parameters',
+                    validation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const { chainId, vaultAddress } = validation.data;
+            const positionHash = `uniswapv3-staking/${chainId}/${vaultAddress}`;
+
+            const result = await prisma.$transaction(async (tx) => {
+                const dbPosition = await getUniswapV3StakingPositionService().findByPositionHash(
+                    user.id, positionHash, tx,
+                );
+                if (!dbPosition) return null;
+
+                const refreshedPosition = await getUniswapV3StakingPositionService().refresh(
+                    dbPosition.id, 'latest', tx,
+                );
+                return refreshedPosition;
+            });
+
+            if (!result) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.POSITION_NOT_FOUND,
+                    'Staking-vault position not found',
+                    `No staking-vault position found for chainId ${chainId} and vaultAddress ${vaultAddress}`,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                });
+            }
+
+            const serializedPosition: GetUniswapV3StakingPositionResponse =
+                serializeUniswapV3StakingPosition(result);
+
+            const response = createSuccessResponse(serializedPosition);
+            apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+            return NextResponse.json(response, { status: 200 });
+        } catch (error) {
+            apiLog.methodError(
+                apiLogger,
+                'POST /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/refresh',
+                error,
+                { requestId },
+            );
+
+            if (error instanceof Error) {
+                if (error.message.includes('not found') || error.message.includes('does not exist')) {
+                    const errorResponse = createErrorResponse(
+                        ApiErrorCode.POSITION_NOT_FOUND,
+                        'Position not found',
+                        error.message,
+                    );
+                    apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                    return NextResponse.json(errorResponse, {
+                        status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                    });
+                }
+            }
+
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.INTERNAL_SERVER_ERROR,
+                'Failed to refresh staking-vault position',
+                error instanceof Error ? error.message : String(error),
+            );
+            apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+            });
+        }
+    });
+}

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/reload-history/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/reload-history/route.ts
@@ -1,0 +1,135 @@
+/**
+ * Staking Vault Position History Reload Endpoint
+ *
+ * POST /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/reload-history
+ *
+ * Completely rebuilds the position's ledger from blockchain history. Calls
+ * `service.reset(id)`, which wipes the ledger and re-imports via
+ * `syncFromChain`. Per PR4 plan refinement #3, `reset` does NOT emit
+ * `position.liquidity.reverted` events — FK cascade handles cleanup, and the
+ * fresh `syncFromChain` re-emits liquidity events that PR3's rule consumes
+ * to rebuild lots/journal entries from scratch.
+ *
+ * Authentication: Required.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/middleware/with-auth';
+import { createPreflightResponse } from '@/lib/cors';
+import {
+    createSuccessResponse,
+    createErrorResponse,
+    ApiErrorCode,
+    ErrorCodeToHttpStatus,
+    GetUniswapV3StakingPositionParamsSchema,
+} from '@midcurve/api-shared';
+import type { UniswapV3StakingPositionResponse } from '@midcurve/api-shared';
+import { serializeUniswapV3StakingPosition } from '@/lib/serializers';
+import { apiLogger, apiLog } from '@/lib/logger';
+import { getUniswapV3StakingPositionService } from '@/lib/services';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+export async function OPTIONS(request: NextRequest) {
+    return createPreflightResponse(request.headers.get('origin'));
+}
+
+export async function POST(
+    request: NextRequest,
+    { params }: { params: Promise<{ chainId: string; vaultAddress: string }> },
+): Promise<Response> {
+    return withAuth(request, async (user, requestId) => {
+        const startTime = Date.now();
+
+        try {
+            const resolvedParams = await params;
+            const validation = GetUniswapV3StakingPositionParamsSchema.safeParse(resolvedParams);
+
+            if (!validation.success) {
+                apiLog.validationError(apiLogger, requestId, validation.error.errors);
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid path parameters',
+                    validation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const { chainId, vaultAddress } = validation.data;
+            const positionHash = `uniswapv3-staking/${chainId}/${vaultAddress}`;
+
+            const dbPosition = await getUniswapV3StakingPositionService().findByPositionHash(
+                user.id, positionHash,
+            );
+
+            if (!dbPosition) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.POSITION_NOT_FOUND,
+                    'Staking-vault position not found',
+                    `No staking-vault position found for chainId ${chainId} and vaultAddress ${vaultAddress}`,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                });
+            }
+
+            const position = await getUniswapV3StakingPositionService().reset(dbPosition.id);
+
+            const serializedPosition = serializeUniswapV3StakingPosition(
+                position,
+            ) as UniswapV3StakingPositionResponse;
+            const response = createSuccessResponse(serializedPosition);
+
+            apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+            return NextResponse.json(response, { status: 200 });
+        } catch (error) {
+            apiLog.methodError(
+                apiLogger,
+                'POST /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/reload-history',
+                error,
+                { requestId },
+            );
+
+            if (error instanceof Error) {
+                if (error.message.includes('not found') || error.message.includes('does not exist')) {
+                    const errorResponse = createErrorResponse(
+                        ApiErrorCode.POSITION_NOT_FOUND,
+                        'Position not found',
+                        error.message,
+                    );
+                    apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                    return NextResponse.json(errorResponse, {
+                        status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                    });
+                }
+                if (error.message.includes('rate limit') || error.message.includes('too many requests')) {
+                    const errorResponse = createErrorResponse(
+                        ApiErrorCode.TOO_MANY_REQUESTS,
+                        'Rate limit exceeded',
+                        error.message,
+                    );
+                    apiLog.requestEnd(apiLogger, requestId, 429, Date.now() - startTime);
+                    return NextResponse.json(errorResponse, {
+                        status: ErrorCodeToHttpStatus[ApiErrorCode.TOO_MANY_REQUESTS],
+                    });
+                }
+            }
+
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.INTERNAL_SERVER_ERROR,
+                'Failed to reload staking-vault position history',
+                error instanceof Error ? error.message : String(error),
+            );
+            apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+            });
+        }
+    });
+}

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/route.ts
@@ -1,0 +1,199 @@
+/**
+ * UniswapV3 Staking Vault Position Endpoint
+ *
+ * GET    /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress
+ * DELETE /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress
+ *
+ * Vaults are owner-bound 1:1 (per SPEC-0003b §2), so the vault address alone
+ * disambiguates — no separate `ownerAddress` segment.
+ *
+ * Authentication: Required (session or API key).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/middleware/with-auth';
+import { createPreflightResponse } from '@/lib/cors';
+import {
+    createSuccessResponse,
+    createErrorResponse,
+    ApiErrorCode,
+    ErrorCodeToHttpStatus,
+    GetUniswapV3StakingPositionParamsSchema,
+} from '@midcurve/api-shared';
+import { serializeUniswapV3StakingPosition } from '@/lib/serializers';
+import { apiLogger, apiLog } from '@/lib/logger';
+import { prisma } from '@/lib/prisma';
+import { getUniswapV3StakingPositionService } from '@/lib/services';
+import type { GetUniswapV3StakingPositionResponse } from '@midcurve/api-shared';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function OPTIONS(request: NextRequest): Promise<Response> {
+    return createPreflightResponse(request.headers.get('origin'));
+}
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ chainId: string; vaultAddress: string }> },
+): Promise<Response> {
+    return withAuth(request, async (user, requestId) => {
+        const startTime = Date.now();
+
+        try {
+            const resolvedParams = await params;
+            const validation = GetUniswapV3StakingPositionParamsSchema.safeParse(resolvedParams);
+
+            if (!validation.success) {
+                apiLog.validationError(apiLogger, requestId, validation.error.errors);
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid path parameters',
+                    validation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const { chainId, vaultAddress } = validation.data;
+            const positionHash = `uniswapv3-staking/${chainId}/${vaultAddress}`;
+
+            apiLog.businessOperation(
+                apiLogger, requestId, 'lookup', 'staking-vault-position',
+                positionHash, { chainId, vaultAddress, userId: user.id },
+            );
+
+            const result = await prisma.$transaction(async (tx) => {
+                const position = await getUniswapV3StakingPositionService().findByPositionHash(
+                    user.id, positionHash, tx,
+                );
+                if (!position) return null;
+
+                const ownerWalletRow = await tx.position.findUnique({
+                    where: { id: position.id },
+                    select: { ownerWallet: true },
+                });
+
+                return { position, ownerWallet: ownerWalletRow?.ownerWallet ?? null };
+            });
+
+            if (!result) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.POSITION_NOT_FOUND,
+                    'Staking-vault position not found',
+                    `No staking-vault position found for chainId ${chainId} and vaultAddress ${vaultAddress}`,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                });
+            }
+
+            const serializedPosition: GetUniswapV3StakingPositionResponse = {
+                ...serializeUniswapV3StakingPosition(result.position),
+                ownerWallet: result.ownerWallet,
+            };
+
+            const response = createSuccessResponse(serializedPosition);
+            apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+            return NextResponse.json(response, { status: 200 });
+        } catch (error) {
+            apiLog.methodError(
+                apiLogger,
+                'GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress',
+                error,
+                { requestId },
+            );
+
+            if (error instanceof Error) {
+                if (error.message.includes('not found') || error.message.includes('does not exist')) {
+                    const errorResponse = createErrorResponse(
+                        ApiErrorCode.POSITION_NOT_FOUND,
+                        'Position not found',
+                        error.message,
+                    );
+                    apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                    return NextResponse.json(errorResponse, {
+                        status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                    });
+                }
+            }
+
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.INTERNAL_SERVER_ERROR,
+                'Failed to fetch staking-vault position',
+                error instanceof Error ? error.message : String(error),
+            );
+            apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+            });
+        }
+    });
+}
+
+export async function DELETE(
+    request: NextRequest,
+    { params }: { params: Promise<{ chainId: string; vaultAddress: string }> },
+): Promise<Response> {
+    return withAuth(request, async (user, requestId) => {
+        const startTime = Date.now();
+
+        try {
+            const resolvedParams = await params;
+            const validation = GetUniswapV3StakingPositionParamsSchema.safeParse(resolvedParams);
+
+            if (!validation.success) {
+                apiLog.validationError(apiLogger, requestId, validation.error.errors);
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid path parameters',
+                    validation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const { chainId, vaultAddress } = validation.data;
+            const positionHash = `uniswapv3-staking/${chainId}/${vaultAddress}`;
+
+            const dbPosition = await getUniswapV3StakingPositionService().findByPositionHash(
+                user.id, positionHash,
+            );
+
+            if (!dbPosition) {
+                // Idempotent — 200 with empty body on missing.
+                const response = createSuccessResponse({});
+                apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+                return NextResponse.json(response, { status: 200 });
+            }
+
+            await getUniswapV3StakingPositionService().delete(dbPosition.id);
+
+            const response = createSuccessResponse({});
+            apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+            return NextResponse.json(response, { status: 200 });
+        } catch (error) {
+            apiLog.methodError(
+                apiLogger,
+                'DELETE /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress',
+                error,
+                { requestId },
+            );
+
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.INTERNAL_SERVER_ERROR,
+                'Failed to delete staking-vault position',
+                error instanceof Error ? error.message : String(error),
+            );
+            apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+            });
+        }
+    });
+}

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/simulate/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/[chainId]/[vaultAddress]/simulate/route.ts
@@ -1,0 +1,204 @@
+/**
+ * Staking Vault Position Simulation Endpoint
+ *
+ * GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/simulate?price=<bigint>
+ *
+ * Mirrors the NFT shape directly — the staking user owns 100% of the underlying
+ * NFT position, so no proportional scaling step is needed (unlike Vault, which
+ * scales by `sharesBalance / totalSupply`).
+ *
+ * Authentication: Required.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { withAuth } from '@/middleware/with-auth';
+import { createPreflightResponse } from '@/lib/cors';
+import {
+    createSuccessResponse,
+    createErrorResponse,
+    ApiErrorCode,
+    ErrorCodeToHttpStatus,
+    GetUniswapV3StakingPositionParamsSchema,
+    PositionSimulateQuerySchema,
+} from '@midcurve/api-shared';
+import type { PositionSimulationResponse } from '@midcurve/api-shared';
+import {
+    calculatePositionValue,
+    getTokenAmountsFromLiquidity_X96,
+    priceToSqrtRatioX96,
+    tickToSqrtRatioX96,
+    type Erc20Token,
+} from '@midcurve/shared';
+import { apiLogger, apiLog } from '@/lib/logger';
+import { getUniswapV3StakingPositionService } from '@/lib/services';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function OPTIONS(request: NextRequest) {
+    return createPreflightResponse(request.headers.get('origin'));
+}
+
+export async function GET(
+    request: NextRequest,
+    { params }: { params: Promise<{ chainId: string; vaultAddress: string }> },
+): Promise<Response> {
+    return withAuth(request, async (user, requestId) => {
+        const startTime = Date.now();
+
+        try {
+            const resolvedParams = await params;
+            const pathValidation = GetUniswapV3StakingPositionParamsSchema.safeParse(resolvedParams);
+            if (!pathValidation.success) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid path parameters',
+                    pathValidation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const queryValidation = PositionSimulateQuerySchema.safeParse({
+                price: new URL(request.url).searchParams.get('price') ?? undefined,
+            });
+            if (!queryValidation.success) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.VALIDATION_ERROR,
+                    'Invalid query parameters',
+                    queryValidation.error.errors,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+                });
+            }
+
+            const { chainId, vaultAddress } = pathValidation.data;
+            const price = BigInt(queryValidation.data.price);
+            const positionHash = `uniswapv3-staking/${chainId}/${vaultAddress}`;
+
+            const dbPosition = await getUniswapV3StakingPositionService().findByPositionHash(
+                user.id, positionHash,
+            );
+
+            if (!dbPosition) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.POSITION_NOT_FOUND,
+                    'Staking-vault position not found',
+                    `No staking-vault position found for chainId ${chainId} and vaultAddress ${vaultAddress}`,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                });
+            }
+
+            // Staking's `simulatePnLAtPrice` only returns positionValue / pnlValue /
+            // pnlPercent (PnLSimulationResult), so we compute base/quote amounts
+            // and phase locally — same shape as the vault route.
+            const baseIsToken0 = !dbPosition.isToken0Quote;
+            const baseToken = (baseIsToken0
+                ? dbPosition.pool.token0
+                : dbPosition.pool.token1) as Erc20Token;
+            const quoteToken = (baseIsToken0
+                ? dbPosition.pool.token1
+                : dbPosition.pool.token0) as Erc20Token;
+
+            const sqrtPriceJSBI = priceToSqrtRatioX96(
+                baseToken.address,
+                quoteToken.address,
+                baseToken.decimals,
+                price,
+            );
+            const sqrtPriceX96 = BigInt(sqrtPriceJSBI.toString());
+            const sqrtPriceLowerX96 = BigInt(
+                tickToSqrtRatioX96(dbPosition.tickLower).toString(),
+            );
+            const sqrtPriceUpperX96 = BigInt(
+                tickToSqrtRatioX96(dbPosition.tickUpper).toString(),
+            );
+
+            const positionValue = calculatePositionValue(
+                dbPosition.liquidity,
+                sqrtPriceX96,
+                dbPosition.tickLower,
+                dbPosition.tickUpper,
+                baseIsToken0,
+            );
+
+            const { token0Amount, token1Amount } = getTokenAmountsFromLiquidity_X96(
+                dbPosition.liquidity,
+                sqrtPriceX96,
+                sqrtPriceLowerX96,
+                sqrtPriceUpperX96,
+            );
+            const baseTokenAmount = baseIsToken0 ? token0Amount : token1Amount;
+            const quoteTokenAmount = baseIsToken0 ? token1Amount : token0Amount;
+
+            const pnlValue = positionValue - dbPosition.costBasis;
+            const pnlPercent =
+                dbPosition.costBasis > 0n
+                    ? Number((pnlValue * 1000000n) / dbPosition.costBasis) / 10000
+                    : 0;
+
+            let phase: 'below' | 'in-range' | 'above';
+            if (sqrtPriceX96 < sqrtPriceLowerX96) phase = 'below';
+            else if (sqrtPriceX96 >= sqrtPriceUpperX96) phase = 'above';
+            else phase = 'in-range';
+
+            const response: PositionSimulationResponse = {
+                ...createSuccessResponse({
+                    price: price.toString(),
+                    positionValue: positionValue.toString(),
+                    pnlValue: pnlValue.toString(),
+                    pnlPercent,
+                    baseTokenAmount: baseTokenAmount.toString(),
+                    quoteTokenAmount: quoteTokenAmount.toString(),
+                    phase,
+                    baseTokenSymbol: baseToken.symbol,
+                    quoteTokenSymbol: quoteToken.symbol,
+                    baseTokenDecimals: baseToken.decimals,
+                    quoteTokenDecimals: quoteToken.decimals,
+                }),
+                meta: { timestamp: new Date().toISOString(), requestId },
+            };
+
+            apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+            return NextResponse.json(response, { status: 200 });
+        } catch (error) {
+            apiLog.methodError(
+                apiLogger,
+                'GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress/simulate',
+                error,
+                { requestId },
+            );
+
+            if (error instanceof Error) {
+                if (error.message.includes('not found') || error.message.includes('does not exist')) {
+                    const errorResponse = createErrorResponse(
+                        ApiErrorCode.POSITION_NOT_FOUND,
+                        'Position not found',
+                        error.message,
+                    );
+                    apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+                    return NextResponse.json(errorResponse, {
+                        status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+                    });
+                }
+            }
+
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.INTERNAL_SERVER_ERROR,
+                'Failed to simulate staking-vault position',
+                error instanceof Error ? error.message : String(error),
+            );
+            apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+            });
+        }
+    });
+}

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/discover/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-staking/discover/route.ts
@@ -1,0 +1,167 @@
+/**
+ * Staking Vault Position Discovery Endpoint
+ *
+ * POST /api/v1/positions/uniswapv3-staking/discover
+ *
+ * Imports a single UniswapV3StakingVault position by `(chainId, vaultAddress)`.
+ * The vault is owner-bound 1:1 (per SPEC-0003b §2), so the owner is derived
+ * from `vault.owner()` on chain — no separate `ownerAddress` parameter.
+ *
+ * Mirrors the Vault `/discover` semantics. After the service creates the
+ * Position row + imports the ledger, this route emits `position.created`
+ * (matches NFT/Vault convention).
+ *
+ * Authentication: Required (session or API key).
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withAuth } from '@/middleware/with-auth';
+import {
+    createSuccessResponse,
+    createErrorResponse,
+    ApiErrorCode,
+    ErrorCodeToHttpStatus,
+} from '@midcurve/api-shared';
+import {
+    getDomainEventPublisher,
+    type PositionLifecyclePayload,
+} from '@midcurve/services';
+import { getUniswapV3StakingPositionService } from '@/lib/services';
+import { createPreflightResponse } from '@/lib/cors';
+import { apiLogger, apiLog } from '@/lib/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const DiscoverStakingRequestSchema = z.object({
+    chainId: z.number().int().positive(),
+    vaultAddress: z.string().regex(/^0x[a-fA-F0-9]{40}$/),
+});
+
+export async function OPTIONS(request: NextRequest): Promise<Response> {
+    return createPreflightResponse(request.headers.get('origin'));
+}
+
+export async function POST(request: NextRequest): Promise<Response> {
+    return withAuth(request, async (user, requestId) => {
+        const startTime = Date.now();
+
+        const body = await request.json();
+        const validation = DiscoverStakingRequestSchema.safeParse(body);
+
+        if (!validation.success) {
+            apiLog.validationError(apiLogger, requestId, validation.error.errors);
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.VALIDATION_ERROR,
+                'Invalid request data',
+                validation.error.errors,
+            );
+            apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+            });
+        }
+
+        const { chainId, vaultAddress } = validation.data;
+
+        try {
+            const position = await getUniswapV3StakingPositionService().discover(user.id, {
+                chainId,
+                vaultAddress,
+            });
+
+            // Emit `position.created` so PR3's journal-posting rule + any other
+            // downstream consumers can react. Mirrors the NFT `/import` route.
+            const eventPublisher = getDomainEventPublisher();
+            await eventPublisher.createAndPublish<PositionLifecyclePayload>({
+                type: 'position.created',
+                entityType: 'position',
+                entityId: position.id,
+                userId: position.userId,
+                payload: {
+                    positionId: position.id,
+                    positionHash: position.positionHash,
+                },
+                source: 'api',
+            });
+
+            apiLog.businessOperation(
+                apiLogger,
+                requestId,
+                'discovered',
+                'staking-vault-position',
+                user.id,
+                { chainId, vaultAddress, positionId: position.id },
+            );
+
+            const responseData = {
+                positionId: position.id,
+                positionHash: position.positionHash,
+            };
+            const response = createSuccessResponse(responseData);
+            apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+            return NextResponse.json(response, { status: 200 });
+        } catch (error) {
+            apiLog.methodError(
+                apiLogger,
+                'POST /api/v1/positions/uniswapv3-staking/discover',
+                error,
+                { requestId },
+            );
+
+            const message = error instanceof Error ? error.message : String(error);
+
+            // Service throws this when the address isn't a valid staking-vault contract.
+            if (message.startsWith('INVALID_VAULT_CONTRACT')) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.BAD_REQUEST,
+                    'Not a valid staking-vault contract',
+                    message,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.BAD_REQUEST],
+                });
+            }
+
+            if (message.includes('not configured') || message.includes('not supported')) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.CHAIN_NOT_SUPPORTED,
+                    'Chain not supported',
+                    message,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.CHAIN_NOT_SUPPORTED],
+                });
+            }
+
+            if (
+                message.includes('contract') ||
+                message.includes('RPC') ||
+                message.includes('Failed to read')
+            ) {
+                const errorResponse = createErrorResponse(
+                    ApiErrorCode.BAD_REQUEST,
+                    'Failed to read staking-vault data from blockchain',
+                    message,
+                );
+                apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+                return NextResponse.json(errorResponse, {
+                    status: ErrorCodeToHttpStatus[ApiErrorCode.BAD_REQUEST],
+                });
+            }
+
+            const errorResponse = createErrorResponse(
+                ApiErrorCode.INTERNAL_SERVER_ERROR,
+                'Failed to discover staking-vault position',
+                message,
+            );
+            apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+            return NextResponse.json(errorResponse, {
+                status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+            });
+        }
+    });
+}

--- a/apps/midcurve-api/src/lib/serializers.ts
+++ b/apps/midcurve-api/src/lib/serializers.ts
@@ -12,6 +12,8 @@ import type {
   UniswapV3PositionState,
   UniswapV3VaultPosition,
   UniswapV3VaultPositionState,
+  UniswapV3StakingPosition,
+  UniswapV3StakingPositionState,
   Erc20Token,
 } from '@midcurve/shared';
 import {
@@ -352,6 +354,106 @@ export function serializeUniswapV3VaultPosition(position: UniswapV3VaultPosition
       priceRangeUpper: position.typedConfig.priceRangeUpper.toString(),
     },
     state: serializeUniswapV3VaultPositionState(position.typedState),
+
+    // Timestamps
+    createdAt: position.createdAt.toISOString(),
+    updatedAt: position.updatedAt.toISOString(),
+  };
+}
+
+// ============================================================================
+// UNISWAPV3 STAKING VAULT POSITION SERIALIZATION
+// ============================================================================
+
+/**
+ * Serialize UniswapV3StakingPositionState for JSON response.
+ */
+export function serializeUniswapV3StakingPositionState(state: UniswapV3StakingPositionState) {
+  return {
+    vaultState: state.vaultState,
+    stakedBase: state.stakedBase.toString(),
+    stakedQuote: state.stakedQuote.toString(),
+    yieldTarget: state.yieldTarget.toString(),
+    pendingBps: state.pendingBps,
+    unstakeBufferBase: state.unstakeBufferBase.toString(),
+    unstakeBufferQuote: state.unstakeBufferQuote.toString(),
+    rewardBufferBase: state.rewardBufferBase.toString(),
+    rewardBufferQuote: state.rewardBufferQuote.toString(),
+    liquidity: state.liquidity.toString(),
+    isOwnedByUser: state.isOwnedByUser,
+    unclaimedYieldBase: state.unclaimedYieldBase.toString(),
+    unclaimedYieldQuote: state.unclaimedYieldQuote.toString(),
+    sqrtPriceX96: state.sqrtPriceX96.toString(),
+    currentTick: state.currentTick,
+    poolLiquidity: state.poolLiquidity.toString(),
+    feeGrowthGlobal0: state.feeGrowthGlobal0.toString(),
+    feeGrowthGlobal1: state.feeGrowthGlobal1.toString(),
+  };
+}
+
+/**
+ * Serialize UniswapV3StakingPosition for JSON response.
+ *
+ * Mirrors `serializeUniswapV3VaultPosition` but uses staking-specific
+ * config/state shapes.
+ */
+export function serializeUniswapV3StakingPosition(position: UniswapV3StakingPosition) {
+  return {
+    id: position.id,
+    positionHash: position.positionHash,
+    protocol: position.protocol as 'uniswapv3-staking',
+    ownerWallet: null as string | null,
+    userId: position.userId,
+    type: position.type,
+
+    // PnL fields
+    currentValue: position.currentValue.toString(),
+    costBasis: position.costBasis.toString(),
+    realizedPnl: position.realizedPnl.toString(),
+    unrealizedPnl: position.unrealizedPnl.toString(),
+    realizedCashflow: position.realizedCashflow.toString(),
+    unrealizedCashflow: position.unrealizedCashflow.toString(),
+
+    // Yield fields
+    collectedYield: position.collectedYield.toString(),
+    unclaimedYield: position.unclaimedYield.toString(),
+    lastYieldClaimedAt: position.lastYieldClaimedAt?.toISOString() ?? new Date(0).toISOString(),
+    totalApr: position.totalApr,
+    baseApr: position.baseApr ?? null,
+    rewardApr: position.rewardApr ?? null,
+
+    // Price range
+    priceRangeLower: position.priceRangeLower.toString(),
+    priceRangeUpper: position.priceRangeUpper.toString(),
+
+    // Pool (same underlying UniswapV3 pool)
+    pool: serializeUniswapV3Pool(position.pool as UniswapV3Pool),
+    isToken0Quote: position.isToken0Quote,
+
+    // Lifecycle
+    positionOpenedAt: position.positionOpenedAt.toISOString(),
+    archivedAt: position.archivedAt?.toISOString() ?? null,
+    isArchived: position.isArchived,
+
+    // Protocol-specific config
+    config: {
+      chainId: position.typedConfig.chainId,
+      vaultAddress: position.typedConfig.vaultAddress,
+      factoryAddress: position.typedConfig.factoryAddress,
+      ownerAddress: position.typedConfig.ownerAddress,
+      underlyingTokenId: position.typedConfig.underlyingTokenId,
+      isToken0Quote: position.typedConfig.isToken0Quote,
+      poolAddress: position.typedConfig.poolAddress,
+      token0Address: position.typedConfig.token0Address,
+      token1Address: position.typedConfig.token1Address,
+      feeBps: position.typedConfig.feeBps,
+      tickSpacing: position.typedConfig.tickSpacing,
+      tickLower: position.typedConfig.tickLower,
+      tickUpper: position.typedConfig.tickUpper,
+      priceRangeLower: position.typedConfig.priceRangeLower.toString(),
+      priceRangeUpper: position.typedConfig.priceRangeUpper.toString(),
+    },
+    state: serializeUniswapV3StakingPositionState(position.typedState),
 
     // Timestamps
     createdAt: position.createdAt.toISOString(),

--- a/apps/midcurve-api/src/lib/services.ts
+++ b/apps/midcurve-api/src/lib/services.ts
@@ -35,6 +35,9 @@ import {
   JournalService,
   UniswapV3VaultPositionService,
   UniswapV3VaultLedgerService,
+  UniswapV3StakingPositionService,
+  UniswapV3StakingLedgerService,
+  UniswapV3StakingAprService,
   UserWalletService,
   PoolSigmaFilterService,
   UserSettingsService,
@@ -63,6 +66,7 @@ let _webhookConfigService: WebhookConfigService | null = null;
 let _favoritePoolService: FavoritePoolService | null = null;
 let _swapRouterService: SwapRouterService | null = null;
 let _uniswapV3VaultPositionService: UniswapV3VaultPositionService | null = null;
+let _uniswapV3StakingPositionService: UniswapV3StakingPositionService | null = null;
 let _userWalletService: UserWalletService | null = null;
 let _userSettingsService: UserSettingsService | null = null;
 
@@ -314,6 +318,38 @@ export function getUniswapV3VaultPositionService(): UniswapV3VaultPositionServic
     _uniswapV3VaultPositionService = new UniswapV3VaultPositionService();
   }
   return _uniswapV3VaultPositionService;
+}
+
+// =============================================================================
+// UniswapV3 Staking Vault factories (SPEC-0003b PR4b)
+// =============================================================================
+
+/** Get singleton instance of `UniswapV3StakingPositionService`. */
+export function getUniswapV3StakingPositionService(): UniswapV3StakingPositionService {
+  if (!_uniswapV3StakingPositionService) {
+    _uniswapV3StakingPositionService = new UniswapV3StakingPositionService();
+  }
+  return _uniswapV3StakingPositionService;
+}
+
+/**
+ * Create a `UniswapV3StakingLedgerService` for a specific position.
+ * Not a singleton — each position requires its own scoped instance.
+ */
+export function getUniswapV3StakingPositionLedgerService(
+  positionId: string,
+): UniswapV3StakingLedgerService {
+  return new UniswapV3StakingLedgerService({ positionId });
+}
+
+/**
+ * Create a `UniswapV3StakingAprService` for a specific position.
+ * Not a singleton — each position requires its own scoped instance.
+ */
+export function getUniswapV3StakingAprService(
+  positionId: string,
+): UniswapV3StakingAprService {
+  return new UniswapV3StakingAprService({ positionId });
 }
 
 /**

--- a/packages/midcurve-api-shared/src/types/positions/index.ts
+++ b/packages/midcurve-api-shared/src/types/positions/index.ts
@@ -13,3 +13,6 @@ export * from './uniswapv3/index.js';
 
 // UniswapV3 Vault-specific types
 export * from './uniswapv3-vault/index.js';
+
+// UniswapV3 Staking Vault-specific types (SPEC-0003b)
+export * from './uniswapv3-staking/index.js';

--- a/packages/midcurve-api-shared/src/types/positions/uniswapv3-staking/get.ts
+++ b/packages/midcurve-api-shared/src/types/positions/uniswapv3-staking/get.ts
@@ -1,0 +1,50 @@
+/**
+ * GET /api/v1/positions/uniswapv3-staking/:chainId/:vaultAddress
+ *
+ * Fetches a specific UniswapV3 staking-vault position owned by the
+ * authenticated user. Vaults are owner-bound 1:1 (per SPEC-0003b §2),
+ * so the vault address alone disambiguates — no separate owner segment.
+ */
+
+import type { UniswapV3StakingPositionResponse } from './typed-response.js';
+import { z } from 'zod';
+
+/** Path parameters for fetching a specific UniswapV3 staking-vault position. */
+export interface GetUniswapV3StakingPositionParams {
+  /** EVM chain ID (e.g., 42161 for Arbitrum). */
+  chainId: string;
+  /** Vault contract address (EIP-55 checksummed). */
+  vaultAddress: string;
+}
+
+/** Success response for GET. Returns the complete staking-vault position. */
+export type GetUniswapV3StakingPositionResponse = UniswapV3StakingPositionResponse;
+
+// =============================================================================
+// Zod schema
+// =============================================================================
+
+export const GetUniswapV3StakingPositionParamsSchema = z.object({
+  chainId: z.string().transform((val, ctx) => {
+    const parsed = parseInt(val, 10);
+    if (isNaN(parsed) || parsed <= 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'chainId must be a valid positive integer',
+      });
+      return z.NEVER;
+    }
+    return parsed;
+  }),
+
+  vaultAddress: z
+    .string()
+    .regex(/^0x[0-9a-fA-F]{40}$/, 'vaultAddress must be a valid EVM address'),
+});
+
+export type GetUniswapV3StakingPositionParamsInput = z.input<
+  typeof GetUniswapV3StakingPositionParamsSchema
+>;
+export type GetUniswapV3StakingPositionParamsOutput = z.output<
+  typeof GetUniswapV3StakingPositionParamsSchema
+>;

--- a/packages/midcurve-api-shared/src/types/positions/uniswapv3-staking/index.ts
+++ b/packages/midcurve-api-shared/src/types/positions/uniswapv3-staking/index.ts
@@ -1,0 +1,9 @@
+/**
+ * UniswapV3 Staking Vault Position Types
+ *
+ * Re-exports all UniswapV3 staking-specific position types and schemas.
+ */
+
+export * from './get.js';
+export * from './response-types.js';
+export * from './typed-response.js';

--- a/packages/midcurve-api-shared/src/types/positions/uniswapv3-staking/response-types.ts
+++ b/packages/midcurve-api-shared/src/types/positions/uniswapv3-staking/response-types.ts
@@ -1,0 +1,53 @@
+/**
+ * UniswapV3 Staking Vault Protocol-Specific Response Types
+ *
+ * Wire shapes for `UniswapV3StakingVault` position config + state after
+ * BigIntToString transformation for API responses.
+ */
+
+/**
+ * UniswapV3 Staking Position Config as it appears in API responses.
+ * All fields are JSON-safe (no bigint).
+ */
+export interface UniswapV3StakingPositionConfigResponse {
+  chainId: number;
+  vaultAddress: string;
+  factoryAddress: string;
+  ownerAddress: string;
+  underlyingTokenId: number;
+  isToken0Quote: boolean;
+  poolAddress: string;
+  token0Address: string;
+  token1Address: string;
+  feeBps: number;
+  tickSpacing: number;
+  tickLower: number;
+  tickUpper: number;
+  priceRangeLower: string;
+  priceRangeUpper: string;
+}
+
+/**
+ * UniswapV3 Staking Position State as it appears in API responses.
+ * All bigint fields converted to strings.
+ */
+export interface UniswapV3StakingPositionStateResponse {
+  vaultState: 'Empty' | 'Staked' | 'FlashCloseInProgress' | 'Settled';
+  stakedBase: string;
+  stakedQuote: string;
+  yieldTarget: string;
+  pendingBps: number;
+  unstakeBufferBase: string;
+  unstakeBufferQuote: string;
+  rewardBufferBase: string;
+  rewardBufferQuote: string;
+  liquidity: string;
+  isOwnedByUser: boolean;
+  unclaimedYieldBase: string;
+  unclaimedYieldQuote: string;
+  sqrtPriceX96: string;
+  currentTick: number;
+  poolLiquidity: string;
+  feeGrowthGlobal0: string;
+  feeGrowthGlobal1: string;
+}

--- a/packages/midcurve-api-shared/src/types/positions/uniswapv3-staking/typed-response.ts
+++ b/packages/midcurve-api-shared/src/types/positions/uniswapv3-staking/typed-response.ts
@@ -1,0 +1,64 @@
+/**
+ * Strongly-typed UniswapV3StakingVault position response.
+ *
+ * Used by UI components consuming staking-vault position data from the API.
+ * Replaces the loosely-typed `Record<string, unknown>` config/state fields
+ * with protocol-specific interfaces.
+ */
+
+import type {
+  UniswapV3StakingPositionConfigResponse,
+  UniswapV3StakingPositionStateResponse,
+} from './response-types.js';
+
+import type { UniswapV3PoolResponse } from '../uniswapv3/typed-response.js';
+
+/**
+ * Complete UniswapV3 Staking Vault Position for API responses.
+ */
+export interface UniswapV3StakingPositionResponse {
+  // Identity
+  id: string;
+  positionHash: string;
+  userId: string;
+  ownerWallet: string | null;
+  protocol: 'uniswapv3-staking';
+  type: string;
+
+  // Pool reference (same underlying Uniswap V3 pool)
+  pool: UniswapV3PoolResponse;
+  isToken0Quote: boolean;
+
+  // PnL fields (bigint → string)
+  currentValue: string;
+  costBasis: string;
+  realizedPnl: string;
+  unrealizedPnl: string;
+  realizedCashflow: string;
+  unrealizedCashflow: string;
+
+  // Yield fields
+  collectedYield: string;
+  unclaimedYield: string;
+  lastYieldClaimedAt: string;
+  totalApr: number | null;
+  baseApr: number | null;
+  rewardApr: number | null;
+
+  // Price range (bigint → string)
+  priceRangeLower: string;
+  priceRangeUpper: string;
+
+  // Lifecycle
+  positionOpenedAt: string;
+  archivedAt: string | null;
+  isArchived: boolean;
+
+  // Protocol-specific (strongly typed)
+  config: UniswapV3StakingPositionConfigResponse;
+  state: UniswapV3StakingPositionStateResponse;
+
+  // Timestamps
+  createdAt: string;
+  updatedAt: string;
+}

--- a/packages/midcurve-services/src/services/position-apr/index.ts
+++ b/packages/midcurve-services/src/services/position-apr/index.ts
@@ -8,5 +8,11 @@ export {
     type UniswapV3AprServiceDependencies,
 } from './uniswapv3-apr-service.js';
 
+export {
+    UniswapV3StakingAprService,
+    type UniswapV3StakingAprServiceConfig,
+    type UniswapV3StakingAprServiceDependencies,
+} from './uniswapv3-staking-apr-service.js';
+
 // Re-export types for convenience
 export type { AprPeriodData } from '../types/position-apr/index.js';

--- a/packages/midcurve-services/src/services/position-apr/uniswapv3-staking-apr-service.test.ts
+++ b/packages/midcurve-services/src/services/position-apr/uniswapv3-staking-apr-service.test.ts
@@ -1,0 +1,178 @@
+/**
+ * UniswapV3StakingAprService — unit tests
+ *
+ * The APR service itself is a thin CRUD layer over `PositionAprPeriod`. The
+ * actual bracketing logic (periods bounded by `STAKING_DISPOSE` events) lives
+ * in `UniswapV3StakingLedgerService.recalculateAggregates` and is exercised
+ * via the ledger service test suite. These tests cover the CRUD surface and
+ * the `calculateSummary` math.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { prismaMock } = vi.hoisted(() => ({
+    prismaMock: {
+        positionAprPeriod: {
+            create: vi.fn(),
+            findMany: vi.fn(),
+            deleteMany: vi.fn(),
+        },
+        positionLedgerEvent: {
+            findUnique: vi.fn(),
+        },
+    },
+}));
+
+vi.mock('@midcurve/database', () => ({
+    prisma: prismaMock,
+    PrismaClient: class {},
+}));
+
+import { UniswapV3StakingAprService } from './uniswapv3-staking-apr-service.js';
+import type { AprPeriodData } from '../types/position-apr/index.js';
+
+const POSITION_ID = 'pos_staking_test';
+
+function makeStoredPeriod(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 'apr_1',
+        positionId: POSITION_ID,
+        startEventId: 'evt_start',
+        endEventId: 'evt_end',
+        startTimestamp: new Date('2026-01-01T00:00:00Z'),
+        endTimestamp: new Date('2026-01-08T00:00:00Z'),
+        durationSeconds: 7 * 86400,
+        costBasis: '1000000000', // 1000 USDC at 6 decimals
+        collectedYieldValue: '10000000', // 10 USDC
+        aprBps: 5217, // ~52% APR
+        eventCount: 5,
+        ...overrides,
+    };
+}
+
+describe('UniswapV3StakingAprService', () => {
+    let service: UniswapV3StakingAprService;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        prismaMock.positionAprPeriod.create.mockReset();
+        prismaMock.positionAprPeriod.findMany.mockReset().mockResolvedValue([]);
+        prismaMock.positionAprPeriod.deleteMany.mockReset().mockResolvedValue({ count: 0 });
+        prismaMock.positionLedgerEvent.findUnique.mockReset();
+        service = new UniswapV3StakingAprService({ positionId: POSITION_ID });
+    });
+
+    // -------------------------------------------------------------------------
+    // 1. persistAprPeriod
+    // -------------------------------------------------------------------------
+    it('persistAprPeriod — writes to PositionAprPeriod with correct fields', async () => {
+        const period: AprPeriodData = {
+            startEventId: 'evt_start',
+            endEventId: 'evt_end',
+            startTimestamp: new Date('2026-01-01T00:00:00Z'),
+            endTimestamp: new Date('2026-01-08T00:00:00Z'),
+            durationSeconds: 7 * 86400,
+            costBasis: 1000_000000n,
+            collectedYieldValue: 10_000000n,
+            aprBps: 5217,
+            eventCount: 5,
+        };
+
+        await service.persistAprPeriod(period);
+
+        expect(prismaMock.positionAprPeriod.create).toHaveBeenCalledTimes(1);
+        const args = prismaMock.positionAprPeriod.create.mock.calls[0]![0];
+        expect(args.data.positionId).toBe(POSITION_ID);
+        expect(args.data.startEventId).toBe('evt_start');
+        expect(args.data.endEventId).toBe('evt_end');
+        expect(args.data.costBasis).toBe('1000000000');
+        expect(args.data.collectedYieldValue).toBe('10000000');
+        expect(args.data.aprBps).toBe(5217);
+    });
+
+    // -------------------------------------------------------------------------
+    // 2. fetchAprPeriods — empty store
+    // -------------------------------------------------------------------------
+    it('fetchAprPeriods — empty store returns []', async () => {
+        prismaMock.positionAprPeriod.findMany.mockResolvedValue([]);
+
+        const periods = await service.fetchAprPeriods();
+        expect(periods).toEqual([]);
+        expect(prismaMock.positionAprPeriod.findMany).toHaveBeenCalledWith({
+            where: { positionId: POSITION_ID },
+            orderBy: { startTimestamp: 'desc' },
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // 3. fetchAprPeriods — bigint round-trip
+    // -------------------------------------------------------------------------
+    it('fetchAprPeriods — converts string columns back to bigint', async () => {
+        prismaMock.positionAprPeriod.findMany.mockResolvedValue([makeStoredPeriod()]);
+
+        const periods = await service.fetchAprPeriods();
+        expect(periods).toHaveLength(1);
+        expect(periods[0]!.costBasis).toBe(1000_000000n);
+        expect(periods[0]!.collectedYieldValue).toBe(10_000000n);
+        expect(typeof periods[0]!.costBasis).toBe('bigint');
+    });
+
+    // -------------------------------------------------------------------------
+    // 4. deleteAllAprPeriods
+    // -------------------------------------------------------------------------
+    it('deleteAllAprPeriods — deletes by positionId', async () => {
+        prismaMock.positionAprPeriod.deleteMany.mockResolvedValue({ count: 3 });
+
+        await service.deleteAllAprPeriods();
+        expect(prismaMock.positionAprPeriod.deleteMany).toHaveBeenCalledWith({
+            where: { positionId: POSITION_ID },
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // 5. calculateSummary — no periods → defaults to zeros + belowThreshold
+    // -------------------------------------------------------------------------
+    it('calculateSummary — no periods returns zero APR with belowThreshold=true', async () => {
+        prismaMock.positionAprPeriod.findMany.mockResolvedValue([]);
+
+        const summary = await service.calculateSummary({
+            positionOpenedAt: new Date(Date.now() - 1000), // 1s ago
+            costBasis: 1000_000000n,
+            unclaimedYield: 0n,
+        });
+
+        expect(summary.realizedFees).toBe(0n);
+        expect(summary.realizedApr).toBe(0);
+        expect(summary.totalApr).toBe(0);
+        expect(summary.belowThreshold).toBe(true); // 1s < 5min
+        expect(summary.rewardApr).toBe(0); // staking has no reward APR
+    });
+
+    // -------------------------------------------------------------------------
+    // 6. calculateSummary — single closed period
+    // -------------------------------------------------------------------------
+    it('calculateSummary — single period: realizedFees + realizedApr computed', async () => {
+        const oneWeekAgo = new Date(Date.now() - 7 * 86400 * 1000);
+        const halfWeekAgo = new Date(Date.now() - 3.5 * 86400 * 1000);
+        prismaMock.positionAprPeriod.findMany.mockResolvedValue([
+            makeStoredPeriod({
+                startTimestamp: oneWeekAgo,
+                endTimestamp: halfWeekAgo,
+                durationSeconds: 3.5 * 86400,
+            }),
+        ]);
+
+        const summary = await service.calculateSummary({
+            positionOpenedAt: oneWeekAgo,
+            costBasis: 1000_000000n,
+            unclaimedYield: 0n,
+        });
+
+        expect(summary.realizedFees).toBe(10_000000n);
+        expect(summary.realizedTWCostBasis).toBe(1000_000000n);
+        expect(summary.realizedActiveDays).toBeGreaterThan(0);
+        expect(summary.realizedApr).toBeGreaterThan(0);
+        expect(summary.totalApr).toBeGreaterThan(0);
+        expect(summary.belowThreshold).toBe(false);
+    });
+});

--- a/packages/midcurve-services/src/services/position-apr/uniswapv3-staking-apr-service.ts
+++ b/packages/midcurve-services/src/services/position-apr/uniswapv3-staking-apr-service.ts
@@ -1,0 +1,242 @@
+/**
+ * UniswapV3StakingAprService
+ *
+ * Handles APR period CRUD operations for UniswapV3StakingVault positions.
+ * Mirrors `UniswapV3AprService` (NFT canonical) with one semantic difference:
+ *
+ * **APR periods for staking are bracketed by `STAKING_DISPOSE` events**, not
+ * `COLLECT`. Staking has no separate fee-collection moment — yield is realized
+ * at swap settlement, so each `STAKING_DISPOSE` ledger event closes one APR
+ * period and starts the next. The bracketing happens during
+ * `UniswapV3StakingLedgerService.recalculateAggregates`; this service is the
+ * thin CRUD layer that persists / reads / deletes the resulting `PositionAprPeriod`
+ * rows and computes the running summary.
+ *
+ * Public surface mirrors `UniswapV3AprService`:
+ * - `fetchAprPeriods(blockNumber?)` — read periods
+ * - `persistAprPeriod(period)` — append a single period (called by the ledger
+ *    service mid-recalc as it crosses each STAKING_DISPOSE)
+ * - `deleteAllAprPeriods()` — wipe periods for this position
+ * - `calculateSummary({ positionOpenedAt, costBasis, unclaimedYield }, blockNumber?)`
+ *    — compute realized + unrealized + total APR (same shape as NFT/Vault)
+ */
+
+import { prisma as prismaClient, PrismaClient } from "@midcurve/database";
+import type { AprSummary } from "@midcurve/shared";
+import type { PrismaTransactionClient } from "../../clients/prisma/index.js";
+import type { AprPeriodData } from "../types/position-apr/index.js";
+
+// ============================================================================
+// SERVICE CONFIGURATION
+// ============================================================================
+
+export interface UniswapV3StakingAprServiceConfig {
+    /** Position ID that this service instance operates on. */
+    positionId: string;
+}
+
+export interface UniswapV3StakingAprServiceDependencies {
+    prisma?: PrismaClient;
+}
+
+// ============================================================================
+// SERVICE
+// ============================================================================
+
+export class UniswapV3StakingAprService {
+    private readonly prisma: PrismaClient;
+    readonly positionId: string;
+
+    constructor(
+        config: UniswapV3StakingAprServiceConfig,
+        dependencies: UniswapV3StakingAprServiceDependencies = {},
+    ) {
+        this.positionId = config.positionId;
+        this.prisma = dependencies.prisma ?? prismaClient;
+    }
+
+    /**
+     * Fetch APR periods up to a specific block.
+     *
+     * Returns periods where the endEvent's blockNumber <= the specified block.
+     * Periods are sorted by `startTimestamp` descending (newest first).
+     */
+    async fetchAprPeriods(
+        blockNumber: number | "latest" = "latest",
+        tx?: PrismaTransactionClient,
+    ): Promise<AprPeriodData[]> {
+        const db = tx ?? this.prisma;
+
+        const periods = await db.positionAprPeriod.findMany({
+            where: { positionId: this.positionId },
+            orderBy: { startTimestamp: "desc" },
+        });
+
+        if (blockNumber === "latest") {
+            return periods.map((period) => this.mapDbPeriodToAprPeriodData(period));
+        }
+
+        const filteredPeriods: AprPeriodData[] = [];
+        for (const period of periods) {
+            const endEvent = await db.positionLedgerEvent.findUnique({
+                where: { id: period.endEventId },
+            });
+            if (endEvent) {
+                const eventConfig = endEvent.config as { blockNumber: number };
+                if (eventConfig.blockNumber <= blockNumber) {
+                    filteredPeriods.push(this.mapDbPeriodToAprPeriodData(period));
+                }
+            }
+        }
+        return filteredPeriods;
+    }
+
+    /**
+     * Append a single APR period. Called by the ledger service's
+     * `recalculateAggregates` as it crosses each `STAKING_DISPOSE` event.
+     */
+    async persistAprPeriod(
+        period: AprPeriodData,
+        tx?: PrismaTransactionClient,
+    ): Promise<void> {
+        const db = tx ?? this.prisma;
+
+        await db.positionAprPeriod.create({
+            data: {
+                positionId: this.positionId,
+                startEventId: period.startEventId,
+                endEventId: period.endEventId,
+                startTimestamp: period.startTimestamp,
+                endTimestamp: period.endTimestamp,
+                durationSeconds: period.durationSeconds,
+                costBasis: period.costBasis.toString(),
+                collectedYieldValue: period.collectedYieldValue.toString(),
+                aprBps: period.aprBps,
+                eventCount: period.eventCount,
+            },
+        });
+    }
+
+    /** Wipe all APR periods for this position. Called at the start of recalc. */
+    async deleteAllAprPeriods(tx?: PrismaTransactionClient): Promise<void> {
+        const db = tx ?? this.prisma;
+
+        await db.positionAprPeriod.deleteMany({
+            where: { positionId: this.positionId },
+        });
+    }
+
+    /**
+     * Compute realized + unrealized + total APR.
+     *
+     * Realized = bracketed periods bounded by STAKING_DISPOSE events.
+     * Unrealized = unclaimedYield since the last dispose (passed in by caller;
+     * staking currently has `unclaimedYield = 0n` until contract issue #69 lands).
+     */
+    async calculateSummary(
+        params: {
+            positionOpenedAt: Date;
+            costBasis: bigint;
+            unclaimedYield: bigint;
+        },
+        blockNumber: number | "latest" = "latest",
+        tx?: PrismaTransactionClient,
+    ): Promise<AprSummary> {
+        const aprPeriods = await this.fetchAprPeriods(blockNumber, tx);
+
+        // Realized metrics from completed APR periods.
+        let realizedFees = 0n;
+        let realizedWeightedCostBasisSum = 0n;
+        let realizedTotalSeconds = 0;
+
+        for (const period of aprPeriods) {
+            realizedFees += period.collectedYieldValue;
+            realizedWeightedCostBasisSum +=
+                period.costBasis * BigInt(period.durationSeconds);
+            realizedTotalSeconds += period.durationSeconds;
+        }
+
+        const realizedTWCostBasis =
+            realizedTotalSeconds > 0
+                ? realizedWeightedCostBasisSum / BigInt(realizedTotalSeconds)
+                : 0n;
+        const realizedActiveDays = realizedTotalSeconds / 86400;
+        const realizedApr =
+            realizedTWCostBasis > 0n && realizedActiveDays > 0
+                ? (Number(realizedFees) / Number(realizedTWCostBasis)) *
+                  (365 / realizedActiveDays) *
+                  100
+                : 0;
+
+        // Unrealized metrics from current state (since the most recent period end).
+        const unrealizedFees = params.unclaimedYield;
+        const unrealizedCostBasis = params.costBasis;
+        const firstPeriod = aprPeriods[0];
+        const lastPeriodEnd = firstPeriod
+            ? firstPeriod.endTimestamp
+            : params.positionOpenedAt;
+        const unrealizedSeconds = Math.max(
+            0,
+            (Date.now() - lastPeriodEnd.getTime()) / 1000,
+        );
+        const unrealizedActiveDays = unrealizedSeconds / 86400;
+        const unrealizedApr =
+            unrealizedCostBasis > 0n && unrealizedActiveDays > 0
+                ? (Number(unrealizedFees) / Number(unrealizedCostBasis)) *
+                  (365 / unrealizedActiveDays) *
+                  100
+                : 0;
+
+        // Time-weighted total APR.
+        const totalActiveDays = realizedActiveDays + unrealizedActiveDays;
+        const totalApr =
+            totalActiveDays > 0
+                ? (realizedApr * realizedActiveDays +
+                      unrealizedApr * unrealizedActiveDays) /
+                  totalActiveDays
+                : 0;
+
+        // Minimum threshold: 5 minutes of active duration.
+        const belowThreshold = totalActiveDays < 0.00347;
+
+        return {
+            realizedFees,
+            realizedTWCostBasis,
+            realizedActiveDays: Math.round(realizedActiveDays * 10) / 10,
+            realizedApr,
+            unrealizedFees,
+            unrealizedCostBasis,
+            unrealizedActiveDays: Math.round(unrealizedActiveDays * 10) / 10,
+            unrealizedApr,
+            totalApr,
+            baseApr: totalApr,
+            rewardApr: 0,
+            totalActiveDays: Math.round(totalActiveDays * 10) / 10,
+            belowThreshold,
+        };
+    }
+
+    private mapDbPeriodToAprPeriodData(period: {
+        startEventId: string;
+        endEventId: string;
+        startTimestamp: Date;
+        endTimestamp: Date;
+        durationSeconds: number;
+        costBasis: string;
+        collectedYieldValue: string;
+        aprBps: number;
+        eventCount: number;
+    }): AprPeriodData {
+        return {
+            startEventId: period.startEventId,
+            endEventId: period.endEventId,
+            startTimestamp: period.startTimestamp,
+            endTimestamp: period.endTimestamp,
+            durationSeconds: period.durationSeconds,
+            costBasis: BigInt(period.costBasis),
+            collectedYieldValue: BigInt(period.collectedYieldValue),
+            aprBps: period.aprBps,
+            eventCount: period.eventCount,
+        };
+    }
+}

--- a/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.test.ts
+++ b/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.test.ts
@@ -94,9 +94,41 @@ interface StoredEvent {
     state: Record<string, unknown>;
 }
 
+interface StoredAprPeriod {
+    id: string;
+    positionId: string;
+    startEventId: string;
+    endEventId: string;
+    startTimestamp: Date;
+    endTimestamp: Date;
+    durationSeconds: number;
+    costBasis: string;
+    collectedYieldValue: string;
+    aprBps: number;
+    eventCount: number;
+}
+
 class FakePrisma {
     public store: StoredEvent[] = [];
+    public aprStore: StoredAprPeriod[] = [];
     private nextId = 1;
+    private nextAprId = 1;
+
+    positionAprPeriod = {
+        create: vi.fn(async ({ data }: { data: any }) => {
+            const row: StoredAprPeriod = { id: `apr_${this.nextAprId++}`, ...data };
+            this.aprStore.push(row);
+            return row;
+        }),
+        findMany: vi.fn(async ({ where }: any) => {
+            return this.aprStore.filter((e) => e.positionId === where.positionId);
+        }),
+        deleteMany: vi.fn(async ({ where }: any) => {
+            const before = this.aprStore.length;
+            this.aprStore = this.aprStore.filter((e) => e.positionId !== where.positionId);
+            return { count: before - this.aprStore.length };
+        }),
+    };
 
     positionLedgerEvent = {
         create: vi.fn(async ({ data }: { data: any }) => {
@@ -935,6 +967,115 @@ describe('UniswapV3StakingLedgerService', () => {
             // deltaPnl = 4500 - 1500 = 3000 (purely principal-floor gain)
             expect(BigInt(dispose.deltaPnl)).toBeGreaterThan(0n);
             expect(dispose.deltaCollectedYield).toBe('0');
+        });
+    });
+
+    // ============================================================================
+    // PR4b — APR period bracketing (added by recalculateAggregates)
+    // ============================================================================
+
+    describe('APR period tracking', () => {
+        it('Stake → Dispose → persists exactly one APR period bracketed by the dispose', async () => {
+            const stake = makeStakeLog(100n, '0xtxA', '0xblkA', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const swap = makeSwapLog(200n, '0xtxB', '0xblkB', 0, {
+                tokenIn: TOKEN1, amountIn: 250n, tokenOut: TOKEN0, amountOut: 250n,
+                effectiveBps: 5000,
+                chainContext: {
+                    stakedBaseBefore: 1000n, stakedQuoteBefore: 500n,
+                    rewardBufferBaseDelta: 50n, rewardBufferQuoteDelta: 25n,
+                    liquidityAfter: 500_000n,
+                },
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake, swap], poolPriceService,
+            );
+
+            // recalculateAggregates ran during importLogsForPosition (post pass).
+            // Expect exactly one APR period whose endTimestamp matches the dispose.
+            expect(fake.aprStore).toHaveLength(1);
+            const period = fake.aprStore[0]!;
+            expect(period.collectedYieldValue).toBe('75'); // yieldQuoteValue from dispose: 50*1 + 25 = 75
+            expect(period.eventCount).toBeGreaterThanOrEqual(1);
+            // The period brackets at the dispose — endEventId points at the swap's ledger event.
+            const swapRow = fake.store.find((e) => e.eventType === 'STAKING_DISPOSE');
+            expect(period.endEventId).toBe(swapRow!.id);
+        });
+
+        it('Stake-only (no dispose) → no APR periods persisted', async () => {
+            const stake = makeStakeLog(100n, '0xtxA', '0xblkA', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake], poolPriceService,
+            );
+            expect(fake.aprStore).toHaveLength(0);
+        });
+
+        it('multiple disposes → one APR period per dispose; sum of collectedYieldValue matches ledger total', async () => {
+            const stake = makeStakeLog(100n, '0xtxA', '0xblkA', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const swap1 = makeSwapLog(200n, '0xtx1', '0xblk1', 0, {
+                tokenIn: TOKEN1, amountIn: 0n, tokenOut: TOKEN0, amountOut: 0n,
+                effectiveBps: 2500,
+                chainContext: {
+                    stakedBaseBefore: 1000n, stakedQuoteBefore: 500n,
+                    rewardBufferBaseDelta: 30n, rewardBufferQuoteDelta: 10n, // yield = 40
+                    liquidityAfter: 750_000n,
+                },
+            });
+            const swap2 = makeSwapLog(300n, '0xtx2', '0xblk2', 0, {
+                tokenIn: TOKEN1, amountIn: 0n, tokenOut: TOKEN0, amountOut: 0n,
+                effectiveBps: 5000,
+                chainContext: {
+                    stakedBaseBefore: 1000n, stakedQuoteBefore: 500n,
+                    rewardBufferBaseDelta: 20n, rewardBufferQuoteDelta: 15n, // yield = 35
+                    liquidityAfter: 375_000n,
+                },
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake, swap1, swap2], poolPriceService,
+            );
+
+            expect(fake.aprStore).toHaveLength(2);
+            const totalYield = fake.aprStore.reduce(
+                (sum, p) => sum + BigInt(p.collectedYieldValue),
+                0n,
+            );
+            // Yield total across both periods = 40 + 35 = 75.
+            expect(totalYield).toBe(75n);
+        });
+
+        it('rerun (idempotency at recalc level) — old periods wiped before regen', async () => {
+            const stake = makeStakeLog(100n, '0xtxA', '0xblkA', 0, {
+                base: 1000n, quote: 500n, yieldTarget: 100n, tokenId: 42n,
+                chainContext: { vaultStateBefore: 'Empty', liquidityAfter: 1_000_000n },
+            });
+            const swap = makeSwapLog(200n, '0xtxB', '0xblkB', 0, {
+                tokenIn: TOKEN1, amountIn: 0n, tokenOut: TOKEN0, amountOut: 0n,
+                effectiveBps: 5000,
+                chainContext: {
+                    stakedBaseBefore: 1000n, stakedQuoteBefore: 500n,
+                    rewardBufferBaseDelta: 50n, rewardBufferQuoteDelta: 25n,
+                    liquidityAfter: 500_000n,
+                },
+            });
+
+            await service.importLogsForPosition(
+                POSITION_CONTEXT, CHAIN_ID, OWNER_ADDRESS, [stake, swap], poolPriceService,
+            );
+            const after1 = fake.aprStore.length;
+
+            // Re-run recalc directly — should wipe + regenerate, not duplicate.
+            await service.recalculateAggregates(false);
+            expect(fake.aprStore.length).toBe(after1); // same count, not 2x
         });
     });
 

--- a/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.ts
+++ b/packages/midcurve-services/src/services/position-ledger/uniswapv3-staking-ledger-service.ts
@@ -51,6 +51,13 @@ import type {
     PositionLedgerEventPayload,
     PositionLiquidityRevertedPayload,
 } from '../../events/types.js';
+import { UniswapV3StakingAprService } from '../position-apr/uniswapv3-staking-apr-service.js';
+import {
+    calculateAprBps,
+    calculateDurationSeconds,
+    calculateTimeWeightedCostBasis,
+} from '../../utils/apr/apr-calculations.js';
+import type { AprPeriodData } from '../types/position-apr/index.js';
 
 // ============================================================================
 // EVENT SIGNATURES
@@ -571,6 +578,7 @@ export class UniswapV3StakingLedgerService {
     private readonly positionId: string;
     private readonly protocol = 'uniswapv3-staking' as const;
     private readonly logger: ServiceLogger;
+    private readonly _aprService: UniswapV3StakingAprService;
 
     constructor(
         config: UniswapV3StakingLedgerServiceConfig,
@@ -579,6 +587,10 @@ export class UniswapV3StakingLedgerService {
         this.positionId = config.positionId;
         this.prisma = deps.prisma ?? prismaClient;
         this.logger = createServiceLogger('uniswapv3-staking-ledger');
+        this._aprService = new UniswapV3StakingAprService(
+            { positionId: config.positionId },
+            { prisma: this.prisma },
+        );
     }
 
     // ============================================================================
@@ -1237,6 +1249,8 @@ export class UniswapV3StakingLedgerService {
         const events = await this.findAll(tx);
 
         if (events.length === 0) {
+            // Wipe APR periods — there's nothing to bracket. Mirrors NFT/Vault.
+            await this._aprService.deleteAllAprPeriods(tx);
             return {
                 liquidityAfter: 0n,
                 costBasisAfter: 0n,
@@ -1248,11 +1262,23 @@ export class UniswapV3StakingLedgerService {
 
         UniswapV3StakingLedgerService.sortByBlockchainCoordinates(events);
 
+        // Wipe existing APR periods — we'll regenerate them as we walk the chain.
+        await this._aprService.deleteAllAprPeriods(tx);
+
         let liquidityAfter = 0n;
         let costBasisAfter = 0n;
         let pnlAfter = 0n;
         let collectedYieldAfter = 0n;
         let previousEventId: string | null = null;
+
+        // APR period tracking — bracketed by STAKING_DISPOSE events.
+        // Staking has no separate fee-collection moment; yield is realized at
+        // each dispose. So each STAKING_DISPOSE closes one period and opens
+        // the next. The first period opens at the first event in the chain.
+        let periodStartTimestamp: Date | null = null;
+        let periodStartEventId: string | null = null;
+        let periodCostBasisSnapshots: Array<{ timestamp: Date; costBasisAfter: bigint }> = [];
+        let periodEventCount = 0;
 
         for (const event of events) {
             const state = event.typedState;
@@ -1301,6 +1327,48 @@ export class UniswapV3StakingLedgerService {
                     liquidityAfter = previousLiquidity;
                     break;
                 }
+            }
+
+            // APR period accumulation — open period if not already open.
+            if (periodStartTimestamp === null) {
+                periodStartTimestamp = event.timestamp;
+                periodStartEventId = event.id;
+            }
+            periodCostBasisSnapshots.push({ timestamp: event.timestamp, costBasisAfter });
+            periodEventCount++;
+
+            // STAKING_DISPOSE closes the current APR period.
+            if (state.eventType === 'STAKING_DISPOSE') {
+                if (periodStartTimestamp && periodCostBasisSnapshots.length >= 2) {
+                    try {
+                        const timeWeightedCostBasis = calculateTimeWeightedCostBasis(periodCostBasisSnapshots);
+                        const durationSeconds = calculateDurationSeconds(periodStartTimestamp, event.timestamp);
+                        const aprBps =
+                            durationSeconds > 0 && timeWeightedCostBasis > 0n
+                                ? calculateAprBps(deltaCollectedYield, timeWeightedCostBasis, durationSeconds)
+                                : 0;
+
+                        const aprPeriod: AprPeriodData = {
+                            startEventId: periodStartEventId!,
+                            endEventId: event.id,
+                            startTimestamp: periodStartTimestamp,
+                            endTimestamp: event.timestamp,
+                            durationSeconds,
+                            costBasis: timeWeightedCostBasis,
+                            collectedYieldValue: deltaCollectedYield,
+                            aprBps,
+                            eventCount: periodEventCount,
+                        };
+                        await this._aprService.persistAprPeriod(aprPeriod, tx);
+                    } catch (e) {
+                        this.logger.warn({ error: e }, 'Skipping invalid APR period');
+                    }
+                }
+                // Open the next period at this event.
+                periodStartTimestamp = event.timestamp;
+                periodStartEventId = event.id;
+                periodCostBasisSnapshots = [{ timestamp: event.timestamp, costBasisAfter }];
+                periodEventCount = 0;
             }
 
             await this.updateEventAggregates(

--- a/packages/midcurve-services/src/services/position-list/position-list-service.test.ts
+++ b/packages/midcurve-services/src/services/position-list/position-list-service.test.ts
@@ -191,6 +191,58 @@ describe('PositionListService', () => {
     );
   });
 
+  it('smoke: uniswapv3-staking row passes through findMany + pool enrichment', async () => {
+    // SPEC-0003b PR4b refinement #4 — staking positions have the same
+    // pool-config primitives as uniswapv3/uniswapv3-vault, so the lean list
+    // path and the includePool enrichment must work without protocol-specific
+    // branches. State (yieldTarget, vaultState) intentionally lives only on
+    // the protocol-specific detail endpoint, not on PositionListRow.
+    const stakingRow = {
+      ...baseRow,
+      id: 'cuid_v3_staking',
+      positionHash: 'uniswapv3-staking/8453/0xVAULT',
+      protocol: 'uniswapv3-staking',
+      type: 'STAKING_VAULT',
+      config: {
+        chainId: 8453,
+        vaultAddress: '0x000000000000000000000000000000000000Va01',
+        poolAddress: POOL_WETH_USDC_BASE,
+        token0Address: WETH_BASE,
+        token1Address: USDC_BASE,
+        feeBps: 500,
+        tickSpacing: 10,
+        tickLower: 200820,
+        tickUpper: 200920,
+        isToken0Quote: false,
+        priceRangeLower: '0',
+        priceRangeUpper: '0',
+      },
+    };
+
+    vi.mocked(mockPrisma.position.findMany).mockResolvedValue([stakingRow] as any);
+    vi.mocked(mockPrisma.position.count).mockResolvedValue(1);
+    vi.mocked(mockPrisma.token.findMany).mockResolvedValue(
+      tokenRows.filter((t) =>
+        t.tokenHash === `erc20/8453/${WETH_BASE}` ||
+        t.tokenHash === `erc20/8453/${USDC_BASE}`,
+      ) as any,
+    );
+
+    const result = await service.list('user_1', { includePool: true });
+
+    expect(result.positions).toHaveLength(1);
+    const [row] = result.positions;
+    expect(row.protocol).toBe('uniswapv3-staking');
+    expect(row.pool).toEqual({
+      chainId: 8453,
+      poolAddress: POOL_WETH_USDC_BASE,
+      feeBps: 500,
+      isToken0Quote: false,
+      token0: { address: WETH_BASE, symbol: 'WETH', decimals: 18 },
+      token1: { address: USDC_BASE, symbol: 'USDC', decimals: 6 },
+    });
+  });
+
   it('skips token lookup entirely when result set is empty', async () => {
     vi.mocked(mockPrisma.position.findMany).mockResolvedValue([] as any);
     vi.mocked(mockPrisma.position.count).mockResolvedValue(0);

--- a/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.test.ts
+++ b/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.test.ts
@@ -30,12 +30,31 @@ const { prismaMock, mockCreateAndPublish, mockLedgerInstance } = vi.hoisted(() =
         positionLedgerEvent: {
             findFirst: vi.fn(),
         },
+        positionAprPeriod: {
+            findMany: vi.fn(async () => []),
+            create: vi.fn(),
+            deleteMany: vi.fn(async () => ({ count: 0 })),
+        },
         token: { findUnique: vi.fn() },
         $transaction: vi.fn(),
     },
     mockCreateAndPublish: vi.fn(async () => 'evt_id'),
     mockLedgerInstance: {
-        syncFromChain: vi.fn(async () => ({ perLogResults: [], allDeletedEvents: [] })),
+        // PR2 → PR4b: syncFromChain returns the import result; PR4b's
+        // refresh()/reset() thread `postImportAggregates` to refreshOnChainState
+        // so the position service skips a redundant recalculateAggregates pass.
+        syncFromChain: vi.fn(async () => ({
+            perLogResults: [],
+            allDeletedEvents: [],
+            preImportAggregates: {
+                liquidityAfter: 0n, costBasisAfter: 0n, realizedPnlAfter: 0n,
+                collectedYieldAfter: 0n, realizedCashflowAfter: 0n,
+            },
+            postImportAggregates: {
+                liquidityAfter: 0n, costBasisAfter: 0n, realizedPnlAfter: 0n,
+                collectedYieldAfter: 0n, realizedCashflowAfter: 0n,
+            },
+        })),
         deleteAll: vi.fn(async () => undefined),
         recalculateAggregates: vi.fn(async () => ({
             liquidityAfter: 0n,
@@ -358,22 +377,28 @@ describe('UniswapV3StakingPositionService', () => {
         vi.clearAllMocks();
         // Reset hoisted mocks (vi.clearAllMocks doesn't reach them)
         mockCreateAndPublish.mockReset().mockResolvedValue('evt_id');
-        mockLedgerInstance.syncFromChain.mockReset().mockResolvedValue({
-            perLogResults: [], allDeletedEvents: [],
-        });
-        mockLedgerInstance.deleteAll.mockReset().mockResolvedValue(undefined);
-        mockLedgerInstance.recalculateAggregates.mockReset().mockResolvedValue({
+        const zeroAggregates = {
             liquidityAfter: 0n,
             costBasisAfter: 0n,
             realizedPnlAfter: 0n,
             collectedYieldAfter: 0n,
             realizedCashflowAfter: 0n,
+        };
+        mockLedgerInstance.syncFromChain.mockReset().mockResolvedValue({
+            perLogResults: [], allDeletedEvents: [],
+            preImportAggregates: zeroAggregates,
+            postImportAggregates: zeroAggregates,
         });
+        mockLedgerInstance.deleteAll.mockReset().mockResolvedValue(undefined);
+        mockLedgerInstance.recalculateAggregates.mockReset().mockResolvedValue(zeroAggregates);
         prismaMock.position.findFirst.mockReset();
         prismaMock.position.create.mockReset();
         prismaMock.position.update.mockReset().mockResolvedValue(makePositionRow());
         prismaMock.position.delete.mockReset();
         prismaMock.positionLedgerEvent.findFirst.mockReset().mockResolvedValue(null);
+        prismaMock.positionAprPeriod.findMany.mockReset().mockResolvedValue([]);
+        prismaMock.positionAprPeriod.create.mockReset();
+        prismaMock.positionAprPeriod.deleteMany.mockReset().mockResolvedValue({ count: 0 });
         prismaMock.token.findUnique.mockReset().mockImplementation(async (q: any) => {
             const hash = q.where.tokenHash as string;
             const addr = hash.split('/').pop()!;
@@ -441,7 +466,13 @@ describe('UniswapV3StakingPositionService', () => {
 
         const result = await service.discoverWalletPositions(USER_ID, OWNER_ADDRESS, [CHAIN_ID]);
 
-        expect(result).toEqual({ found: 0, imported: 0, skipped: 0, errors: 0 });
+        expect(result).toEqual({
+            positions: [],
+            found: 0,
+            imported: 0,
+            skipped: 0,
+            errors: 0,
+        });
     });
 
     // -------------------------------------------------------------------------
@@ -609,6 +640,10 @@ describe('UniswapV3StakingPositionService', () => {
         await service.refresh(POSITION_ID);
         const initialSyncCalls = mockLedgerInstance.syncFromChain.mock.calls.length;
 
+        // Reset the recalc-call counter so the threading assertion below is
+        // scoped to just the reset() invocation, not the prior refresh().
+        mockLedgerInstance.recalculateAggregates.mockClear();
+
         await service.reset(POSITION_ID);
 
         expect(mockLedgerInstance.syncFromChain.mock.calls.length).toBe(initialSyncCalls + 1);
@@ -619,6 +654,21 @@ describe('UniswapV3StakingPositionService', () => {
             (c) => c[0].type === 'position.liquidity.reverted',
         ).length;
         expect(revertCount).toBe(0);
+
+        // PR4a review point #4 / PR4b — recalc-threading invariant.
+        // After reset:
+        //   - syncFromChain returns a stub StakingImportLogsResult with
+        //     `postImportAggregates` (mocked above).
+        //   - reset() threads that into refreshOnChainState, which must NOT
+        //     call recalculateAggregates itself (it consumes the threaded value).
+        // The fetchAprSummary path inside reset doesn't run, but
+        // refreshOnChainState's own recalc — the one we're optimizing away —
+        // is what we're asserting absence of.
+        //
+        // Note: the position service's `fetchAprSummary` (a separate REST entry
+        // point) DOES still call recalculateAggregates; that's not in scope
+        // here because reset() doesn't invoke it.
+        expect(mockLedgerInstance.recalculateAggregates).not.toHaveBeenCalled();
     });
 
     // -------------------------------------------------------------------------

--- a/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.ts
+++ b/packages/midcurve-services/src/services/position/uniswapv3-staking-position-service.ts
@@ -62,7 +62,13 @@ import { UniswapV3PoolService } from '../pool/uniswapv3-pool-service.js';
 import type { PrismaTransactionClient } from '../../clients/prisma/index.js';
 import { EvmBlockService } from '../block/evm-block-service.js';
 import { UniswapV3PoolPriceService } from '../pool-price/uniswapv3-pool-price-service.js';
-import { UniswapV3StakingLedgerService } from '../position-ledger/uniswapv3-staking-ledger-service.js';
+import {
+    UniswapV3StakingLedgerService,
+    type StakingImportLogsResult,
+    type StakingLedgerAggregates,
+} from '../position-ledger/uniswapv3-staking-ledger-service.js';
+import { UniswapV3StakingAprService } from '../position-apr/uniswapv3-staking-apr-service.js';
+import type { AprSummary } from '@midcurve/shared';
 import { CacheService } from '../cache/index.js';
 import { SharedContractService } from '../automation/shared-contract-service.js';
 import { Erc20TokenService } from '../token/erc20-token-service.js';
@@ -486,9 +492,16 @@ export class UniswapV3StakingPositionService {
         userId: string,
         walletAddress: string,
         chainIds?: number[],
-    ): Promise<{ found: number; imported: number; skipped: number; errors: number }> {
+    ): Promise<{
+        positions: UniswapV3StakingPosition[];
+        found: number;
+        imported: number;
+        skipped: number;
+        errors: number;
+    }> {
         const supportedChains = chainIds ?? this._evmConfig.getSupportedChainIds();
         const ownerAddress = normalizeAddress(walletAddress);
+        const positions: UniswapV3StakingPosition[] = [];
         let found = 0;
         let imported = 0;
         let skipped = 0;
@@ -534,7 +547,11 @@ export class UniswapV3StakingPositionService {
                 }
 
                 try {
-                    await this.discover(userId, { chainId, vaultAddress: vaultAddr });
+                    const newPosition = await this.discover(userId, {
+                        chainId,
+                        vaultAddress: vaultAddr,
+                    });
+                    positions.push(newPosition);
                     imported++;
                 } catch (e) {
                     this.logger.warn(
@@ -546,7 +563,7 @@ export class UniswapV3StakingPositionService {
             }
         }
 
-        return { found, imported, skipped, errors };
+        return { positions, found, imported, skipped, errors };
     }
 
     // =========================================================================
@@ -567,8 +584,12 @@ export class UniswapV3StakingPositionService {
         blockNumber: number | 'latest' = 'latest',
         dbTx?: PrismaTransactionClient,
     ): Promise<UniswapV3StakingPosition> {
-        await this.refreshAllPositionLogs(id, blockNumber, dbTx);
-        return this.refreshOnChainState(id, blockNumber, dbTx);
+        // Recalc-threading optimization (PR4a review point #4):
+        // syncFromChain already runs recalculateAggregates pre+post; we thread
+        // the post result into refreshOnChainState so it doesn't run a third
+        // pass.
+        const importResult = await this.refreshAllPositionLogs(id, blockNumber, dbTx);
+        return this.refreshOnChainState(id, blockNumber, dbTx, importResult.postImportAggregates);
     }
 
     // =========================================================================
@@ -609,13 +630,50 @@ export class UniswapV3StakingPositionService {
         await ledgerService.deleteAll(dbTx);
 
         // Reimport — emits `position.liquidity.{increased,decreased}` for PR3 to rebuild.
-        await this.refreshAllPositionLogs(id, 'latest', dbTx);
-        return this.refreshOnChainState(id, 'latest', dbTx);
+        // Same recalc-threading optimization as `refresh()` (PR4a review point #4).
+        const importResult = await this.refreshAllPositionLogs(id, 'latest', dbTx);
+        return this.refreshOnChainState(id, 'latest', dbTx, importResult.postImportAggregates);
     }
 
     // =========================================================================
     // FETCH METRICS (non-persisted)
     // =========================================================================
+
+    /**
+     * Compute APR summary for the position using the staking APR service.
+     * Used by the `/apr` REST endpoint (PR4b).
+     */
+    async fetchAprSummary(
+        id: string,
+        blockNumber: number | 'latest' = 'latest',
+        tx?: PrismaTransactionClient,
+    ): Promise<AprSummary> {
+        const position = await this.findById(id, tx);
+        if (!position) throw new Error(`Staking-vault position not found: ${id}`);
+
+        const ledgerService = new UniswapV3StakingLedgerService(
+            { positionId: id },
+            { prisma: this.prisma },
+        );
+        const aggregates = await ledgerService.recalculateAggregates(
+            position.isToken0Quote,
+            tx,
+        );
+
+        const aprService = new UniswapV3StakingAprService(
+            { positionId: id },
+            { prisma: this.prisma },
+        );
+        return aprService.calculateSummary(
+            {
+                positionOpenedAt: position.positionOpenedAt,
+                costBasis: aggregates.costBasisAfter,
+                unclaimedYield: 0n, // PR4a limitation — see fetchMetrics
+            },
+            blockNumber,
+            tx,
+        );
+    }
 
     async fetchMetrics(
         id: string,
@@ -691,7 +749,7 @@ export class UniswapV3StakingPositionService {
         id: string,
         blockNumber: number | 'latest' = 'latest',
         dbTx?: PrismaTransactionClient,
-    ): Promise<void> {
+    ): Promise<StakingImportLogsResult> {
         const position = await this.findById(id, dbTx);
         if (!position) throw new Error(`Staking-vault position not found: ${id}`);
 
@@ -702,8 +760,10 @@ export class UniswapV3StakingPositionService {
 
         // PR2's syncFromChain handles: block-range resolution, log fetching,
         // chain-context population, ledger import, AND domain event publishing.
-        // The position service is a thin orchestration layer here.
-        await ledgerService.syncFromChain(
+        // The position service is a thin orchestration layer here. Returns the
+        // import result so callers can thread `postImportAggregates` to
+        // `refreshOnChainState` and skip a redundant recalculateAggregates pass.
+        return await ledgerService.syncFromChain(
             position,
             this._evmConfig,
             this._poolPriceService,
@@ -723,6 +783,7 @@ export class UniswapV3StakingPositionService {
         id: string,
         blockNumber: number | 'latest' = 'latest',
         dbTx?: PrismaTransactionClient,
+        precomputedAggregates?: StakingLedgerAggregates,
     ): Promise<UniswapV3StakingPosition> {
         const position = await this.findById(id, dbTx);
         if (!position) throw new Error(`Staking-vault position not found: ${id}`);
@@ -766,14 +827,17 @@ export class UniswapV3StakingPositionService {
 
         const unclaimedYield = 0n; // see comment above
 
+        // Recalc-threading optimization (PR4a review point #4): when called from
+        // refresh()/reset(), syncFromChain has already run recalculateAggregates
+        // (pre + post). Use the threaded `postImportAggregates` and skip the
+        // redundant pass. Direct callers (e.g. integration tests) can omit the
+        // param and we'll fetch aggregates ourselves.
         const ledgerService = new UniswapV3StakingLedgerService(
             { positionId: id },
             { prisma: this.prisma },
         );
-        const aggregates = await ledgerService.recalculateAggregates(
-            position.isToken0Quote,
-            dbTx,
-        );
+        const aggregates = precomputedAggregates
+            ?? await ledgerService.recalculateAggregates(position.isToken0Quote, dbTx);
 
         const unrealizedPnl = currentValue - aggregates.costBasisAfter;
 
@@ -785,6 +849,19 @@ export class UniswapV3StakingPositionService {
             select: { timestamp: true },
         });
         const correctedOpenedAt = firstEvent?.timestamp ?? position.positionOpenedAt;
+
+        // APR summary — use the staking APR service, fed by the periods that
+        // recalculateAggregates persisted for this position.
+        const aprService = new UniswapV3StakingAprService(
+            { positionId: id },
+            { prisma: this.prisma },
+        );
+        const aprSummary = await aprService.calculateSummary(
+            { positionOpenedAt: correctedOpenedAt, costBasis: aggregates.costBasisAfter, unclaimedYield },
+            blockNumber,
+            dbTx,
+        );
+        const persistedApr = aprSummary.belowThreshold ? null : aprSummary.totalApr;
 
         const isClosedTransition =
             onChain.vaultState === 'Settled' && position.typedState.vaultState !== 'Settled';
@@ -799,6 +876,9 @@ export class UniswapV3StakingPositionService {
                 unrealizedPnl: unrealizedPnl.toString(),
                 collectedYield: aggregates.collectedYieldAfter.toString(),
                 unclaimedYield: unclaimedYield.toString(),
+                totalApr: persistedApr,
+                baseApr: persistedApr,
+                rewardApr: 0,
                 positionOpenedAt: correctedOpenedAt,
             },
         });


### PR DESCRIPTION
## Summary

PR4 of 5 for SPEC-0003b (issue #63). PR4a (#68, the position service) is merged; PR4b wires it to the API surface.

- 9 REST endpoints under `/api/v1/positions/uniswapv3-staking/...` (discover, GET/DELETE, refresh, reload-history, ledger, apr, accounting, simulate, pnl-curve). `/conversion` deliberately dropped — the principal-vs-yield split exposed by `/accounting` and `/apr` already answers that question natively for staking, and the NFT math doesn't translate.
- `UniswapV3StakingAprService` — mirrors `UniswapV3AprService`, but APR periods are bracketed by `STAKING_DISPOSE` events (vs `COLLECT` for NFT). Periods are persisted by the staking ledger service inside `recalculateAggregates`.
- Three service factories in `apps/midcurve-api/src/lib/services.ts`: position, ledger, APR.
- Wire types + Zod path-param schema in `@midcurve/api-shared`. Shared/common wire types reused for ledger, APR, accounting, simulation, pnl-curve.
- Top-level `/positions/discover` now scans NFT + staking in parallel and emits `position.created` for each newly-imported position. Staking's `discoverWalletPositions` now returns `positions: UniswapV3StakingPosition[]` (parity with NFT).
- `/positions/refresh-all` dispatches per protocol (`uniswapv3` / `uniswapv3-vault` / `uniswapv3-staking`).
- **Recalc-threading optimization** (PR4a review point #4): `syncFromChain`'s `postImportAggregates` are threaded through `refreshOnChainState` so `refresh()` and `reset()` stop triggering a redundant `recalculateAggregates` pass. Test #11 explicitly asserts this invariant. `fetchMetrics` keeps its own recalc — separate REST entry, no upstream context.

## Notes for reviewers

- `/ledger` is unpaginated for parity with NFT/Vault. If settled vaults grow event-heavy in production, paginate all three protocols together in a follow-up rather than diverging staking now.
- `simulate` and `pnl-curve` mirror the NFT shape directly (no proportional scaling). The staking user owns 100% of the underlying NFT — none of vault's `sharesBalance / totalSupply` math is needed.
- Staking's `simulatePnLAtPrice` returns the base `PnLSimulationResult` (no `phase`/`baseTokenAmount`/`quoteTokenAmount`); the `/simulate` route computes those locally, same shape as the vault route.
- `PositionListService` is already protocol-agnostic — added a smoke test that confirms a `uniswapv3-staking` row passes through `findMany` and `includePool` enrichment without protocol-specific branches.

## Test plan

- [x] `pnpm typecheck` monorepo-wide green
- [x] `pnpm --filter @midcurve/services test:run` green (189 tests)
  - 14 PR4a position-service tests (test #11 updated for threading invariant)
  - 30 ledger tests (4 new APR-bracketing cases)
  - 6 new APR service tests
  - 5 position-list tests (1 new staking smoke)
- [x] `pnpm --filter @midcurve/api-shared test:run` green (8 tests)
- [x] `pnpm --filter @midcurve/shared test:run` green (127 tests)
- [ ] Manual smoke against a real Arbitrum vault (post-merge):
  - [ ] `POST /positions/uniswapv3-staking/discover` → `{ positionId, positionHash }`
  - [ ] `GET /positions/uniswapv3-staking/42161/0x.../accounting` — journal entries from PR3 visible
  - [ ] `GET /positions/uniswapv3-staking/42161/0x.../apr` — periods bracketed by STAKING_DISPOSE
  - [ ] `GET /positions/uniswapv3-staking/42161/0x.../simulate?price=...`
  - [ ] `POST /positions/refresh-all` re-syncs the staking position
  - [ ] `POST /positions/discover` (top-level) returns staking finds for the wallet
  - [ ] `GET /positions/list?protocols=uniswapv3-staking`

## Out of scope

- MCP tools → PR5
- API integration test infrastructure — pre-existing gap, not introduced here
- Real `unclaimedYieldBase/Quote` values — blocked on #69 (contract change)
- `discoverWalletPositions` `fromBlock` deploy-block bound — blocked on #70 (data migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)