### PR TITLE
docs(staking-vault): add UV3 staking vault concept, spec, and UI docs

### DIFF
--- a/docs/positions/uniswapv3-staking-vault/mental-model.md
+++ b/docs/positions/uniswapv3-staking-vault/mental-model.md
@@ -1,0 +1,60 @@
+# Staking Vault — Mental Model
+
+> Reference document capturing the conceptual frame of the Uniswap V3
+> Staking Vault, agreed before SPEC-0003a implementation. The vault is
+> a wrapper around a UV3 position that converts its yield-farming
+> semantics into staking semantics. This document fixes _what we are
+> building and why_, so implementation issues can be reviewed against
+> intent.
+
+## Core points
+
+**What goes in comes out.**
+- The owner deposits an inventory `(B base, Q quote)` — and gets exactly that inventory back at the end.
+- The position internally "does something" (tick-crossings, rebalancing, fee accrual), but from the outside this state is opaque and irrelevant.
+- Like a fixed-term deposit: principal in, identical principal out, plus interest.
+
+**Yield target as a termination condition — not as a yield number.**
+- `T` is not "the return I'd like", it is the **definition of the end state**.
+- Without `T` there would be no well-defined condition under which an executor could meaningfully act.
+- Once the position reaches `Deposit + T`, the goal is met — full stop. Whatever market value exists beyond that goes to the executor.
+
+**Owner outcome is deterministic and known in advance.**
+- On regular settlement, the owner receives exactly `(B, Q + T)`. To the wei.
+- No surprises to the upside (the upside tail is given up), no surprises to the downside (except under market stress that forces a `flashClose` at spot).
+- The owner knows _before staking_ what will happen at the end.
+
+**Permissionless execution.**
+- Nobody needs to be online. Nobody is commissioned. Nobody is trusted.
+- Solvers, MEV bots, keepers compete for the trigger and close the position precisely when it is profitable for them — which structurally coincides with the moment the owner's target is reached.
+- No allowlist, no relayer, no third party with rights over the vault.
+
+**Four discrete events replace continuous yield-farming.**
+- The owner sees: `Stake` → `Swap` → `Unstake` → `ClaimRewards`.
+- Instead of thousands of tick-crossings, a single point of realisation.
+- Clean accounting view: deposit, contract settlement, payout. Whatever happened inside the contract is the internal matter of one contracting party.
+
+**Structural precondition for a clear holding period.**
+- The vault does not deliver "better tax treatment" — it delivers the **structural precondition under which a holding-period view becomes defensible at all**.
+- Between `Stake` and `Swap` there is no token movement to the owner's account.
+- Whether a specific tax authority recognises this is jurisdiction-dependent — what is _our_ responsibility is the structural cleanliness of the view.
+
+**Trade-off: upside tail in exchange for determinism.**
+- The owner gives up the market upside above `T` — it goes to the executor.
+- In return: permissionless automation, deterministic outcome, semantic cleanliness.
+- This is _not_ a yield optimiser. Anyone seeking maximum return holds the position directly and closes it manually.
+
+**Emergency exit via `flashClose`.**
+- If the market never delivers the target, or the owner wants out earlier: `flashClose(bps)` closes the position (fully or partially) at the spot price, financed via a flash loan.
+- Cost: flash-loan fee plus possibly forgone yield.
+- Preserves owner optionality without undermining the regular mechanism.
+
+**Top-up and partial unstake extend the model — they do not break it.**
+- **Top-up**: more stake in the same construct, with the implicit yield rate held constant (`T` scales proportionally to `Q`).
+- **Partial unstake**: realises only a fraction at the next executor trigger; the remainder runs on with an unchanged risk/return profile.
+- Both preserve determinism per closed fraction; they are levers _within_ the model, not outside of it.
+
+**Outcome disciplinarian, not yield optimiser.**
+- This is the single sentence that holds everything else together.
+- The vault converts an open, continuous market exposure into a closed, terminable one — with a clear beginning, a clear termination condition, and a clear payout amount.
+- Whoever wants this conversion is the target audience. Whoever does not should stick with the bare UV3 position.

--- a/docs/positions/uniswapv3-staking-vault/position-concept.md
+++ b/docs/positions/uniswapv3-staking-vault/position-concept.md
@@ -322,3 +322,296 @@ chooses via `T` which class is active. The strong guarantee
 (principal at `T = 0`) is always available; the weaker guarantee
 (principal + `T` at `T > 0`) is market-conditional. Risk discussion
 should always specify which class is in scope.
+
+## 2.1 Common metric mapping
+
+**Global valuation rule.** All live valuations of quote-denominated
+quantities use the current pool price from `pool.slot0().sqrtPriceX96`.
+External price sources (Coingecko, Chainlink, CEX aggregators) are not
+admissible. Rationale: what the vault can actually deliver is
+pool-intrinsic; an external valuation could produce a value that the
+vault cannot realise.
+
+**Default conventions.** Unless overridden below: `realizedCashflow =
+unrealizedCashflow = 0` (the vault produces no periodic income stream
+in the funding/interest sense; yield is an endpoint payout, not a
+flow). `unrealizedPnl` is the standard derived value `currentValue −
+costBasis`, not a stored cumulative.
+
+| Field | Meaning for this position | On-chain reads / source | Unit, quote-side mapping | Ledger-derived vs. live |
+|---|---|---|---|---|
+| `id`, `userId`, `protocol`, `type`, `positionHash`, `createdAt`, `updatedAt`, `archivedAt`, `isArchived` | Standard framework fields | Database | n/a | DB-managed |
+| `ownerWallet` | The on-chain vault owner, set at clone init and immutable | `vault.owner()` once at import | `evm:<address>` | Live, immutable after init |
+| `currentValue` | Mark-to-market of vault contents at pool price: filled buffers + active wrapped-NFT liquidity (projected onto current tick) + uncollected UV3 fees, all in quote | `vault.unstakeBufferBase/Quote`, `vault.rewardBufferBase/Quote`, `npm.positions(tokenId).liquidity`, `tokensOwed*`, `pool.slot0()` | Quote bigint via `isToken0Quote` mapping; `base × P_pool + quote` decomposition | Live |
+| `costBasis` | Cumulative quote value of capital currently deployed | Ledger-cumulative; written on `STAKING_DEPOSIT` (positive) and `STAKING_DISPOSE` (proportional negative) | Quote bigint | Ledger-derived |
+| `realizedPnl` | Quote-denominated PnL recognised at disposal (`B × ΔP` insight: the principal payout valued at `P_settle` minus its proportional cost basis, minus any flash-loan fee) | Ledger-cumulative; written on `STAKING_DISPOSE` | Quote bigint | Ledger-derived |
+| `realizedCashflow` | n/a — no periodic income stream in the vault model | — | `0` | constant |
+| `unrealizedPnl` | Standard derived value `currentValue − costBasis` | Computed | Quote bigint | Live (derived) |
+| `unrealizedCashflow` | n/a | — | `0` | constant |
+| `collectedYield` | Cumulative quote value of yield drained to owner; recognised at drain time, valued at `P_drain` | Ledger-cumulative; written only on `STAKING_CLAIM_REWARDS` | Quote bigint | Ledger-derived |
+| `unclaimedYield` | Quote-valued contents of the reward buffer (UV3 fees + LVR substance + allocated `T` share) | `vault.rewardBufferBase × P_pool + vault.rewardBufferQuote` | Quote bigint | Live |
+| `lastYieldClaimedAt` | Timestamp of the most recent `STAKING_CLAIM_REWARDS` event | Ledger | Date | Ledger-derived |
+| `baseApr` | Time-weighted APR computed from `collectedYield` over weighted average `costBasis`, bracketed on `STAKING_DEPOSIT` / `STAKING_DISPOSE` / `STAKING_CLAIM_REWARDS` events | `PositionAprPeriod` aggregation | Float, basis-point precision | Aggregated from ledger periods |
+| `rewardApr` | n/a — no external incentive programmes | — | `null` | constant |
+| `totalApr` | `baseApr` (or `null`) | Computed | Float \| null | Aggregated |
+| `positionOpenedAt` | Timestamp of the first `STAKING_DEPOSIT` event | Ledger | Date | Ledger-derived |
+| `priceRangeLower`, `priceRangeUpper` | The wrapped NFT's price range, projected into quote via `isToken0Quote` | Computed once at import from `vault.tickLower()`, `vault.tickUpper()` via `TickMath` | Quote bigint | Static (immutable post-init) |
+
+**Notes on three contested choices.**
+
+- **`currentValue` is mark-to-market, not settlement-now or
+  flashClose-now.** Settlement-now valuation collapses under
+  Underwater (where `swap()` reverts); flashClose-now requires a
+  flash-loan-fee estimate that is not pool-intrinsic. Mark-to-market
+  is always well-defined and symmetric with NFT valuation, which
+  matters for portfolio-level aggregates.
+
+- **`collectedYield` recognises at drain time, not at disposal time.**
+  This is asymmetric with `realizedPnl` (which recognises at disposal):
+  `realizedPnl` is a disposal quantity (it measures the position's own
+  unwind), while `collectedYield` is a cashflow quantity (it measures
+  what the owner actually received in quote terms). This follows
+  [philosophy.md §Cash Flow Measurement] directly. The asymmetry has a
+  practical consequence: any FX drift on the base component of the
+  reward buffer between disposal and drain flows into `collectedYield`
+  rather than being booked separately. For owners who drain promptly
+  (or for `flashClose` with auto-drain in the same transaction), the
+  drift is zero.
+
+- **`priceRangeLower/Upper` is the wrapped-NFT range, not the
+  swap-executable band.** The NFT range is the region where the
+  position is productive (rebalancing, accruing fees) — the same
+  semantics as for a bare NFT position, and the same condition under
+  which the position is in profit at settlement (modulo the LVR
+  substance ceded to the executor). The Underwater condition is
+  surfaced separately in `state.swapStatus`, not via the range field.
+
+## 2.2 Type-specific metrics
+
+The `state` JSON shape under `@midcurve/shared/src/types/position/uniswapv3-staking-vault/`. Filter test: included if the UI reads it for a badge, action gate, or status label; excluded if it is only an implementation detail of `currentValue`.
+
+| Field | Type | Source | UI consumer |
+|---|---|---|---|
+| `vaultState` | `'Empty' \| 'Staking' \| 'Settled'` | `vault.state()`, mapped (on-chain `Staked → Staking`; `FlashCloseInProgress` is transient and never observed between transactions) | Lifecycle badge in card header |
+| `swapStatus` | `'NotApplicable' \| 'NoSwapNeeded' \| 'Executable' \| 'Underwater'` | `vault.quoteSwap().status` | Health indicator badge; gates the self-execute swap button |
+| `swapQuote` | `{ tokenIn, minAmountIn, tokenOut, amountOut, effectiveBps } \| null` | `vault.quoteSwap()` (full struct) | Swap tab in detail page; informs the close-position formular |
+| `stakedBase` | `bigint` | `vault.stakedBase()` | Current-stake display; input for PnL-curve simulation |
+| `stakedQuote` | `bigint` | `vault.stakedQuote()` | dito |
+| `yieldTarget` | `bigint` | `vault.yieldTarget()` | "T" display; key configuration parameter |
+| `pendingBps` | `number` (0..10000) | `vault.partialUnstakeBps()` | "Partial unstake pending: X%" indicator |
+| `effectiveBps` | `number` (1..10000) | derived: `pendingBps == 0 ? 10000 : pendingBps` | Shows what fraction the next swap would actually settle |
+| `unstakeBufferBase`, `unstakeBufferQuote` | `bigint` | `vault.unstakeBufferBase/Quote()` | Drain-principal button gating (enabled if > 0) |
+| `rewardBufferBase`, `rewardBufferQuote` | `bigint` | `vault.rewardBufferBase/Quote()` | Claim-rewards button gating (enabled if > 0) |
+| `sqrtPriceX96` | `bigint` | `pool.slot0().sqrtPriceX96` | Pool price display; input for currentValue and swapStatus |
+| `currentTick` | `number` | `pool.slot0().tick` | In-range / out-of-range computation |
+| `poolLiquidity` | `bigint` | `pool.liquidity()` | Optional comparison display (own position vs. pool TVL) |
+| `wrappedNftLiquidity` | `bigint` | `npm.positions(wrappedTokenId).liquidity` | Active-liquidity indicator; null when `vaultState == Settled` |
+
+**Stale-quote handling.** `swapQuote` changes block-by-block as
+`sqrtPriceX96` moves. The cached value in `state` is only as fresh as
+the last refresh. Before any user-initiated swap action (the "Execute
+Swap" button in the swap tab), the UI must re-fetch the quote directly
+from RPC and reconcile with the cached value. If the drift exceeds a
+tolerated band, prompt the user to reconfirm — analogous to the
+existing slippage-protection pattern on NFT close orders.
+
+**Wrapped-NFT internals deliberately excluded.** The `feeGrowthInside*X128`
+checkpoints, `tokensOwed*` snapshot, and tick-level fee-growth fields
+are implementation details of how `currentValue` and `unclaimedYield`
+are computed. The vault user does not see them: by design, the
+wrapper hides UV3 internals so the user sees a single quote-valued
+yield number, not a four-component fee picture. Power users who want
+the on-chain detail can use a block explorer.
+
+## 2.3 PnL decomposition
+
+**Model A.** Yield is booked separately from PnL: `collectedYield` /
+`unclaimedYield` are dedicated fields, `realizedPnl` carries only the
+disposal consequence on the principal (the `B × ΔP` quantity). Yield
+never lands in `pnl`. This conforms to [philosophy.md]'s
+yield-vs-value-appreciation separation.
+
+`realizedCashflow` and `unrealizedCashflow` are constant `0` (no
+funding, no interest stream).
+
+### Event taxonomy
+
+Five new `EventType` values, prefixed `STAKING_*` (analogous to
+`VAULT_*` for vault shares).
+
+#### `STAKING_DEPOSIT`
+
+Owner stakes — initial stake or top-up. Same delta pattern in both
+cases; the distinction lives in NPM mechanics (mint vs.
+increaseLiquidity), not in accounting.
+
+| Field | Value |
+|---|---|
+| `deltaCostBasis` | `+(baseConsumed × P_stake + quoteConsumed)` |
+| `deltaPnl` | `0` |
+| `deltaCollectedYield` | `0` |
+| `deltaRealizedCashflow` | `0` |
+| `deltaLiquidity` | `+addedLiquidity` (UV3 L units) |
+| `tokenValue` | equals `deltaCostBasis` |
+| `rewards` | `[]` |
+| `config` | `{ baseConsumed, quoteConsumed, baseRefunded, quoteRefunded, sqrtPriceX96 }` |
+
+#### `STAKING_DISPOSE`
+
+A disposal — `swap()` (permissionless or owner-self-execute, identical
+accounting) or `flashClose()`. One event per disposal.
+
+| Field | Value |
+|---|---|
+| `deltaCostBasis` | `−(costBasisBefore × bps / 10000)` |
+| `deltaPnl` | `principalPayoutValue − proportionalCostBasis − flashLoanFee` |
+| `deltaCollectedYield` | `0` (recognition at drain) |
+| `deltaRealizedCashflow` | `0` |
+| `deltaLiquidity` | `−removedLiquidity` |
+| `tokenValue` | `0` (no movement to owner; tokens move into the buffers) |
+| `rewards` | `[]` |
+| `config` | `{ bps, disposalKind: 'swap' \| 'flashClose', executor, principalPayoutBase, principalPayoutQuote, rewardFillBase, rewardFillQuote, sqrtPriceX96, flashLoanFee }` |
+
+`principalPayoutValue = principalPayoutBase × P_settle + principalPayoutQuote`. `flashLoanFee == 0` unless `disposalKind == 'flashClose'`. The `executor` field captures the `msg.sender` of the underlying call, which lets the UI distinguish self-executed from third-party-executed disposals; on `flashClose` it is always the owner.
+
+#### `STAKING_UNSTAKE`
+
+Drain of `unstakeBuffer*` to the owner. Owner-triggered, or
+auto-emitted inside a `flashClose` transaction.
+
+| Field | Value |
+|---|---|
+| `deltaCostBasis` | `0` |
+| `deltaPnl` | `0` |
+| `deltaCollectedYield` | `0` |
+| `deltaRealizedCashflow` | `0` |
+| `deltaLiquidity` | `0` |
+| `tokenValue` | `+(drainedBase × P_drain + drainedQuote)` |
+| `rewards` | `[]` |
+| `config` | `{ drainedBase, drainedQuote, sqrtPriceX96 }` |
+
+Marker only — cumulatives were already adjusted at `STAKING_DISPOSE`.
+`tokenValue` records the actual movement to the owner for audit and
+reconciliation.
+
+#### `STAKING_CLAIM_REWARDS`
+
+Drain of `rewardBuffer*` to the owner. The single event that writes
+`deltaCollectedYield`, per the drain-time recognition rule from 2.1.
+
+| Field | Value |
+|---|---|
+| `deltaCostBasis` | `0` |
+| `deltaPnl` | `0` |
+| `deltaCollectedYield` | `+(drainedBase × P_drain + drainedQuote)` |
+| `deltaRealizedCashflow` | `0` |
+| `deltaLiquidity` | `0` |
+| `tokenValue` | equals `deltaCollectedYield` |
+| `rewards` | `[]` |
+| `config` | `{ drainedBase, drainedQuote, sqrtPriceX96 }` |
+
+`rewards: []` is intentional. The `rewards` array is for external
+reward-token programmes; the vault's intrinsic yield is in token0/
+token1 amounts and is not a separate reward-token category.
+
+#### `STAKING_CHANGE_CONFIG`
+
+Owner-intent change — `setYieldTarget`, `setPartialUnstakeBps`, or
+`increasePartialUnstakeBps`. Neutral in all financial dimensions, but
+ledger-visible for audit trail and history-tab display.
+
+| Field | Value |
+|---|---|
+| `deltaCostBasis` | `0` |
+| `deltaPnl` | `0` |
+| `deltaCollectedYield` | `0` |
+| `deltaRealizedCashflow` | `0` |
+| `deltaLiquidity` | `0` |
+| `tokenValue` | `0` |
+| `rewards` | `[]` |
+| `config` | `{ action: 'setYieldTarget' \| 'setPartialUnstakeBps' \| 'increasePartialUnstakeBps', oldValue, newValue }` |
+
+The journal-posting rule produces no `JournalEntry` for this event;
+it is purely a marker.
+
+### Account mapping
+
+The journal-posting rule (`UniswapV3StakingVaultPostJournalEntriesRule`)
+maps each non-marker event to journal lines. The chart of accounts
+reuses the existing slots — `Position`, `Cash`, `Yield`, `PnL` — and
+introduces one new account: `Suspense`, representing buffer contents
+that economically belong to the owner but physically still sit inside
+the vault.
+
+#### `STAKING_DEPOSIT` (value `V`)
+
+```
+Debit  Position[vaultAddress]   V
+Credit Cash[ownerWallet]        V
+```
+
+#### `STAKING_DISPOSE` (profitable)
+
+```
+Debit  Suspense[vaultAddress]   principalPayoutValue
+Credit Position[vaultAddress]   proportionalCostBasis
+Credit PnL[ownerWallet]         realizedPnl
+```
+
+#### `STAKING_DISPOSE` (loss-making)
+
+```
+Debit  Suspense[vaultAddress]   principalPayoutValue
+Debit  PnL[ownerWallet]         |realizedPnl|
+Credit Position[vaultAddress]   proportionalCostBasis
+```
+
+For `flashClose` with non-zero flash-loan fee, append:
+
+```
+Debit  PnL[ownerWallet]         flashLoanFee
+Credit Cash[ownerWallet]        flashLoanFee
+```
+
+#### `STAKING_UNSTAKE` (value `V`)
+
+```
+Debit  Cash[ownerWallet]        V
+Credit Suspense[vaultAddress]   V
+```
+
+The Suspense account drains to zero per disposal once the owner
+unstakes. If `Suspense[vaultAddress]` carries an open balance, it
+indicates an undrained `unstakeBuffer*` — visible in reconciliation
+and in any "pending balance" UI.
+
+#### `STAKING_CLAIM_REWARDS` (value `V`)
+
+```
+Debit  Cash[ownerWallet]        V
+Credit Yield[ownerWallet]       V
+```
+
+Direct path with no Suspense intermediate, because yield recognition
+happens at drain (per 2.1) — there is no period of "yield owed but
+not yet recognised". This mirrors the NFT `COLLECT` event exactly.
+
+### Reconciliation
+
+`UniswapV3StakingVaultReconcileCostBasisRule` periodically checks:
+
+- `Position[vaultAddress]` balance equals `Position.costBasis` (the
+  primary cost-basis invariant).
+- `Suspense[vaultAddress]` balance equals
+  `unstakeBufferBase × P_pool + unstakeBufferQuote` at the refresh
+  block (the buffer-tracking invariant).
+
+A mismatch on either signals a missed event or a misposted event.
+
+## 2.4 Domain events
+
+Existing routing key family is reused: `position.liquidity.uniswapv3-staking-vault.<eventType>` with `eventType ∈ {deposit, dispose, unstake, claim_rewards, change_config}`. Existing payload shape (positionId, eventId, eventType, blockNumber, txHash, plus event-specific config) suffices — no payload extensions, no new exchange. Per the new guide §2.4, no deviation conditions apply.
+
+## 2.5 Computation as code (deferred)
+
+Per guide §2.5, the metric derivation rules are locked in TypeScript under `packages/midcurve-shared/src/metrics/uniswapv3-staking-vault/` (`common-metrics.ts` + `specific-metrics.ts`). This is a build artefact, not a concept artefact, and is produced as a separate implementation issue against the build phases — not as part of this concept document.

--- a/docs/positions/uniswapv3-staking-vault/position-concept.md
+++ b/docs/positions/uniswapv3-staking-vault/position-concept.md
@@ -348,10 +348,10 @@ costBasis`, not a stored cumulative.
 | `realizedCashflow` | n/a — no periodic income stream in the vault model | — | `0` | constant |
 | `unrealizedPnl` | Standard derived value `currentValue − costBasis` | Computed | Quote bigint | Live (derived) |
 | `unrealizedCashflow` | n/a | — | `0` | constant |
-| `collectedYield` | Cumulative quote value of yield drained to owner; recognised at drain time, valued at `P_drain` | Ledger-cumulative; written only on `STAKING_CLAIM_REWARDS` | Quote bigint | Ledger-derived |
+| `collectedYield` | Cumulative quote value of yield recognised at the disposal that filled the reward buffer; valued at `P_settle` | Ledger-cumulative; written on `STAKING_DISPOSE` (the reward-fill component) | Quote bigint | Ledger-derived |
 | `unclaimedYield` | Quote-valued contents of the reward buffer (UV3 fees + LVR substance + allocated `T` share) | `vault.rewardBufferBase × P_pool + vault.rewardBufferQuote` | Quote bigint | Live |
 | `lastYieldClaimedAt` | Timestamp of the most recent `STAKING_CLAIM_REWARDS` event | Ledger | Date | Ledger-derived |
-| `baseApr` | Time-weighted APR computed from `collectedYield` over weighted average `costBasis`, bracketed on `STAKING_DEPOSIT` / `STAKING_DISPOSE` / `STAKING_CLAIM_REWARDS` events | `PositionAprPeriod` aggregation | Float, basis-point precision | Aggregated from ledger periods |
+| `baseApr` | Time-weighted APR computed from `collectedYield` over weighted average `costBasis`, bracketed on `STAKING_DEPOSIT` and `STAKING_DISPOSE` events | `PositionAprPeriod` aggregation | Float, basis-point precision | Aggregated from ledger periods |
 | `rewardApr` | n/a — no external incentive programmes | — | `null` | constant |
 | `totalApr` | `baseApr` (or `null`) | Computed | Float \| null | Aggregated |
 | `positionOpenedAt` | Timestamp of the first `STAKING_DEPOSIT` event | Ledger | Date | Ledger-derived |
@@ -366,17 +366,23 @@ costBasis`, not a stored cumulative.
   is always well-defined and symmetric with NFT valuation, which
   matters for portfolio-level aggregates.
 
-- **`collectedYield` recognises at drain time, not at disposal time.**
-  This is asymmetric with `realizedPnl` (which recognises at disposal):
-  `realizedPnl` is a disposal quantity (it measures the position's own
-  unwind), while `collectedYield` is a cashflow quantity (it measures
-  what the owner actually received in quote terms). This follows
-  [philosophy.md §Cash Flow Measurement] directly. The asymmetry has a
-  practical consequence: any FX drift on the base component of the
-  reward buffer between disposal and drain flows into `collectedYield`
-  rather than being booked separately. For owners who drain promptly
-  (or for `flashClose` with auto-drain in the same transaction), the
-  drift is zero.
+- **`collectedYield` recognises at disposal time, symmetric with
+  `realizedPnl`.** Both are recognised at the same event
+  (`STAKING_DISPOSE`) because both reflect the realisation of position
+  economics — `realizedPnl` for the principal component, `collectedYield`
+  for the yield component. The drain events (`STAKING_UNSTAKE`,
+  `STAKING_CLAIM_REWARDS`) are pure asset/liability movements within
+  the position's accounting; they have no recognition impact.
+
+  The mark-to-market value of buffered tokens between disposal and
+  drain is reflected only in `unrealizedPnl` (live valuation of the
+  buffer at pool price vs. its booked value at disposal). It does not
+  produce a separate realised PnL component; the buffered tokens are
+  held at-cost from the disposal moment until they leave the vault.
+  Any FX drift on the base component between disposal and drain is
+  visible to the user via the `unrealizedPnl` movement, then folds
+  into the next disposal's `Realized Gains` / `Realized Losses` if
+  not yet drained.
 
 - **`priceRangeLower/Upper` is the wrapped-NFT range, not the
   swap-executable band.** The NFT range is the region where the
@@ -465,14 +471,14 @@ accounting) or `flashClose()`. One event per disposal.
 |---|---|
 | `deltaCostBasis` | `−(costBasisBefore × bps / 10000)` |
 | `deltaPnl` | `principalPayoutValue − proportionalCostBasis − flashLoanFee` |
-| `deltaCollectedYield` | `0` (recognition at drain) |
+| `deltaCollectedYield` | `+rewardFillValue` (recognition at disposal) |
 | `deltaRealizedCashflow` | `0` |
 | `deltaLiquidity` | `−removedLiquidity` |
 | `tokenValue` | `0` (no movement to owner; tokens move into the buffers) |
 | `rewards` | `[]` |
 | `config` | `{ bps, disposalKind: 'swap' \| 'flashClose', executor, principalPayoutBase, principalPayoutQuote, rewardFillBase, rewardFillQuote, sqrtPriceX96, flashLoanFee }` |
 
-`principalPayoutValue = principalPayoutBase × P_settle + principalPayoutQuote`. `flashLoanFee == 0` unless `disposalKind == 'flashClose'`. The `executor` field captures the `msg.sender` of the underlying call, which lets the UI distinguish self-executed from third-party-executed disposals; on `flashClose` it is always the owner.
+`principalPayoutValue = principalPayoutBase × P_settle + principalPayoutQuote`. `rewardFillValue = rewardFillBase × P_settle + rewardFillQuote`. `flashLoanFee == 0` unless `disposalKind == 'flashClose'`. The `executor` field captures the `msg.sender` of the underlying call, which lets the UI distinguish self-executed from third-party-executed disposals; on `flashClose` it is always the owner.
 
 #### `STAKING_UNSTAKE`
 
@@ -496,19 +502,22 @@ reconciliation.
 
 #### `STAKING_CLAIM_REWARDS`
 
-Drain of `rewardBuffer*` to the owner. The single event that writes
-`deltaCollectedYield`, per the drain-time recognition rule from 2.1.
+Drain of `rewardBuffer*` to the owner.
 
 | Field | Value |
 |---|---|
 | `deltaCostBasis` | `0` |
 | `deltaPnl` | `0` |
-| `deltaCollectedYield` | `+(drainedBase × P_drain + drainedQuote)` |
+| `deltaCollectedYield` | `0` (already recognised at the prior `STAKING_DISPOSE`) |
 | `deltaRealizedCashflow` | `0` |
 | `deltaLiquidity` | `0` |
-| `tokenValue` | equals `deltaCollectedYield` |
+| `tokenValue` | `+(drainedBase × P_drain + drainedQuote)` |
 | `rewards` | `[]` |
 | `config` | `{ drainedBase, drainedQuote, sqrtPriceX96 }` |
+
+Marker only — `collectedYield` was incremented at the `STAKING_DISPOSE`
+that filled the reward buffer. `tokenValue` records the actual
+movement to the owner.
 
 `rewards: []` is intentional. The `rewards` array is for external
 reward-token programmes; the vault's intrinsic yield is in token0/
@@ -537,74 +546,139 @@ it is purely a marker.
 ### Account mapping
 
 The journal-posting rule (`UniswapV3StakingVaultPostJournalEntriesRule`)
-maps each non-marker event to journal lines. The chart of accounts
-reuses the existing slots — `Position`, `Cash`, `Yield`, `PnL` — and
-introduces one new account: `Suspense`, representing buffer contents
-that economically belong to the owner but physically still sit inside
-the vault.
+maps each non-marker event to a single journal entry containing all
+required lines. The chart of accounts adds four new accounts to the
+existing schema:
+
+| Code | Account | Class | Normal side | Purpose |
+|---|---|---|---|---|
+| 1010 | Staking Position at Cost | Asset | Debit | Active UV3 liquidity, at acquisition cost |
+| 1020 | Position Cash Holdings | Asset | Debit | Buffered tokens (unstake + reward), at disposal value |
+| 2000 | Pending Settlement | Liability | Credit | Obligation to owner for buffered tokens, at disposal value |
+| 4400 | Realized Yield | Revenue | Credit | Yield recognised at disposal |
+
+Existing accounts in use: `3000 Contributed Capital`, `3100 Capital Returned`, `4100 Realized Gains`, `4300 FX Gain / Loss`, `5000 Realized Losses`.
+
+The `2xxx` Liability class is new in the chart of accounts. Account
+codes are suggestions; final assignment is the implementation phase's
+responsibility (must align with existing conventions in
+`account_definitions`).
 
 #### `STAKING_DEPOSIT` (value `V`)
 
 ```
-Debit  Position[vaultAddress]   V
-Credit Cash[ownerWallet]        V
+DR 1010 Staking Position at Cost   V
+CR 3000 Contributed Capital        V
 ```
+
+Identical to the existing NFT/Vault-Share acquisition pattern.
 
 #### `STAKING_DISPOSE` (profitable)
 
 ```
-Debit  Suspense[vaultAddress]   principalPayoutValue
-Credit Position[vaultAddress]   proportionalCostBasis
-Credit PnL[ownerWallet]         realizedPnl
+DR 3100 Capital Returned          principalPayout + rewardFill
+DR 1020 Position Cash Holdings    principalPayout + rewardFill
+CR 1010 Staking Position at Cost  proportionalCostBasis
+CR 4100 Realized Gains            principalPayout − proportionalCostBasis
+CR 4400 Realized Yield            rewardFill
+CR 2000 Pending Settlement        principalPayout + rewardFill
 ```
+
+A single journal entry combining two effects. The first set of lines
+(Capital Returned, Staking Position at Cost reduction, Realized Gains,
+Realized Yield) follows the existing NFT/Vault-Share disposal pattern:
+equity is reclassified from active capital to returned capital, the
+cost basis is removed, gains and yield are recognised. The other two
+lines (Position Cash Holdings, Pending Settlement) record the buffer
+creation: tokens enter the vault's cash holdings as an asset, balanced
+by a liability to the owner.
+
+Balance check: DR `2 × (principalPayout + rewardFill)` equals CR
+`proportionalCostBasis + (principalPayout − proportionalCostBasis) +
+rewardFill + (principalPayout + rewardFill) = 2 × (principalPayout +
+rewardFill)`. ✓
 
 #### `STAKING_DISPOSE` (loss-making)
 
 ```
-Debit  Suspense[vaultAddress]   principalPayoutValue
-Debit  PnL[ownerWallet]         |realizedPnl|
-Credit Position[vaultAddress]   proportionalCostBasis
+DR 3100 Capital Returned          principalPayout + rewardFill
+DR 1020 Position Cash Holdings    principalPayout + rewardFill
+DR 5000 Realized Losses           |principalPayout − proportionalCostBasis|
+CR 1010 Staking Position at Cost  proportionalCostBasis
+CR 4400 Realized Yield            rewardFill
+CR 2000 Pending Settlement        principalPayout + rewardFill
 ```
 
-For `flashClose` with non-zero flash-loan fee, append:
+Identical structure to the profitable variant, with `Realized Losses`
+on the debit side instead of `Realized Gains` on the credit side.
+
+#### `STAKING_DISPOSE` with non-zero `flashLoanFee`
+
+If the on-chain pipeline can extract `flashLoanFee` separately (a
+Phase 5 question — on-chain events do not directly emit this value;
+the pipeline would need to parse provider-specific events from
+Aave/Balancer/Morpho or compute the fee via token-difference on the
+flash-loan helper contract), an additional pair of lines is appended:
 
 ```
-Debit  PnL[ownerWallet]         flashLoanFee
-Credit Cash[ownerWallet]        flashLoanFee
+DR 5000 Realized Losses           flashLoanFee
+CR 3100 Capital Returned          flashLoanFee
 ```
 
-#### `STAKING_UNSTAKE` (value `V`)
+If extraction is not feasible, the fee is implicit in a smaller
+`principalPayout` and subsumed in `Realized Gains` / `Realized Losses`.
+This is a pipeline-availability decision, not a concept-level
+decision; the journal-posting rule will conditionally include or omit
+these lines based on whether `config.flashLoanFee > 0`.
+
+#### `STAKING_UNSTAKE` (drained value `V`)
 
 ```
-Debit  Cash[ownerWallet]        V
-Credit Suspense[vaultAddress]   V
+DR 2000 Pending Settlement        V
+CR 1020 Position Cash Holdings    V
 ```
 
-The Suspense account drains to zero per disposal once the owner
-unstakes. If `Suspense[vaultAddress]` carries an open balance, it
-indicates an undrained `unstakeBuffer*` — visible in reconciliation
-and in any "pending balance" UI.
+Pure asset/liability movement. The drained value `V` equals the value
+originally booked into Pending Settlement at the disposal — no
+revaluation occurs at drain time. Any FX drift on the base component
+between disposal and drain is visible only via the position's
+`unrealizedPnl` (the live mark-to-market of the buffer at pool price
+vs. its booked value at disposal). It does not produce a separate
+realised PnL line at drain; if not yet drained, the drift folds into
+the next disposal's `Realized Gains` / `Realized Losses`.
 
-#### `STAKING_CLAIM_REWARDS` (value `V`)
+#### `STAKING_CLAIM_REWARDS` (drained value `V`)
 
 ```
-Debit  Cash[ownerWallet]        V
-Credit Yield[ownerWallet]       V
+DR 2000 Pending Settlement        V
+CR 1020 Position Cash Holdings    V
 ```
 
-Direct path with no Suspense intermediate, because yield recognition
-happens at drain (per 2.1) — there is no period of "yield owed but
-not yet recognised". This mirrors the NFT `COLLECT` event exactly.
+Identical mechanism to `STAKING_UNSTAKE`, just for the reward-buffer
+slice of `Pending Settlement`. Yield was already recognised as
+`Realized Yield` at the prior `STAKING_DISPOSE`; the drain is a pure
+asset/liability movement.
+
+#### `STAKING_CHANGE_CONFIG`
+
+No journal entry. Marker only.
 
 ### Reconciliation
 
-`UniswapV3StakingVaultReconcileCostBasisRule` periodically checks:
+`UniswapV3StakingVaultReconcileRule` periodically checks two
+invariants:
 
-- `Position[vaultAddress]` balance equals `Position.costBasis` (the
-  primary cost-basis invariant).
-- `Suspense[vaultAddress]` balance equals
-  `unstakeBufferBase × P_pool + unstakeBufferQuote` at the refresh
-  block (the buffer-tracking invariant).
+- **Cost-basis invariant.** `1010 Staking Position at Cost` balance
+  equals `Position.costBasis`. The primary check that
+  deposit/disposal cost-basis movements are consistent.
+- **Buffer-tracking invariant.** `1020 Position Cash Holdings` balance
+  equals `2000 Pending Settlement` balance, both equal to the booked
+  value of all four buffer slots (`unstakeBufferBase × P_settle +
+  unstakeBufferQuote + rewardBufferBase × P_settle + rewardBufferQuote`,
+  where `P_settle` is the pool price at the disposal that filled each
+  buffer component). Note: this is the *booked* value, not the
+  current pool-price-marked value, since neither account is revalued
+  at drain.
 
 A mismatch on either signals a missed event or a misposted event.
 

--- a/docs/positions/uniswapv3-staking-vault/position-concept.md
+++ b/docs/positions/uniswapv3-staking-vault/position-concept.md
@@ -1,0 +1,324 @@
+# What is a `uniswapv3-staking-vault` position?
+
+> Phase 1 concept document for the Uniswap V3 Staking Vault integration,
+> per [how-to-implement-new-positions.md](../../how-to-implement-new-positions.md).
+> This document fixes the position's identity, lifecycle, and economic
+> invariant. It is the north star for Phase 2 (metrics) and Phase 3 (UI).
+> See [mental-model.md](./mental-model.md) for the user-facing framing
+> that motivates the decisions captured here.
+
+## 1.1 Identity
+
+**`protocol`**: `uniswapv3-staking-vault`
+
+The discriminator names the specific vault construct, not the broader
+"Uniswap V3 staking" category. Future staking wrappers around UV3 (e.g.
+a shared-vault variant managing many positions in one contract) would
+take their own discriminator under the same family.
+
+**`type`**: `STAKING` (new value; not reused from `LP_CONCENTRATED`)
+
+The `type` discriminator names the **risk class**, not the vehicle. A
+bare UV3 NFT under `LP_CONCENTRATED` carries the classical LP risk
+shape — continuous rebalancing, IL/LVR exposure, range mechanics, fee
+accrual visible to the holder. The vault deliberately hides those from
+the user: from outside, the position behaves as a fixed-deposit-like
+construct with a market-conditional yield claim. That is a different
+risk shape and warrants its own type. The `STAKING` value is generic
+enough to admit future non-vault staking constructs (shared vaults,
+hook-based variants) under the same risk class without further type
+proliferation.
+
+**`positionHash`**: `uniswapv3-staking-vault/<chainId>/<vaultAddress>`
+
+The vault address is globally unique per chain; each vault is its own
+EIP-1167 clone with its own address. The wrapped UV3 NFT's `tokenId`
+is an internal implementation detail of the vault — one vault holds
+exactly one position over its lifetime (SPEC-0003a §1: _"One vault per
+UV3 position"_), so `tokenId` is derivable from `vaultAddress` and is
+not part of the position's identity.
+
+**Owner model**: Owner-bound 1:1
+
+A single user owns a single contract clone. Ownership is encoded
+on-chain at clone initialisation and is structurally immutable —
+SPEC-0003a §1: _"The owner address is set once during clone
+initialization. Once set, it MUST NOT be mutable. No transfer function,
+no ownership token, no upgrade mechanism that could rebind it."_
+
+The factory's `createVault()` performs deployment AND initialisation
+atomically in the same call frame, closing the standard EIP-1167
+front-running race where a third party could claim ownership of a
+freshly deployed but uninitialised clone. From an integration
+perspective: every vault address has exactly one owner, known
+unambiguously from the moment the vault exists.
+
+## 1.2 Lifecycle
+
+Three user-facing states:
+
+- **`Empty`** — clone is deployed, `stake()` has never been called.
+  Formally the entry state, but typically observable only for a few
+  microseconds: the factory composes deploy + initialise + initial
+  stake into a single transaction by convention. We retain the state
+  in the model as the formal origin of the lifecycle, not as a
+  realistic user-facing state.
+- **`Staking`** — UV3 position is open and active. `swap()` is
+  callable, all owner levers (top-up, yield-target adjustment, partial
+  unstake) are available. The normal operating state.
+- **`Settled`** — position is fully closed (`liquidity == 0`). No new
+  operations possible, but `unstake()` and `claimRewards()` remain
+  callable to drain any buffered amounts the final settlement filled.
+  Terminal.
+
+**Naming note.** The user-facing name `Staking` deliberately diverges
+from SPEC-0003a's on-chain storage name `Staked`. Gerund vs. past
+participle is a meaningful distinction here: the on-chain storage slot
+records that staking _has occurred_, while the user-facing state names
+the activity that _is occurring_. Both names are correct in their own
+domain; the divergence should not surprise readers who put SPEC and
+this document side by side.
+
+**On-chain-only state.** SPEC-0003a §4 also defines a
+`FlashCloseInProgress` storage state. It is a transient reentrancy
+lock that lives only inside a single transaction — it is never
+observable as the persistent state between transactions, so it is not
+part of the user-facing lifecycle. It belongs to the contract's
+implementation, not to the position's semantics.
+
+### Transitions
+
+| From | To | Trigger | Class | Reversible? |
+|---|---|---|---|---|
+| `Empty` | `Staking` | `stake()` (initial) | owner-initiated | no |
+| `Staking` | `Staking` | `stake()` (top-up) | owner-initiated | self-loop |
+| `Staking` | `Staking` | `setYieldTarget()` | owner-initiated | self-loop |
+| `Staking` | `Staking` | `setPartialUnstakeBps()` / `increasePartialUnstakeBps()` | owner-initiated | self-loop |
+| `Staking` | `Staking` | `swap()` with `effectiveBps < 10000` | permissionless | self-loop |
+| `Staking` | `Staking` | `unstake()` / `claimRewards()` | owner-initiated | self-loop |
+| `Staking` | `Staking` | `flashClose(bps < 10000)` | owner-initiated | self-loop |
+| `Staking` | `Settled` | `swap()` with `effectiveBps == 10000` | permissionless | no |
+| `Staking` | `Settled` | `flashClose(10000)` | owner-initiated | no |
+| `Settled` | `Settled` | `unstake()` / `claimRewards()` | owner-initiated | self-loop |
+
+`multicall()` is not a transition in its own right; it composes the
+transitions above and inherits their state checks per inner call.
+
+### Two structural properties
+
+**Forward-monotonic.** There is no path from `Staking` back to `Empty`,
+and no path from `Settled` back to `Staking`. SPEC-0003a §19 enumerates
+the deliberate omissions: no `cancelStake()`, no range adjustment, no
+position re-mint. The lifecycle is a strict forward axis. For the UI
+this means the lifecycle badge has no surprises; for the indexer it
+means a simple monotonic state derivation from event order.
+
+**No automatic transitions.** Nothing in this design happens
+chain-driven without an explicit transaction. Even `Settled` is not
+reached automatically when some market condition flips — it always
+requires a caller (executor via `swap`, owner via `flashClose`). This
+distinguishes the vault from positions with auto-liquidation
+(lending, perps). Phase 4 (on-chain pipeline) does not need a
+background watcher for passive transitions.
+
+## 1.3 Economic invariant
+
+### What the position does economically
+
+The vault converts a continuously-rebalancing UV3 position into a
+**terminable fixed-deposit construct with an embedded limit-order
+clause**. The owner provides an inventory `(B, Q)`, defines a yield
+expectation `T` in quote units, and on regular settlement receives
+exactly `(B, Q + T)` back. Market activity in between is absorbed by
+the vault; the owner sees neither the tick-crossings nor the range
+behaviour of the wrapped NFT.
+
+The user's exposure decomposes into two distinct components:
+
+- A **deterministic quote claim** of size `T` (the yield target),
+  realised only if a settlement actually occurs.
+- An **underwater residual risk** on the principal `(B, Q)` itself,
+  realisable if the owner exits via `flashClose` while market
+  conditions cannot deliver `(B, Q + T)`.
+
+These two components are not "two parts of one return" — they are two
+separate claims with different guarantee classes, and the owner
+chooses via `T` which class is active. This is the central
+characterisation; everything below sharpens it.
+
+### The token-conservation invariant
+
+For every settlement event closing a fraction `bps` of the staked
+liquidity, the vault structurally guarantees:
+
+> **The owner receives at least `(B × bps/10000, Q × bps/10000)` of
+> principal and at least `T × bps/10000` of quote-side yield, for the
+> closed fraction `bps`.**
+
+This invariant is encoded in `swap()`: the executor _must_ fill the
+deficit on each side, otherwise the transaction reverts (SPEC-0003a §13).
+The invariant is range-independent (evaluated only at settlement,
+never continuously), top-up-stable (scales proportionally with each
+top-up per SPEC §8.2), and partial-stable (additive across multiple
+settlements per `bps`).
+
+A property of the underlying UV3 primitive does most of the work here:
+
+> **Closing a UV3 position via `decreaseLiquidity + collect` never
+> yields both `b < B` and `q < Q` simultaneously.**
+
+The bonding curve traverses a single conversion direction at a time
+(price up → sells base, gains quote; price down → gains base, sells
+quote), and fees accumulate additively on both sides. There is no
+market path that reduces both inventory sides at once. This is a UV3
+property, not a vault property — the vault inherits it.
+
+### Two guarantee classes
+
+The owner chooses, via `T`, which of two guarantee classes is active:
+
+**Strong guarantee (T = 0): principal-only, structurally always
+honourable.** With `T = 0`, the partial-target reduces to
+`(B × bps/10000, Q × bps/10000)`. By the UV3 property above, the
+condition `b < targetBase AND q < targetQuote` becomes structurally
+impossible — every settlement falls into Case 1, 2, or 3 of SPEC-0003a
+§11. The vault is **always liquidatable via `swap()`**, and the owner
+recovers principal `(B, Q)` exactly. There is no market scenario that
+prevents principal recovery. The vault is never structurally
+insolvent against a `T = 0` claim.
+
+**Conditional guarantee (T > 0): principal-plus-yield, market-dependent.**
+With `T > 0`, the partial-target widens to
+`(B × bps/10000, (Q + T) × bps/10000)`, and a Case-4 region opens up
+in the inventory space:
+`Q × bps/10000 ≤ q < (Q + T) × bps/10000` combined with `b < targetBase`.
+This region exists _only because_ `T > 0`. In Case 4, `swap()` reverts
+with `Underwater()`. The owner can:
+
+- wait for market conditions to change (the vault stays in `Staking`,
+  fees may accumulate, price may move back into a settleable region),
+- call `setYieldTarget(0)` (or any lower value that the current
+  inventory can support) — this collapses Case 4 back into Cases 1–3
+  and restores `swap()` callability, but at the cost of forgoing the
+  original yield claim,
+- exit via `flashClose` (see below) at the realised market value.
+
+Underwater is therefore not "the market broke the vault" — it is "the
+owner's yield claim exceeds the market's current ability to deliver".
+The owner caused it (by setting `T`), and the owner can resolve it
+(by lowering `T`).
+
+### Three exit paths
+
+When the owner wants to terminate the position, three paths are
+available, in descending order of accounting cleanliness:
+
+**(1) Wait for an external executor.** The vault sits in `Staking`
+until a third-party executor (solver, MEV bot, keeper) calls `swap()`
+because external conditions make the offered rate profitable for them.
+Maximally clean: the four canonical events (`Stake`, `Swap`,
+`Unstake`, `ClaimRewards`) appear in their intended order, the owner
+is uninvolved during the swap itself, and tokens never flow through
+the owner's wallet during settlement. Cost: waiting time, market-
+dependent.
+
+**(2) Self-execute via `swap()`.** The owner calls `swap()` themselves,
+supplying the deficit-side liquidity (quote in Case 2, base in Case 3)
+from their own wallet. This stays fully inside the staking semantics:
+the event sequence is identical to (1), with the owner address in the
+`executor` slot of the `Swap` event. Three separable token movements
+result — owner-as-executor sends `amountIn`, owner-as-executor receives
+`amountOut`, owner-as-owner later receives `unstake()` and
+`claimRewards()` payouts — and each is bookable independently in the
+owner's accounting. The "below-spot" component the owner appears to
+pay themselves is a temporary capital lock-up, not an economic loss:
+
+- At `T = 0`, the swap is a structurally fair inventory cycle; the
+  owner's net token position changes by zero (excluding gas).
+- At `T > 0`, the swap funds the `T` payout from the owner's own
+  liquidity, which then returns to them via `claimRewards()`. Again
+  net zero, with a visible accounting span across two movements that
+  makes the `T` payment auditable.
+
+This path is the under-appreciated middle option. It is always
+available to an owner with sufficient liquidity, which is often the
+case — an owner who sized `(B, Q)` typically holds comparable amounts
+on their wallet.
+
+**(3) `flashClose(bps)`.** Externally-financed exit via a flash-loan
+callback (SPEC-0003a §15). Available when the owner has neither
+patience nor liquidity. Auto-drains all buffers in a single transaction,
+which collapses the `Stake → Swap → Unstake → ClaimRewards` event
+sequence into a compressed `FlashCloseInitiated → Unstake → ClaimRewards`
+that mixes the position-close, the flash-loan pull/repay, the external
+swap, and the settlement drain into one transaction. The accounting
+outcome is the same in net terms, but the events are no longer cleanly
+separable. Cost: flash-loan fee plus possibly forgone yield.
+
+The cleanliness ordering — **(1) wait > (2) self-execute > (3) flashClose**
+— is what determines `flashClose`'s role in the design. It is the
+emergency option, not the default convenience. Earlier framings of
+`flashClose` as "the owner's go-to convenience function" were wrong;
+it is the path the owner takes only when neither (1) nor (2) is
+viable.
+
+### What is emergent (not invariant)
+
+- **When** settlement occurs — depends on spot-price movement, time
+  in range, fee accumulation, executor behaviour, and owner action.
+- **Which case** settlement falls into (1, 2, or 3) — depends on the
+  position's end-state inventory.
+- **How much above `T`** of quote value accumulates — goes to the
+  executor, not the owner. From the user's perspective there is no
+  "bonus", only the deterministic `T`.
+- **Whether the position enters underwater at all** — depends on
+  volatility and range choice relative to the chosen `T`.
+
+### Yield: origins and mechanism
+
+The yield the owner receives has two structural sources, which the
+vault collapses externally into a single number:
+
+- **UV3 fees** that accumulate over the position's lifetime, on both
+  token sides, collected via `collect` at settlement.
+- **LVR substance** that the executor voluntarily transfers to the
+  vault: the executor pays a below-spot rate at `swap()`, and the
+  difference between spot and the executor's input flows into the
+  reward buffer. The executor accepts this because their net is still
+  positive against external venues — the pool's tractability condition
+  is `Fee-APR > σ²/8` (see [lvr-theory-summary.md] context).
+
+Both sources flow indistinguishably into the `rewardBuffer*` slots
+(SPEC-0003a §11) and are paid to the owner via `claimRewards()`. The
+owner sees a single yield number: `T`, quote-denominated, agreed up
+front, paid at settlement. The decomposition into "fees" and
+"LVR-compensation" does not exist for the user — and that is by
+design.
+
+### Risk: origins and crystallisation points
+
+Four risk classes, each with a clear crystallisation point:
+
+| Risk | Driver | Crystallises at |
+|---|---|---|
+| **Principal risk** | structurally **zero at `T = 0`**; non-zero only if owner exits via `flashClose` while `T > 0` is unresolved | `flashClose` call (and only if owner has not first lowered `T`) |
+| **Yield-fulfilment risk** | volatility relative to range width and `T` size | First settlement attempt; or owner's `setYieldTarget(0)` decision to abandon the claim |
+| **Liquidity risk on `flashClose`** | external flash-loan provider conditions (Aave / Balancer / Morpho) | `flashClose` call |
+| **Smart-contract risk** | bugs in vault, NFT manager, or flash-loan provider | Exploit events; mitigation is audit + time-in-production |
+
+Two risks deliberately **not** in this list:
+
+- **IL / LVR from owner perspective.** The vault absorbs both; the
+  owner does not see them. The owner economically still bears LVR
+  (they cede LVR substance to the executor), but as a component of
+  "T vs. market upside" rather than a separate risk.
+- **Permissionless executor behaviour.** Not a risk in the classical
+  sense, because the executor can structurally only act under
+  conditions that preserve principal and yield. The owner does not
+  need to trust the executor.
+
+The take-away: the vault has **two guarantee classes**, and the owner
+chooses via `T` which class is active. The strong guarantee
+(principal at `T = 0`) is always available; the weaker guarantee
+(principal + `T` at `T > 0`) is market-conditional. Risk discussion
+should always specify which class is in scope.

--- a/docs/positions/uniswapv3-staking-vault/rfc-0003-staking-vault.md
+++ b/docs/positions/uniswapv3-staking-vault/rfc-0003-staking-vault.md
@@ -1,0 +1,595 @@
+# RFC-0003: Staking Vault
+
+**Status:** Draft (rewrite)
+**Issue:** TBD
+**Implementation:** SPEC-0003b
+**Author:** @0xNedAlbo
+**Last updated:** 2026-05-06
+
+---
+
+## 1. Summary
+
+The Staking Vault wraps a single Uniswap V3 NFT position and turns it into
+a yield-target-based staking primitive. The owner deposits a position with
+a fixed quote-side reward target `T`. The vault closes the position
+(fully or partially) when the on-chain conditions allow it to honor the
+deposit `(B, Q)` plus the target `T`, paying the owner exactly that and
+distributing any surplus along well-defined paths.
+
+Settlement is permissionless. External actors — keepers, solvers, helper
+bots — drive the close in exchange for either an LVR-implied rate
+discount (when a token swap is needed) or an explicit bounty (when no
+swap is needed). The owner has additional owner-only paths for direct
+trades and for capital-light exits via flash callback.
+
+The vault uses no oracle. All pricing is deterministic from the pool
+state at execution time, classified by a four-case partition over the
+`(b, q)`-balance after position close.
+
+## 2. Motivation
+
+A Uniswap V3 LP position is a complex, two-sided exposure with no
+intrinsic exit signal. The provider holds two tokens that drift relative
+to spot, accumulates fees, and must decide manually when to close — which
+typically means writing a bot, paying for an aggregator, or eyeballing
+the position in a UI.
+
+This RFC turns the position into a position that **closes itself when
+the right economic conditions are met**, without requiring the owner to
+run infrastructure. The mechanism that makes this possible is a vault
+contract that:
+
+- Holds the NFT and the deposit accounting `(B, Q, T)`
+- Exposes a permissionless close path that settles when on-chain state
+  shows the deposit-plus-target is recoverable
+- Compensates external actors via implicit (LVR rate) or explicit
+  (bounty) rewards, so a third-party keeper has positive expected value
+  for closing
+- Falls back to owner-controlled paths (direct trade, flash exit) when
+  external action does not materialize or the owner wants to override
+
+The economic primitive being expressed is: **"I want exactly `B` base
+plus `Q + T` quote out of this position. Close it as soon as the pool
+allows. If it cannot be closed at this target, leave it staked."**
+
+## 3. Concepts and notation
+
+### 3.1 Quote and base
+
+The vault distinguishes the two pool tokens as **quote** and **base**.
+Quote is the unit of account for the yield target; base is everything
+else. Mapping is fixed at stake time via the `isToken0Quote` flag.
+
+For a WETH/USDC position with USDC as quote, base is WETH. The owner's
+yield target `T` is denominated in USDC. The owner's payout on full
+settlement is `(B WETH, Q + T USDC)`.
+
+### 3.2 Deposit and target
+
+At `stake()`, the vault records the deposit `(B, Q)` from the actual
+token amounts consumed by the NFPM mint (after slippage refunds). The
+yield target `T` is set by the owner and is mutable while staked.
+
+`(B, Q, T)` together form the *settlement contract* the vault makes with
+the owner: on full settlement, the owner receives at least `(B, Q + T)`,
+distributed across `unstakeBuffer` (B and Q) and `rewardBuffer` (T plus
+any surplus).
+
+### 3.3 Position close and balance after close
+
+When a settlement path triggers, the vault calls UV3's
+`decreaseLiquidity` (proportional to the close fraction) and `collect`
+(all uncollected fees, not pro-rated — UV3 fee collection is
+all-or-nothing per `tokenId`). The resulting fresh balance the vault
+receives is denoted `(b, q)`.
+
+This is the central observable: `(b, q)` is what the position can
+deliver right now, and the four-case classification compares it to the
+targets `(B × frac, (Q + T) × frac)` where `frac` is the close fraction.
+
+### 3.4 LVR-implied rate
+
+LVR ("loss versus rebalancing") is the structural feature of UV3
+positions where the average price the position trades at across its
+range is below the current spot price. The vault exposes this rate
+mechanically: in Cases 2 and 3 below, the vault offers a swap at the
+exact `(b, q)`-derived rate from the partial close, which is by
+construction the LVR-implied rate. The keeper accepts that rate (or
+declines).
+
+The vault never quotes "spot minus X%". It quotes "this much in, this
+much out, take it or leave it." The fact that this rate corresponds to
+a discount versus current spot is not a parameter — it is the structural
+property of the close itself.
+
+## 4. The four cases
+
+After closing the position, the vault holds `(b, q)` of base and quote
+respectively. Compare against `(targetBase, targetQuote) = (B × frac,
+(Q + T) × frac)`:
+
+| Case | Condition | Status |
+|------|-----------|--------|
+| 1 | `b ≥ targetBase AND q ≥ targetQuote` | NoSwapNeeded |
+| 2 | `b > targetBase AND q < targetQuote` | Executable |
+| 3 | `b < targetBase AND q > targetQuote` | Executable |
+| 4 | `b < targetBase AND q < targetQuote` | Underwater |
+
+**Case 1 (NoSwapNeeded).** The vault holds enough of both tokens. No
+trade is needed; settlement is purely accounting. Surplus over
+`(B, Q + T)` is the *bounty* paid to the caller of the permissionless
+`settle()` path (see §5.3).
+
+**Case 2 (Executable, base surplus).** Vault has too much base, not
+enough quote. It offers `(b − targetBase)` base to a keeper in exchange
+for at least `(targetQuote − q)` quote. The keeper sells the base on
+the market and keeps the LVR-implied rate as profit.
+
+**Case 3 (Executable, quote surplus).** Symmetric to Case 2: vault has
+too much quote, offers it for base.
+
+**Case 4 (Underwater).** The position cannot deliver `(B, Q + T)` at the
+current price. This is **only reachable when `T > 0`**. Mathematically,
+a UV3 position close always yields either `(b ≥ B AND q ≤ Q)` or
+`(b ≤ B AND q ≥ Q)` plus non-negative fees on both sides. So `b < B`
+implies `q ≥ Q`, and Case 4's `q < Q + T` requires `T > fees_quote`.
+
+This means Underwater is always a yield-target phenomenon, never a pool
+phenomenon. The owner controls whether the position is in Case 4: if
+`setYieldTarget(0)` is called, the vault transitions to Case 2 or 3 and
+becomes Executable. The owner trades reward expectation for exit
+optionality.
+
+### 4.1 Boundary handling
+
+Comparisons use `≥` consistently. Boundary equalities (`b == B`, `q ==
+Q+T`) fall into Case 1. Degenerate sub-amounts (`amountIn == 0` or
+`amountOut == 0` in Cases 2/3) are handled by the standard token-flow
+path with zero transfers — they do not constitute special cases.
+
+### 4.2 Why no fifth case
+
+A previous draft of this RFC proposed a fifth "discount swap" case
+(both surpluses, swap at oracle-discounted rate to incentivize a
+keeper). It was rejected because:
+
+1. It required a TWAP oracle, contradicting the no-oracle goal.
+2. It introduced an arbitrary 5% discount parameter.
+3. The case it addressed — both surpluses — is now handled cleanly by
+   `settle()` with surplus-as-bounty, no oracle needed.
+
+The four-case partition is final.
+
+## 5. Settlement paths
+
+The vault exposes four mutually exclusive settlement paths, each
+matching exactly one role × case combination.
+
+| Function | Caller | Cases | Close size | Token flow |
+|----------|--------|-------|------------|------------|
+| `swap` | Owner | 2, 3 | partial or full | atomic in/out |
+| `flashSwap` | Public | 2, 3 | full | callback push/pull |
+| `settle` | Public | 1 | full | bounty push to recipient |
+| `flashSettle` | Owner | 1, 2, 3, 4 | partial or full | callback push/pull |
+
+### 5.1 `swap()` — owner trade
+
+The owner trades against the vault at the LVR-implied rate. The owner
+specifies the close size as a `liquidity` parameter (an explicit number
+of NFPM liquidity units), and the vault dictates the resulting
+`(amountIn, amountOut)` from the post-close state.
+
+Slippage bounds (`amountInMax`, `amountOutMin`) protect against pool
+drift between off-chain quote and on-chain execution. The owner pays
+`amountIn` of `tokenIn`; the recipient receives `amountOut` of
+`tokenOut`. Reverts in Case 1 (use `settle`) and Case 4 (reduce T or
+use `flashSettle`).
+
+This is the "I want to close manually and trade against my own vault"
+path. It is partial-capable because the owner is in control of close
+size and is aware of the implications.
+
+### 5.2 `flashSwap()` — keeper trade
+
+Permissionless. Always full close. The keeper provides a callback
+contract; the vault pushes `tokenOut` to the callback and expects
+`tokenIn ≥ amountInMin` returned. The frame is reentrancy-locked via
+the `FlashSwapInProgress` state.
+
+This is the **primary keeper integration point**. A standalone keeper
+bot:
+
+1. Polls `quoteSwap()` across vaults
+2. For Executable status, evaluates whether the LVR-implied rate is
+   profitable after gas and external swap costs
+3. Calls `flashSwap()` with a callback that takes a UV3-pool flash
+   loan, executes the trade, sells the result on AMM, repays
+4. Keeps the LVR-discount as profit
+
+Why always full? Yield-target preservation. Partial close shrinks `T`
+proportionally, leaving the remainder exposed to further drift. If
+keeper #1 closes 30%, keeper #2 may find a Case-4 position. The
+yield-target promise breaks. Owners reaching `q ≥ Q + T` want the full
+position closed atomically.
+
+### 5.3 `settle()` — Case 1 with bounty
+
+Permissionless. Always full close. Used when the position is in
+NoSwapNeeded — both surpluses present, no trade needed.
+
+Mechanics:
+
+- Position fully closed, vault holds `(b, q)` with `b ≥ B`, `q ≥ Q+T`
+- `unstakeBuffer` filled with exactly `(B, Q)`
+- `rewardBuffer` filled with exactly `(0, T)`
+- Surplus `(b − B, q − (Q+T))` transferred to caller's `recipient` as
+  bounty
+
+The bounty exists because Case 1 has no implicit keeper reward (no
+trade, no LVR discount). It compensates for gas and incentivizes
+permissionless settlement, so the owner's yield target is realized
+without owner action.
+
+In practice the bounty is small. Case 1 only arises when UV3 fees push
+both `b` past `B` and `q` past `Q + T` simultaneously. If either
+inequality were strict by more than a dust amount, the position would
+already have been in Case 2 or 3 and a `flashSwap()` keeper would have
+settled it earlier. Case 1 is an edge case at the four-quadrant origin,
+and its bounty reflects that.
+
+The owner trades the surplus over `(B, Q + T)` against the guarantee
+that the position settles automatically when T is reached. For typical
+positions with small Case-1 surplus, this is a favorable trade.
+
+### 5.4 `flashSettle()` — owner exit
+
+Owner only. Any case (including Underwater). Partial-capable.
+
+Mechanics:
+
+- Position closes `liquidity` units, freeing `(b, q)` proportional to
+  the close fraction
+- All freed `(b, q)` is pushed to `callbackTarget`
+- Callback must return `(B × frac, (Q + T) × frac)` to the vault
+- Vault verifies and fills buffers additively
+- Owner subsequently calls `unstake()` and `claimRewards()` to drain
+
+This is **not a swap**. The helper receives whatever the pool gave at
+execution time and must return the deposit-plus-target. Whether the
+helper needs to swap, top up from inventory, or use a flash loan
+depends on the case classification at execution time:
+
+- Case 1 (b > B, q > Q+T): helper holds surplus, returns the targets,
+  keeps the rest (functionally a private `settle` for the owner)
+- Cases 2/3: helper has imbalance, swaps externally, returns targets
+- Case 4: helper has shortfalls on both sides, must source liquidity
+  via flash loan or owner inventory
+
+Overpayment is accepted on both sides and flows to `rewardBuffer`. This
+makes defensive helper implementations safe — round-up buffers,
+slippage cushions, and flash-loan fee margins all over-return without
+revert risk, and the surplus flows back to the owner.
+
+Purpose: enable owner exit (full or partial) without requiring the
+owner to bring matched capital. The helper bridges the capital gap; the
+owner recovers only the bridging cost plus flash fees plus gas. This
+contrasts with the alternative path `swap → unstake → claimRewards`,
+which requires the owner to bring full `amountIn` from external
+inventory.
+
+## 6. State machine
+
+```
+            ┌─────────┐
+            │  Empty  │
+            └────┬────┘
+                 │ stake()
+                 ▼
+            ┌─────────┐
+            │ Staked  │ ───────┐
+            └────┬────┘        │ swap (partial)
+                 │             │ flashSettle (partial)
+                 │             │
+                 │ swap (full) │
+                 │ flashSwap   │
+                 │ settle      │
+                 │ flashSettle (full)
+                 │             │
+                 ├──◄──── FlashSwapInProgress (transient)
+                 ├──◄──── FlashSettleInProgress (transient)
+                 │             │
+                 │             ▼
+                 │        ┌─────────┐
+                 └───────►│ Settled │
+                          └─────────┘
+```
+
+States:
+
+- **Empty** — clone initialized, no position yet
+- **Staked** — active position, all settlement paths available
+- **FlashSwapInProgress** — transient, between callback push and verification
+- **FlashSettleInProgress** — transient, between callback push and verification
+- **Settled** — position fully closed, buffers filled, drains pending
+
+`unstake()` and `claimRewards()` are available in `Staked` and `Settled`.
+`stakeTopUp()` and `setYieldTarget()` are available only in `Staked`.
+
+The state lock during the two flash callbacks ensures all other vault
+functions revert during the callback frame, preventing reentrancy
+attacks and racing modifications.
+
+## 7. Buffer mechanics
+
+The vault holds two pairs of buffers:
+
+- `unstakeBufferBase`, `unstakeBufferQuote` — accumulating principal
+  reclaimed via settlement. Drained by `unstake()`.
+- `rewardBufferBase`, `rewardBufferQuote` — accumulating yield reward
+  including target T and any surplus. Drained by `claimRewards()`.
+
+Buffers fill **additively** across multiple settlement calls. A vault
+may settle in pieces (multiple partial swaps, then a full flashSettle,
+etc.); each call adds to existing buffer balances. Drains zero out the
+respective buffers and transfer to owner.
+
+Per-case buffer increments:
+
+| Path | unstakeBase += | unstakeQuote += | rewardBase += | rewardQuote += |
+|------|----------------|------------------|---------------|----------------|
+| `swap` (Case 2) | B × frac | Q × frac | (b − B × frac) | (q + amountIn − Q × frac) |
+| `swap` (Case 3) | B × frac | Q × frac | (b + amountIn − B × frac) | (q − Q × frac) |
+| `flashSwap` (Case 2) | B | Q | (b − B) | (q + amountIn − Q) |
+| `flashSwap` (Case 3) | B | Q | (b + amountIn − B) | (q − Q) |
+| `settle` | B | Q | 0 | T |
+| `flashSettle` (any case) | B × frac | Q × frac | (postBase − B × frac) | (postQuote − Q × frac) |
+
+In `flashSettle`, `postBase` and `postQuote` are the actual amounts the
+helper returned (`≥ B × frac`, `≥ (Q+T) × frac`). Overpayment flows to
+reward.
+
+In `settle`, the surplus over `(B, Q+T)` does *not* flow to reward —
+it goes to the caller as bounty (see §5.3). The reward buffer receives
+exactly `T`.
+
+## 8. Top-up
+
+`stakeTopUp()` adds liquidity to the existing position. The vault adds
+the consumed `(amount0, amount1)` to `(B, Q)` proportionally. The yield
+target `T` is scaled by the new-to-old quote ratio:
+
+```
+T_new = T_old × (Q + ΔQ) / Q   (rounded up)
+```
+
+Rounding up prevents downward drift on repeated tiny top-ups. Skipped if
+`Q == 0` (no anchor to scale against — a base-only initial deposit
+with later top-up keeps T constant).
+
+The implicit yield rate `T / Q` stays constant (modulo rounding). An
+owner who originally deposited 1000 quote at T = 100 (10%) and later
+adds another 1000 quote ends up with `B' = 2 × B`, `Q' = 2000`,
+`T' = 200` — same 10% rate over the larger position.
+
+## 9. Yield target mutability
+
+`setYieldTarget()` allows the owner to change `T` while staked. This
+serves three purposes:
+
+1. **Lower T to escape Underwater.** Setting `T = 0` always makes the
+   position Executable (Cases 2 or 3). Useful when the owner concedes
+   the target and wants to exit at break-even on principal alone.
+
+2. **Raise T to take more risk.** Owner extends their reward
+   expectation, accepting that the position stays open longer.
+
+3. **Adjust to changed pool conditions.** Volume regime shifts may
+   warrant target recalibration without forcing a close + re-stake.
+
+Mutability is protected against keeper front-running by the slippage
+parameters at the keeper's call site. The keeper specifies its accepted
+bounds via `amountInMax` / `amountOutMin`; if the owner raises T
+between the keeper's quote and execution, the keeper's bounds are
+violated and the call reverts cleanly. No locking or commit-reveal is
+needed.
+
+## 10. Pricing and oracle stance
+
+The vault uses **no external price oracle and no pool TWAP**. All
+pricing is deterministic from the pool state at execution time:
+
+- `pool.slot0().sqrtPriceX96` — current spot price, used to compute
+  `(b, q)` from the partial close
+- NFPM `positions(tokenId)` — current liquidity, fee growth, owed amounts
+- `LiquidityAmounts.getAmountsForLiquidity` — to convert liquidity ×
+  sqrtPrice to token amounts
+
+The four-case classification depends only on `(b, q)` versus
+`(B × frac, (Q + T) × frac)`. There is no rate-decision step that
+requires an oracle.
+
+Consequences:
+
+- No deployment dependency on Chainlink, third-party feeds, or
+  cross-pool basis
+- No TWAP-manipulation surface
+- Per-call gas is reduced (no oracle round-trip)
+- Pricing is exactly the LVR-implied rate, which is always at or below
+  current spot — keepers self-select based on whether external markets
+  give them better prices (in which case they don't act and the vault
+  stays open)
+
+The trade-off is that the vault cannot offer a "spot-priced" trade. In
+particular, a Case-4 position cannot be closed by the vault itself
+without owner action (either lower T or use flashSettle). This is by
+design: the no-oracle stance is non-negotiable and Case 4 is rare and
+recoverable.
+
+## 11. Solver-network compatibility
+
+Each settlement path moves exactly one token in and exactly one token
+out per call (or zero in the no-trade paths). This single-direction
+property is essential for solver-network compatibility — limit-order
+solvers (Composable CoW, similar) cannot express "executor sends X
+base AND Y quote, receives Z quote" in a single atomic intent.
+
+The vault's `quoteSwap()` returns the exact `(bidToken, bidAmount,
+askToken, askAmountMin)` at full close. A solver-network adapter or
+keeper bot can read this view, decide whether to act, and call
+`flashSwap()` (or `swap()` for owner-side flows) without further
+negotiation.
+
+The atomic-trade form of `swap()` matches solver-routing patterns where
+the settlement contract holds `tokenIn` from another order in the same
+batch. The callback form of `flashSwap()` matches keeper patterns where
+the bot needs to bridge funds via a flash loan.
+
+The vault thus supports both **direct keepers** (no solver network,
+take the LVR rate directly) and **solver-network integration** (vault
+appears as a venue in a routed order), without requiring different
+contract paths.
+
+## 12. Reward direction
+
+The yield target is quote-denominated. The owner's reward is
+quote-denominated. Base-side fees collected during settlement flow into
+the swap step (executor takes them in Cases 2/3) or into the bounty
+(caller takes them in Case 1) or into the reward buffer (in
+flashSettle's overpayment path).
+
+The owner sees a clean quote-denominated outcome on `claimRewards()`,
+plus base-side amounts only when surplus flows through `flashSettle`'s
+overpayment path or through `swap`'s buffer increments. The latter is
+typically small (fee accumulation, not principal drift).
+
+## 13. Reentrancy and state locks
+
+All state-mutating functions use OpenZeppelin's `nonReentrant` modifier
+as a baseline guard against unexpected reentrancy from non-standard
+tokens (ERC-777, fee-on-transfer hooks, transfer hooks).
+
+The two flash paths add explicit state locks:
+
+- `flashSwap` sets state to `FlashSwapInProgress` before the callback
+- `flashSettle` sets state to `FlashSettleInProgress` before the callback
+
+While in either of these states, all other vault functions revert via
+the state-check modifiers. This is a stronger, semantically richer guard
+than `nonReentrant` alone — it prevents not just direct reentrancy but
+also any cross-function interaction during the callback frame.
+
+The state lock also makes the in-progress condition observable. An
+indexer seeing a `FlashSwapInitiated` event without a matching `Swap`
+event in the same transaction knows the call reverted.
+
+## 14. Multicall
+
+The vault inherits OpenZeppelin's `Multicall` mixin, allowing the owner
+to bundle multiple calls atomically. Common patterns:
+
+- `setYieldTarget` then `flashSettle`, to lower T just-in-time for an
+  Underwater exit
+- `unstake` then `claimRewards`, to drain both buffers in one tx
+- `swap` (partial) then `unstake` then `claimRewards`, for an owner-
+  driven manual close cycle
+
+Per-call state checks remain authoritative — `multicall` does not bypass
+them. The `nonReentrant` modifier across calls in the same multicall
+is handled per individual call (each enters and exits its own guard).
+
+## 15. Out of scope
+
+The following are explicitly out of scope for this RFC:
+
+- **CoW-Swap adapter**. A separate concern that wraps the vault's
+  `flashSwap()` and `quoteSwap()` to make vaults visible to a CoW
+  solver network. The vault's interface is designed to be compatible
+  but the adapter itself is not part of the vault.
+
+- **Multi-position vaults**. Each vault wraps exactly one NFT. Owners
+  with multiple positions deploy multiple vaults via the factory.
+
+- **Cross-vault accounting**. Each vault is fully self-contained. There
+  is no protocol-level treasury, fee, or shared state.
+
+- **Vault transferability**. The owner is bound at clone init time and
+  cannot be changed. Owners who want to transfer ownership use
+  `flashSettle` to exit and re-stake under the new owner.
+
+- **Per-vault TWAP windows or oracle configuration**. Removed in this
+  rewrite — the vault is fully oracle-free.
+
+## 16. Design decisions log
+
+Decisions made during chat-mode design that are now baked in:
+
+- **Liquidity over basis points**. NFPM liquidity units (uint128) are
+  used as the close-size parameter, replacing the earlier `bps`-based
+  approach. Liquidity is the natural primitive for UV3, makes top-up
+  semantics simpler, and avoids the implicit-vs-explicit-fraction
+  confusion of `pendingBps`.
+
+- **No `pendingBps` mechanism**. Removed. The owner uses the explicit
+  `liquidity` parameter at the call site of `swap` or `flashSettle`.
+  Permissionless paths (`flashSwap`, `settle`) are always full close.
+
+- **Four settlement paths, not one**. Earlier drafts had a single
+  `swap()` that handled all roles and cases. Splitting into `swap`
+  (owner-trade), `flashSwap` (keeper-trade), `settle` (Case 1 bounty),
+  `flashSettle` (owner-exit-with-helper) gives each path a single,
+  clear responsibility and matches the actual economic actor in each
+  scenario.
+
+- **Bounty-as-surplus in settle**. The bounty for Case 1 is the surplus
+  over `(B, Q + T)`. Owner trades this surplus against the
+  permissionless settlement guarantee. In practice the surplus is
+  small (Case 1 only arises near the four-quadrant origin), so the
+  trade is favorable.
+
+- **Underwater = T-escapable**. Mathematically Case 4 is only reachable
+  when `T > 0`. Setting `T = 0` always makes the position Executable.
+  This is documented as the recommended path out of Underwater, in
+  addition to `flashSettle` with helper.
+
+- **No oracle, no TWAP**. Earlier drafts proposed a 5%-discount Case
+  for both-surplus situations using TWAP-spot pricing. Replaced by
+  `settle` with surplus-as-bounty. The vault is now fully oracle-free.
+
+- **Overpayment to reward in flash callbacks**. Both `flashSwap` and
+  `flashSettle` accept callback over-return as overpayment that flows
+  to the reward buffer. This makes defensive helper implementations
+  safe (round-up buffers, slippage cushions).
+
+- **`callbackTarget == address(0)` rejected**. Earlier draft proposed a
+  no-callback mode for `flashSettle`. Removed because the use cases
+  it would address are already covered by `swap`, `settle`, or direct
+  pre-funding plus drain. Keeping `flashSettle` callback-only
+  simplifies the contract and clarifies the function's purpose.
+
+## 17. Open questions
+
+- **Bounty floor for `settle()`**. Should `settle` revert if both
+  surpluses are zero (boundary case)? Current decision: no, because the
+  position *is* settle-able and an owner-affiliated helper may want to
+  trigger settlement even without bounty. A bot operator who only
+  cares about profit will simply not call when the bounty is zero.
+
+- **Recipient for `swap()`**. Currently `recipient` is mandatory and
+  cannot be `address(0)`. Should `address(0)` be interpreted as
+  "owner"? Decision: no, explicitness preferred. Owner specifies
+  `recipient = msg.sender` if they want to send to themselves.
+
+- **Slippage protection for `flashSettle`**. Currently no slippage
+  bounds. Helper-side slippage protection is the helper-contract's
+  responsibility. Should we add explicit bounds on `flashSettle` for
+  cases where the owner uses a generic helper they don't fully
+  control? Open.
+
+- **Permissionless `settle()` recipient policy**. Should there be any
+  policy on who can be the recipient (e.g., must equal `msg.sender`)?
+  Currently no — operator can route to any address. Open whether
+  abuse vectors exist (e.g., spam settle calls to drain owner's
+  surplus to attacker-controlled addresses). Counter-argument: the
+  owner's deposit-plus-target is preserved regardless, only the small
+  surplus is at stake.

--- a/docs/positions/uniswapv3-staking-vault/spec-0003b-staking-vault.md
+++ b/docs/positions/uniswapv3-staking-vault/spec-0003b-staking-vault.md
@@ -1,0 +1,1399 @@
+# SPEC-0003b: Staking Vault for Uniswap V3 Positions — Implementation Spec
+
+**Date:** 2026-05-06
+**Status:** ready for implementation
+**Source:** Derived from local RFC-0003 (rev. 2026-05-06).
+**Audience:** Coding agent (Claude Code).
+
+This spec describes *what* to implement. Conceptual rationale and
+alternatives live in the RFC. Read the spec for code; consult the RFC
+only if a concrete decision in the spec seems ambiguous.
+
+This spec replaces SPEC-0003a in full. The changes are substantive —
+different external interface, different settlement-path factoring,
+different storage shape — and a clean rewrite is preferable to a
+diff-style update.
+
+---
+
+## 1. Architecture
+
+- **`StakingVaultFactory`** — singleton contract per chain. Deploys
+  `StakingVault` clones via EIP-1167 minimal proxy.
+- **`StakingVault`** — single implementation contract. Each clone wraps
+  exactly one Uniswap V3 position and is bound to exactly one owner.
+- **Non-transferable ownership.** The owner address is set once during
+  clone initialization. Once set, it MUST NOT be mutable. No transfer
+  function, no ownership token, no upgrade mechanism that could rebind it.
+- **Atomic create-and-initialize.** The factory's `createVault()` MUST
+  perform the clone deployment AND initialization atomically in the same
+  call frame. This closes the standard EIP-1167 race-condition where a
+  third party could front-run an external `initialize()` call. The
+  implementation's `initialize()` SHOULD additionally revert on a second
+  invocation.
+- **One vault per UV3 position.** A new clone is deployed per
+  `createVault()` call; once a vault has minted its UV3 position via
+  `stake()`, that position lives for the vault's lifetime. Owners create
+  multiple positions by deploying multiple vaults; in-vault top-ups apply
+  to the existing position only.
+
+## 2. Roles
+
+- **Owner** — caller of the initial `stake()`. Set as the vault's `owner`
+  for the vault's lifetime. Sole authorized caller of owner-only
+  functions: `stakeTopUp`, `setYieldTarget`, `swap`, `flashSettle`,
+  `unstake`, `claimRewards`.
+- **Executor** — any external address. Calls `flashSwap()` (Cases 2/3)
+  and `settle()` (Case 1) in valid states. Self-selecting; nobody is
+  required to execute. Solver-network compatible: the vault offers a
+  limit-order-style trade (vault dictates the exact output and a minimum
+  input); the executor accepts (calls) or declines (does not call).
+
+## 3. Storage
+
+Per-vault clone state:
+
+| Slot | Type | Set by | Mutability |
+|---|---|---|---|
+| `owner` | `address` | `initialize()` | immutable post-init |
+| `pool` | `address` (IUniswapV3Pool) | initial `stake()` | immutable post-stake |
+| `tokenId` | `uint256` (UV3 NFT ID) | initial `stake()` | immutable post-stake |
+| `token0`, `token1` | `address` | initial `stake()` | immutable post-stake |
+| `tickLower`, `tickUpper` | `int24` | initial `stake()` | immutable post-stake |
+| `isToken0Quote` | `bool` | initial `stake()` | immutable post-stake |
+| `stakedBase` | `uint256` (= B) | `stake()` / settlement paths | additive on stake; subtractive on settlement |
+| `stakedQuote` | `uint256` (= Q) | `stake()` / settlement paths | additive on stake; subtractive on settlement |
+| `yieldTarget` | `uint256` (= T) | `stake()` / `setYieldTarget()` / settlement | scaled on top-up; absolute via setter; reduced on settlement |
+| `state` | `enum` | transitions | per state machine |
+| `unstakeBufferBase` | `uint256` | settlement paths fill; `unstake` drains | |
+| `unstakeBufferQuote` | `uint256` | settlement paths fill; `unstake` drains | |
+| `rewardBufferBase` | `uint256` | settlement paths fill; `claimRewards` drains | |
+| `rewardBufferQuote` | `uint256` | settlement paths fill; `claimRewards` drains | |
+
+The `pendingBps` slot from SPEC-0003a is REMOVED. Partial close is
+expressed at call time via an explicit `liquidity` parameter on the
+relevant functions.
+
+The state enum:
+
+```solidity
+enum State {
+    Empty,                   // initial state, before stake()
+    Staked,                  // position open
+    FlashSwapInProgress,     // transient, set during flashSwap callback
+    FlashSettleInProgress,   // transient, set during flashSettle callback
+    Settled                  // position fully closed
+}
+```
+
+## 4. State machine
+
+Transitions:
+
+| From | Trigger | To |
+|---|---|---|
+| `Empty` | `stake()` | `Staked` |
+| `Staked` | `swap(liquidity < positionLiquidity, ...)` | `Staked` |
+| `Staked` | `swap(liquidity == positionLiquidity, ...)` | `Settled` |
+| `Staked` | `flashSwap(...)` (entry) | `FlashSwapInProgress` |
+| `FlashSwapInProgress` | callback returns successfully | `Settled` (always full close) |
+| `Staked` | `settle(...)` | `Settled` (always full close) |
+| `Staked` | `flashSettle(liquidity, ...)` (entry) | `FlashSettleInProgress` |
+| `FlashSettleInProgress` | callback returns successfully (partial) | `Staked` |
+| `FlashSettleInProgress` | callback returns successfully (full) | `Settled` |
+
+Callability matrix:
+
+| Function | `Empty` | `Staked` | `FlashSwapInProgress` | `FlashSettleInProgress` | `Settled` |
+|---|:---:|:---:|:---:|:---:|:---:|
+| `initialize()` | ✓ once | — | — | — | — |
+| `stake()` | ✓ | — | — | — | — |
+| `stakeTopUp()` | — | ✓ | — | — | — |
+| `setYieldTarget()` | — | ✓ | — | — | — |
+| `quoteSwap()` (view) | always | always | always | always | always |
+| `previewSettle()` (view) | always | always | always | always | always |
+| `positionLiquidity()` (view) | always | always | always | always | always |
+| `swap()` | — | ✓ | — | — | — |
+| `flashSwap()` | — | ✓ | — | — | — |
+| `settle()` | — | ✓ | — | — | — |
+| `flashSettle()` | — | ✓ | — | — | — |
+| `unstake()` | — | ✓ | — | — | ✓ |
+| `claimRewards()` | — | ✓ | — | — | ✓ |
+| `multicall()` | always (composes the above; subject to per-call state checks) |
+
+`unstake()` and `claimRewards()` are explicitly callable in `Staked` so
+that mid-lifecycle partial-settlement buffers can be drained without
+waiting for full close.
+
+## 5. Tokens and conventions
+
+- **`base`** — the position's non-quote token. Read via `baseToken()`.
+- **`quote`** — the position's quote-denominated token. Read via
+  `quoteToken()`. Equals `token0` or `token1` based on
+  `isToken0Quote`.
+- All amounts (`B`, `Q`, `T`, buffer values, function parameters) are in
+  smallest token units (no decimals normalisation).
+- The vault never holds either token outside of:
+  - the open UV3 position (managed by NFPM),
+  - the four buffer slots,
+  - the transient frame of a `flashSwap`/`flashSettle` callback (between
+    push and verification).
+
+## 6. Errors
+
+```solidity
+error AlreadyInitialized();
+error NotOwner();
+error WrongState();
+error ZeroOwner();
+
+error InvalidLiquidity();              // 0 or > positionLiquidity
+error InvalidRecipient();              // address(0)
+error InvalidCallbackTarget();         // address(0)
+error DeadlineExpired();
+error TokenMismatch();                 // tokenIn/tokenOut don't match case
+error SlippageExceeded();              // amountInMax / amountOutMin breached
+
+error UseSettleInsteadOfSwap();        // swap() in Case 1
+error UseFlashSettleInsteadOfSwap();   // swap() in Case 4
+error UseSettleInsteadOfFlashSwap();   // flashSwap() in Case 1
+error UseFlashSettleInsteadOfFlashSwap(); // flashSwap() in Case 4
+error UseSwapInsteadOfSettle();        // settle() in Case 2/3
+error UseFlashSettleInsteadOfSettle(); // settle() in Case 4
+
+error InsufficientReturn();            // flashSwap callback returned < amountInMin
+error InsufficientBaseReturned();      // flashSettle callback returned < expectedBase
+error InsufficientQuoteReturned();     // flashSettle callback returned < expectedQuote
+
+error NothingToUnstake();              // unstakeBuffer* both zero
+error NothingToClaim();                // rewardBuffer* both zero
+
+error PoolResolutionFailed();          // factory could not derive pool address
+error YieldTargetOverflow();           // Q + T overflows uint256 — would force Underwater
+```
+
+## 7. Public interface
+
+```solidity
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// ─── Parameter structs ─────────────────────────────────────────────────
+
+struct StakeParams {
+    address token0;
+    address token1;
+    uint24  fee;
+    int24   tickLower;
+    int24   tickUpper;
+    uint256 amount0Desired;
+    uint256 amount1Desired;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    uint256 deadline;
+}
+
+struct TopUpParams {
+    uint256 amount0Desired;
+    uint256 amount1Desired;
+    uint256 amount0Min;
+    uint256 amount1Min;
+    uint256 deadline;
+}
+
+// ─── Quote types ───────────────────────────────────────────────────────
+
+enum SwapStatus {
+    NotApplicable,  // state ∉ {Staked}
+    NoSwapNeeded,   // Case 1 — settle() bounty path
+    Executable,     // Case 2 or 3 — swap() / flashSwap() trade path
+    Underwater      // Case 4 — only when T > 0; reduce T or use flashSettle()
+}
+
+struct SwapQuote {
+    SwapStatus status;
+    uint128    liquidity;       // current position liquidity; 0 if NotApplicable
+    address    bidToken;        // 0 unless Executable; vault offers this token
+    uint256    bidAmount;       // 0 unless Executable; exact at full close
+    address    askToken;        // 0 unless Executable; vault demands this token
+    uint256    askAmountMin;    // 0 unless Executable; minimum at full close
+}
+
+// ─── Callback interfaces ───────────────────────────────────────────────
+
+interface IFlashSwapCallback {
+    function flashSwapCallback(
+        address tokenIn,
+        uint256 amountInMin,
+        address tokenOut,
+        uint256 amountOut,
+        bytes calldata data
+    ) external;
+}
+
+interface IFlashSettleCallback {
+    function flashSettleCallback(
+        uint256 expectedBase,
+        uint256 expectedQuote,
+        bytes calldata data
+    ) external;
+}
+
+// ─── Vault interface ───────────────────────────────────────────────────
+
+interface IStakingVault {
+
+    // ── Events ────────────────────────────────────────────────────────
+
+    event Stake(
+        address indexed owner,
+        uint256 baseDelta,
+        uint256 quoteDelta,
+        uint256 yieldTargetAfter,
+        uint256 indexed tokenId,
+        uint128 liquidityDelta
+    );
+    event YieldTargetSet(
+        address indexed owner,
+        uint256 oldTarget,
+        uint256 newTarget
+    );
+    event Swap(
+        address indexed caller,
+        address indexed recipient,
+        uint128 liquidityClosed,
+        address tokenIn,
+        uint256 amountIn,
+        address tokenOut,
+        uint256 amountOut
+    );
+    event FlashSwapInitiated(
+        address indexed caller,
+        address indexed callbackTarget,
+        uint128 liquidityClosed,
+        address tokenIn,
+        uint256 amountInMin,
+        address tokenOut,
+        uint256 amountOut,
+        bytes data
+    );
+    event Settle(
+        address indexed caller,
+        address indexed recipient,
+        uint128 liquidityClosed,
+        uint256 baseBounty,
+        uint256 quoteBounty
+    );
+    event FlashSettleInitiated(
+        address indexed owner,
+        uint128 liquidity,
+        address indexed callbackTarget,
+        bytes data
+    );
+    event FlashSettle(
+        address indexed owner,
+        uint128 liquidityClosed,
+        uint256 expectedBase,
+        uint256 expectedQuote,
+        uint256 baseReturned,
+        uint256 quoteReturned
+    );
+    event Unstake(address indexed owner, uint256 base, uint256 quote);
+    event ClaimRewards(address indexed owner, uint256 baseAmount, uint256 quoteAmount);
+
+    // ── Initialization ────────────────────────────────────────────────
+
+    function initialize(address owner) external;
+
+    // ── Owner lifecycle ───────────────────────────────────────────────
+
+    function stake(
+        StakeParams calldata positionParams,
+        bool isToken0Quote,
+        uint256 yieldTarget
+    ) external returns (uint256 tokenId);
+
+    function stakeTopUp(TopUpParams calldata params) external;
+
+    function setYieldTarget(uint256 newTarget) external;
+
+    // ── Views ─────────────────────────────────────────────────────────
+
+    function positionLiquidity() external view returns (uint128);
+
+    function quoteSwap() external view returns (SwapQuote memory);
+
+    function previewSettle() external view returns (
+        bool canSettle,
+        uint128 liquidity,
+        uint256 baseBounty,
+        uint256 quoteBounty
+    );
+
+    // ── Settlement — owner trade (Cases 2, 3) ─────────────────────────
+
+    function swap(
+        uint128 liquidity,
+        address tokenIn,
+        uint256 amountInMax,
+        address tokenOut,
+        uint256 amountOutMin,
+        address recipient,
+        uint256 deadline
+    ) external returns (uint256 amountIn, uint256 amountOut);
+
+    // ── Settlement — permissionless trade (Cases 2, 3) ────────────────
+
+    function flashSwap(
+        address tokenIn,
+        uint256 amountInMax,
+        address tokenOut,
+        uint256 amountOutMin,
+        address callbackTarget,
+        bytes calldata data,
+        uint256 deadline
+    ) external returns (uint256 amountIn, uint256 amountOut);
+
+    // ── Settlement — permissionless no-trade (Case 1) ─────────────────
+
+    function settle(
+        address recipient,
+        uint256 deadline
+    ) external returns (uint256 baseBounty, uint256 quoteBounty);
+
+    // ── Settlement — owner exit with helper (any case) ────────────────
+
+    function flashSettle(
+        uint128 liquidity,
+        address callbackTarget,
+        bytes calldata data,
+        uint256 deadline
+    ) external;
+
+    // ── Buffer drains — owner only ────────────────────────────────────
+
+    function unstake() external;
+
+    function claimRewards() external;
+
+    // ── Multicall (provided by OZ Multicall mixin) ────────────────────
+    // function multicall(bytes[] calldata) external returns (bytes[] memory);
+}
+```
+
+## 8. `stake()` — initial mint
+
+Owner-only, `nonReentrant`. State must be `Empty`.
+
+```
+function stake(
+    StakeParams calldata p,
+    bool isToken0Quote_,
+    uint256 yieldTarget_
+) external onlyOwner nonReentrant returns (uint256 tokenId_) {
+    require(state == Empty);
+
+    // Pull desired amounts from caller
+    if (p.amount0Desired > 0)
+        IERC20(p.token0).safeTransferFrom(msg.sender, this, p.amount0Desired);
+    if (p.amount1Desired > 0)
+        IERC20(p.token1).safeTransferFrom(msg.sender, this, p.amount1Desired);
+
+    // Approve NFPM (forceApprove for non-zero-only tokens)
+    if (p.amount0Desired > 0) IERC20(p.token0).forceApprove(npm, p.amount0Desired);
+    if (p.amount1Desired > 0) IERC20(p.token1).forceApprove(npm, p.amount1Desired);
+
+    uint128 liquidity_;
+    uint256 amount0Used;
+    uint256 amount1Used;
+    (tokenId_, liquidity_, amount0Used, amount1Used) = npm.mint(MintParams({
+        token0: p.token0, token1: p.token1, fee: p.fee,
+        tickLower: p.tickLower, tickUpper: p.tickUpper,
+        amount0Desired: p.amount0Desired, amount1Desired: p.amount1Desired,
+        amount0Min: p.amount0Min, amount1Min: p.amount1Min,
+        recipient: address(this), deadline: p.deadline
+    }));
+
+    // Reset approvals
+    if (p.amount0Desired > 0) IERC20(p.token0).forceApprove(npm, 0);
+    if (p.amount1Desired > 0) IERC20(p.token1).forceApprove(npm, 0);
+
+    // Refund unconsumed
+    uint256 r0 = p.amount0Desired - amount0Used;
+    uint256 r1 = p.amount1Desired - amount1Used;
+    if (r0 > 0) IERC20(p.token0).safeTransfer(msg.sender, r0);
+    if (r1 > 0) IERC20(p.token1).safeTransfer(msg.sender, r1);
+
+    // Persist immutable position params
+    tokenId       = tokenId_;
+    token0        = p.token0;
+    token1        = p.token1;
+    tickLower     = p.tickLower;
+    tickUpper     = p.tickUpper;
+    isToken0Quote = isToken0Quote_;
+    yieldTarget   = yieldTarget_;
+
+    if (isToken0Quote_) { stakedQuote = amount0Used; stakedBase = amount1Used; }
+    else                { stakedQuote = amount1Used; stakedBase = amount0Used; }
+
+    pool  = _resolvePool(p.token0, p.token1, p.fee);
+    state = Staked;
+
+    emit Stake(owner, stakedBase, stakedQuote, yieldTarget_, tokenId_, liquidity_);
+    return tokenId_;
+}
+```
+
+Rules:
+- `(stakedBase, stakedQuote)` derived from *consumed* amounts, not desired.
+- Vault balance after `stake()` exactly matches the open UV3 position;
+  all four buffer slots are zero.
+- `yieldTarget_ == 0` is legitimate (no bonus, fee-folding only).
+- `yieldTarget_ == type(uint256).max` is the "let it run" sentinel that
+  effectively disables external execution.
+- `_resolvePool` calls `npm.factory().getPool(token0, token1, fee)`;
+  reverts with `PoolResolutionFailed` if returned address is zero or
+  the staticcall fails.
+
+## 9. `stakeTopUp()` — additive
+
+Owner-only, `nonReentrant`. State must be `Staked`.
+
+```
+function stakeTopUp(TopUpParams calldata p) external onlyOwner nonReentrant {
+    require(state == Staked);
+
+    if (p.amount0Desired > 0) {
+        IERC20(token0).safeTransferFrom(msg.sender, this, p.amount0Desired);
+        IERC20(token0).forceApprove(npm, p.amount0Desired);
+    }
+    if (p.amount1Desired > 0) {
+        IERC20(token1).safeTransferFrom(msg.sender, this, p.amount1Desired);
+        IERC20(token1).forceApprove(npm, p.amount1Desired);
+    }
+
+    (uint128 liquidityDelta, uint256 amount0Used, uint256 amount1Used) =
+        npm.increaseLiquidity(IncreaseLiquidityParams({
+            tokenId: tokenId,
+            amount0Desired: p.amount0Desired,
+            amount1Desired: p.amount1Desired,
+            amount0Min: p.amount0Min,
+            amount1Min: p.amount1Min,
+            deadline: p.deadline
+        }));
+
+    if (p.amount0Desired > 0) IERC20(token0).forceApprove(npm, 0);
+    if (p.amount1Desired > 0) IERC20(token1).forceApprove(npm, 0);
+
+    uint256 r0 = p.amount0Desired - amount0Used;
+    uint256 r1 = p.amount1Desired - amount1Used;
+    if (r0 > 0) IERC20(token0).safeTransfer(msg.sender, r0);
+    if (r1 > 0) IERC20(token1).safeTransfer(msg.sender, r1);
+
+    uint256 baseAdded;
+    uint256 quoteAdded;
+    if (isToken0Quote) { quoteAdded = amount0Used; baseAdded = amount1Used; }
+    else                { quoteAdded = amount1Used; baseAdded = amount0Used; }
+
+    // Scale T proportionally so the implicit yield rate stays constant.
+    // T_new = T_old × (Q + ΔQ) / Q, ceil-rounded. Skip if Q == 0.
+    uint256 oldQ = stakedQuote;
+    if (oldQ > 0 && quoteAdded > 0) {
+        uint256 oldT = yieldTarget;
+        uint256 newT = mulDivCeil(oldT, oldQ + quoteAdded, oldQ);
+        if (newT != oldT) {
+            yieldTarget = newT;
+            emit YieldTargetSet(owner, oldT, newT);
+        }
+    }
+
+    stakedBase  += baseAdded;
+    stakedQuote += quoteAdded;
+
+    emit Stake(owner, baseAdded, quoteAdded, yieldTarget, tokenId, liquidityDelta);
+}
+```
+
+Rules:
+- T-scaling uses ceiling division to avoid downward drift on repeated
+  tiny top-ups.
+- `Q == 0` (out-of-range-above initial stake) leaves T unchanged.
+- `Stake` event in top-up mode emits the deltas.
+
+## 10. `setYieldTarget()`
+
+Owner-only, `nonReentrant`. State must be `Staked`.
+
+```
+function setYieldTarget(uint256 newT) external onlyOwner nonReentrant {
+    require(state == Staked);
+    uint256 old = yieldTarget;
+    yieldTarget = newT;
+    emit YieldTargetSet(owner, old, newT);
+}
+```
+
+Rules:
+- Any `uint256` value accepted (including `0` and `type(uint256).max`).
+- This is the canonical Underwater-escape: setting `T = 0` (or any
+  small enough value) converts Case 4 into Case 1, 2, or 3, making the
+  position settleable again.
+
+## 11. Case classification
+
+Inputs at the moment of settlement:
+- `(B, Q, T)` from storage.
+- `(b, q)` derived from the position close (principal + fees), as
+  detailed in §12.
+- `frac` = `liquidity / positionLiquidity` for partial; `1` for full.
+  Concretely, `targetBase = mulDiv(B, liquidity, positionLiquidity)`,
+  `targetQuote = mulDiv(Q + T, liquidity, positionLiquidity)`. Use
+  `mulDiv` with floor rounding.
+
+Classification, applied in priority order (first match wins):
+
+```
+if (Q + T overflows uint256)
+    → revert YieldTargetOverflow
+
+if (b ≥ targetBase AND q ≥ targetQuote)
+    → NoSwapNeeded        // Case 1
+
+if (b ≥ targetBase)       // implies q < targetQuote
+    → Executable, Case 2  // executor sends quote, receives base
+
+if (q ≥ targetQuote)      // implies b < targetBase
+    → Executable, Case 3  // executor sends base, receives quote
+
+else
+    → Underwater          // Case 4: both deficits
+```
+
+Per-case quantities:
+
+| Case | bidToken | bidAmount | askToken | askAmountMin | tokenIn (executor pays) | tokenOut (executor receives) |
+|------|----------|-----------|----------|--------------|--------------------------|-------------------------------|
+| 1    | (none)   | 0         | (none)   | 0            | (n/a)                    | (n/a)                         |
+| 2    | base     | b − targetBase | quote    | targetQuote − q | quote | base                  |
+| 3    | quote    | q − targetQuote | base     | targetBase − b  | base  | quote                 |
+| 4    | (none)   | 0         | (none)   | 0            | (revert)                 | (revert)                      |
+
+In `quoteSwap()`, the `Underwater` overflow case returns
+`(Underwater, L, 0, 0, 0, 0)` rather than reverting — overflow at view
+time is informational. The settlement functions revert on overflow so
+the state cannot be corrupted.
+
+## 12. `quoteSwap()` and `previewSettle()`
+
+Both are pure views over current state. They use the same underlying
+case classification but expose different fields.
+
+### 12.1 `quoteSwap()`
+
+```
+function quoteSwap() external view returns (SwapQuote memory) {
+    if (state != Staked) {
+        return SwapQuote(NotApplicable, 0, 0, 0, 0, 0);
+    }
+
+    uint128 posLiq = positionLiquidity();
+    (uint256 b, uint256 q) = _expectedFreedAmounts(posLiq);
+
+    // Q + T overflow guard — view does not revert
+    unchecked {
+        if (Q + T < Q) {
+            return SwapQuote(Underwater, posLiq, 0, 0, 0, 0);
+        }
+    }
+
+    uint256 targetBase  = B;
+    uint256 targetQuote = Q + T;
+
+    if (b >= targetBase && q >= targetQuote) {
+        return SwapQuote(NoSwapNeeded, posLiq, 0, 0, 0, 0);
+    }
+    if (b >= targetBase /* && q < targetQuote */) {
+        return SwapQuote(
+            Executable, posLiq,
+            baseToken(),  b - targetBase,
+            quoteToken(), targetQuote - q
+        );
+    }
+    if (q >= targetQuote /* && b < targetBase */) {
+        return SwapQuote(
+            Executable, posLiq,
+            quoteToken(), q - targetQuote,
+            baseToken(),  targetBase - b
+        );
+    }
+    return SwapQuote(Underwater, posLiq, 0, 0, 0, 0);
+}
+```
+
+Rules:
+- `liquidity` always equals `positionLiquidity()` for `Staked`-state
+  results; zero for `NotApplicable`.
+- Bid/ask fields zero in non-`Executable` results.
+- View, no state mutation.
+
+### 12.2 `_expectedFreedAmounts(closeLiquidity)`
+
+Internal helper. Computes what `(b, q)` the vault would hold after
+closing exactly `closeLiquidity` units of the position. Returns
+`(b, q)`.
+
+```
+function _expectedFreedAmounts(uint128 closeLiquidity)
+    internal view
+    returns (uint256 b, uint256 q)
+{
+    (
+        ,,,,,,,
+        uint128 liquidity,
+        uint256 fgInside0Last,
+        uint256 fgInside1Last,
+        uint128 owed0,
+        uint128 owed1
+    ) = npm.positions(tokenId);
+
+    uint256 amount0;
+    uint256 amount1;
+    if (closeLiquidity > 0 && liquidity > 0) {
+        require(closeLiquidity <= liquidity);  // enforced by callers
+        (uint160 sqrtPriceX96,,,,,,) = IUniswapV3Pool(pool).slot0();
+        uint160 lo = TickMath.getSqrtRatioAtTick(tickLower);
+        uint160 hi = TickMath.getSqrtRatioAtTick(tickUpper);
+        (amount0, amount1) = LiquidityAmounts.getAmountsForLiquidity(
+            sqrtPriceX96, lo, hi, closeLiquidity
+        );
+    }
+
+    // Add ALL uncollected fees (collect is all-or-nothing, NOT pro-rated)
+    (uint256 fees0, uint256 fees1) = LibUniswapV3Fees.uncollectedFees(
+        pool, tickLower, tickUpper,
+        liquidity, fgInside0Last, fgInside1Last, owed0, owed1
+    );
+    amount0 += fees0;
+    amount1 += fees1;
+
+    if (isToken0Quote) { q = amount0; b = amount1; }
+    else                { q = amount1; b = amount0; }
+}
+```
+
+The all-uncollected-fees behaviour matches SPEC-0003a §11/§13: UV3's
+`collect` is all-or-nothing, so a partial close still pulls 100% of
+accumulated fees on top of the proportional principal share.
+
+### 12.3 `previewSettle()`
+
+```
+function previewSettle() external view returns (
+    bool canSettle, uint128 liquidity, uint256 baseBounty, uint256 quoteBounty
+) {
+    if (state != Staked) return (false, 0, 0, 0);
+
+    uint128 posLiq = positionLiquidity();
+    (uint256 b, uint256 q) = _expectedFreedAmounts(posLiq);
+
+    unchecked {
+        if (Q + T < Q) return (false, posLiq, 0, 0);
+    }
+
+    if (b >= B && q >= Q + T) {
+        return (true, posLiq, b - B, q - (Q + T));
+    }
+    return (false, posLiq, 0, 0);
+}
+```
+
+Rules:
+- Returns `(true, liquidity, baseBounty, quoteBounty)` exactly when
+  `settle()` would succeed at this state.
+- `baseBounty` and `quoteBounty` may be zero (boundary case
+  `b == B AND q == Q + T`).
+
+## 13. `swap()` — owner trade
+
+Owner-only, `nonReentrant`. State must be `Staked`. Reverts in Cases
+1 and 4 with case-specific errors.
+
+```
+function swap(
+    uint128 liquidity_,
+    address tokenIn,
+    uint256 amountInMax,
+    address tokenOut,
+    uint256 amountOutMin,
+    address recipient,
+    uint256 deadline
+) external onlyOwner nonReentrant returns (uint256 amountIn, uint256 amountOut) {
+    require(state == Staked);
+    require(deadline >= block.timestamp, DeadlineExpired);
+    require(recipient != address(0), InvalidRecipient);
+
+    uint128 posLiq = positionLiquidity();
+    require(liquidity_ > 0 && liquidity_ <= posLiq, InvalidLiquidity);
+
+    unchecked {
+        if (Q + T < Q) revert YieldTargetOverflow();
+    }
+
+    uint256 targetBase  = mulDiv(B,     liquidity_, posLiq);
+    uint256 targetQuote = mulDiv(Q + T, liquidity_, posLiq);
+
+    address baseTok  = baseToken();
+    address quoteTok = quoteToken();
+
+    uint256 preBase  = IERC20(baseTok).balanceOf(this);
+    uint256 preQuote = IERC20(quoteTok).balanceOf(this);
+
+    _closePartial(liquidity_);
+
+    uint256 b = IERC20(baseTok).balanceOf(this) - preBase;
+    uint256 q = IERC20(quoteTok).balanceOf(this) - preQuote;
+
+    if (b >= targetBase && q >= targetQuote) revert UseSettleInsteadOfSwap();
+
+    if (b >= targetBase) {
+        // Case 2: caller sends quote, receives base
+        require(tokenIn  == quoteTok && tokenOut == baseTok,  TokenMismatch);
+        amountIn  = targetQuote - q;
+        amountOut = b - targetBase;
+    } else if (q >= targetQuote) {
+        // Case 3: caller sends base, receives quote
+        require(tokenIn  == baseTok && tokenOut == quoteTok, TokenMismatch);
+        amountIn  = targetBase - b;
+        amountOut = q - targetQuote;
+    } else {
+        revert UseFlashSettleInsteadOfSwap();
+    }
+
+    require(amountIn  <= amountInMax,  SlippageExceeded);
+    require(amountOut >= amountOutMin, SlippageExceeded);
+
+    IERC20(tokenIn).safeTransferFrom(msg.sender, this, amountIn);
+    IERC20(tokenOut).safeTransfer(recipient, amountOut);
+
+    _settleBuffersAndStake(liquidity_, posLiq, preBase, preQuote);
+
+    if (liquidity_ == posLiq) state = Settled;
+
+    emit Swap(msg.sender, recipient, liquidity_,
+              tokenIn, amountIn, tokenOut, amountOut);
+    return (amountIn, amountOut);
+}
+```
+
+Rules:
+- `liquidity_` is in NFPM units; partial close reduces position
+  proportionally.
+- The `_closePartial` helper invokes `npm.decreaseLiquidity` (with
+  zero `amount0Min`/`amount1Min` — slippage bound is enforced at the
+  vault layer via `amountInMax`/`amountOutMin`) and `npm.collect`
+  (all uncollected). See §16.1.
+- Multi-call composition is supported: `[swap(small), swap(small),
+  ...]` distributes the close in segments. Each call closes its
+  fraction of the current `positionLiquidity` snapshot at call time.
+
+## 14. `flashSwap()` — permissionless trade
+
+Permissionless, no `onlyOwner`. State must be `Staked`. Reverts in
+Cases 1 and 4 with case-specific errors. Always full close.
+
+```
+function flashSwap(
+    address tokenIn,
+    uint256 amountInMax,
+    address tokenOut,
+    uint256 amountOutMin,
+    address callbackTarget,
+    bytes calldata data,
+    uint256 deadline
+) external nonReentrant returns (uint256 amountIn, uint256 amountOut) {
+    require(state == Staked);
+    require(deadline >= block.timestamp, DeadlineExpired);
+    require(callbackTarget != address(0), InvalidCallbackTarget);
+
+    unchecked {
+        if (Q + T < Q) revert YieldTargetOverflow();
+    }
+
+    uint128 posLiq = positionLiquidity();
+    address baseTok  = baseToken();
+    address quoteTok = quoteToken();
+
+    uint256 preBase  = IERC20(baseTok).balanceOf(this);
+    uint256 preQuote = IERC20(quoteTok).balanceOf(this);
+
+    _closePartial(posLiq);   // full close
+
+    uint256 b = IERC20(baseTok).balanceOf(this) - preBase;
+    uint256 q = IERC20(quoteTok).balanceOf(this) - preQuote;
+
+    uint256 targetBase  = B;
+    uint256 targetQuote = Q + T;
+
+    if (b >= targetBase && q >= targetQuote) revert UseSettleInsteadOfFlashSwap();
+
+    address tokenInExpected;
+    address tokenOutExpected;
+    uint256 amountInMin;
+
+    if (b >= targetBase) {
+        // Case 2
+        tokenInExpected  = quoteTok;
+        tokenOutExpected = baseTok;
+        amountInMin      = targetQuote - q;
+        amountOut        = b - targetBase;
+    } else if (q >= targetQuote) {
+        // Case 3
+        tokenInExpected  = baseTok;
+        tokenOutExpected = quoteTok;
+        amountInMin      = targetBase - b;
+        amountOut        = q - targetQuote;
+    } else {
+        revert UseFlashSettleInsteadOfFlashSwap();
+    }
+
+    require(tokenIn  == tokenInExpected
+         && tokenOut == tokenOutExpected, TokenMismatch);
+    require(amountInMin <= amountInMax,  SlippageExceeded);
+    require(amountOut   >= amountOutMin, SlippageExceeded);
+
+    // Push tokenOut to callback target
+    state = FlashSwapInProgress;
+    emit FlashSwapInitiated(
+        msg.sender, callbackTarget, posLiq,
+        tokenIn, amountInMin, tokenOut, amountOut, data
+    );
+    IERC20(tokenOut).safeTransfer(callbackTarget, amountOut);
+
+    // Snapshot vault's tokenIn pre-callback balance
+    uint256 preTokenIn = (tokenIn == baseTok) ? preBase : preQuote;
+
+    IFlashSwapCallback(callbackTarget).flashSwapCallback(
+        tokenIn, amountInMin, tokenOut, amountOut, data
+    );
+
+    // Verify
+    uint256 postTokenIn = IERC20(tokenIn).balanceOf(this) - preTokenIn;
+    if (postTokenIn < amountInMin) revert InsufficientReturn();
+    amountIn = postTokenIn;
+
+    _settleBuffersAndStake(posLiq, posLiq, preBase, preQuote);
+
+    state = Settled;
+    emit Swap(msg.sender, callbackTarget, posLiq,
+              tokenIn, amountIn, tokenOut, amountOut);
+}
+```
+
+Rules:
+- `flashSwap` is always full close. The case-derived `amountOut` is
+  pushed before the callback; verification compares post-callback
+  vault balance.
+- Overpayment of `tokenIn` flows into the reward buffer via
+  `_settleBuffersAndStake` (see §16.2).
+- The case classification runs *after* the position is closed but
+  *before* the token push; the `tokenIn`/`tokenOut` parameters are
+  validated against the case-derived expected pair.
+- The `nonReentrant` guard plus the `FlashSwapInProgress` state-lock
+  jointly prevent any reentrant access. Other vault functions check
+  `state == Staked` (or another valid state) and revert during
+  `FlashSwapInProgress`.
+
+## 15. `settle()` — permissionless no-trade
+
+Permissionless. State must be `Staked`. Only succeeds in Case 1.
+
+```
+function settle(
+    address recipient,
+    uint256 deadline
+) external nonReentrant returns (uint256 baseBounty, uint256 quoteBounty) {
+    require(state == Staked);
+    require(deadline >= block.timestamp, DeadlineExpired);
+    require(recipient != address(0), InvalidRecipient);
+
+    unchecked {
+        if (Q + T < Q) revert YieldTargetOverflow();
+    }
+
+    uint128 posLiq = positionLiquidity();
+    address baseTok  = baseToken();
+    address quoteTok = quoteToken();
+
+    uint256 preBase  = IERC20(baseTok).balanceOf(this);
+    uint256 preQuote = IERC20(quoteTok).balanceOf(this);
+
+    _closePartial(posLiq);   // full close
+
+    uint256 b = IERC20(baseTok).balanceOf(this) - preBase;
+    uint256 q = IERC20(quoteTok).balanceOf(this) - preQuote;
+
+    if (b < B || q < Q + T) {
+        // Not Case 1
+        if (b < B && q < Q + T) revert UseFlashSettleInsteadOfSettle();
+        revert UseSwapInsteadOfSettle();
+    }
+
+    // Buffer fill: exact (B, Q) → unstake; exact (0, T) → reward.
+    unstakeBufferBase  += B;
+    unstakeBufferQuote += Q;
+    rewardBufferQuote  += T;
+
+    // Bounty = surplus over (B, Q+T)
+    baseBounty  = b - B;
+    quoteBounty = q - (Q + T);
+
+    if (baseBounty  > 0) IERC20(baseTok).safeTransfer(recipient, baseBounty);
+    if (quoteBounty > 0) IERC20(quoteTok).safeTransfer(recipient, quoteBounty);
+
+    // Reduce active stake to zero (full close)
+    stakedBase  = 0;
+    stakedQuote = 0;
+    yieldTarget = 0;
+
+    state = Settled;
+    emit Settle(msg.sender, recipient, posLiq, baseBounty, quoteBounty);
+}
+```
+
+Rules:
+- Always full close. Partial settle is not supported.
+- The function does NOT revert if `baseBounty == 0 && quoteBounty == 0`
+  (boundary case where `b == B AND q == Q + T`); the position still
+  settles and the caller just doesn't profit.
+- The bounty mechanism replaces the SPEC-0003a "Case 3 with 5%
+  discount" logic. Surplus over `(B, Q+T)` goes to the caller as
+  bounty rather than to the owner via reward buffer.
+
+## 16. `flashSettle()` — owner exit with helper
+
+Owner-only, `nonReentrant`. State must be `Staked`. Helper receives
+the freed `(b, q)` and must return at least `(B × frac, (Q+T) × frac)`.
+
+```
+function flashSettle(
+    uint128 liquidity_,
+    address callbackTarget,
+    bytes calldata data,
+    uint256 deadline
+) external onlyOwner nonReentrant {
+    require(state == Staked);
+    require(deadline >= block.timestamp, DeadlineExpired);
+    require(callbackTarget != address(0), InvalidCallbackTarget);
+
+    uint128 posLiq = positionLiquidity();
+    require(liquidity_ > 0 && liquidity_ <= posLiq, InvalidLiquidity);
+
+    unchecked {
+        if (Q + T < Q) revert YieldTargetOverflow();
+    }
+
+    uint256 expectedBase  = mulDiv(B,     liquidity_, posLiq);
+    uint256 expectedQuote = mulDiv(Q + T, liquidity_, posLiq);
+
+    address baseTok  = baseToken();
+    address quoteTok = quoteToken();
+
+    uint256 preBase  = IERC20(baseTok).balanceOf(this);
+    uint256 preQuote = IERC20(quoteTok).balanceOf(this);
+
+    _closePartial(liquidity_);
+
+    uint256 freedBase  = IERC20(baseTok).balanceOf(this)  - preBase;
+    uint256 freedQuote = IERC20(quoteTok).balanceOf(this) - preQuote;
+
+    state = FlashSettleInProgress;
+    emit FlashSettleInitiated(owner, liquidity_, callbackTarget, data);
+
+    if (freedBase  > 0) IERC20(baseTok).safeTransfer(callbackTarget,  freedBase);
+    if (freedQuote > 0) IERC20(quoteTok).safeTransfer(callbackTarget, freedQuote);
+
+    IFlashSettleCallback(callbackTarget).flashSettleCallback(
+        expectedBase, expectedQuote, data
+    );
+
+    uint256 postBase  = IERC20(baseTok).balanceOf(this)  - preBase;
+    uint256 postQuote = IERC20(quoteTok).balanceOf(this) - preQuote;
+
+    if (postBase  < expectedBase)  revert InsufficientBaseReturned();
+    if (postQuote < expectedQuote) revert InsufficientQuoteReturned();
+
+    // Buffer fill — same accounting pattern as the trade paths.
+    uint256 unstakeBaseDelta  = mulDiv(B, liquidity_, posLiq);
+    uint256 unstakeQuoteDelta = mulDiv(Q, liquidity_, posLiq);
+
+    unstakeBufferBase  += unstakeBaseDelta;
+    unstakeBufferQuote += unstakeQuoteDelta;
+    rewardBufferBase   += postBase  - unstakeBaseDelta;
+    rewardBufferQuote  += postQuote - unstakeQuoteDelta;
+
+    stakedBase  -= unstakeBaseDelta;
+    stakedQuote -= unstakeQuoteDelta;
+    yieldTarget -= mulDiv(T, liquidity_, posLiq);
+
+    state = (liquidity_ == posLiq) ? Settled : Staked;
+
+    emit FlashSettle(owner, liquidity_,
+                     expectedBase, expectedQuote,
+                     postBase, postQuote);
+}
+```
+
+Rules:
+- The freed `(b, q)` from the close are pushed to the callback. The
+  callback returns at least `(expectedBase, expectedQuote)`. Any
+  overpayment flows to `rewardBuffer*` and is owed to the owner via
+  `claimRewards()`.
+- This is NOT a swap. The helper might internally swap, top up, or
+  do nothing depending on the case. The vault interface only sees
+  push and verification.
+- No auto-drain. Owner calls `unstake()` and `claimRewards()`
+  separately. Multicall composition is supported for one-tx
+  ergonomics.
+- `liquidity_ == posLiq` transitions to `Settled`. Otherwise back to
+  `Staked` with reduced principal and target.
+
+### 16.1 `_closePartial(liquidity)`
+
+Internal helper used by all four settlement paths. Burns `liquidity`
+units of the position and collects all uncollected fees.
+
+```
+function _closePartial(uint128 liquidity_) internal {
+    require(liquidity_ > 0);
+    npm.decreaseLiquidity(DecreaseLiquidityParams({
+        tokenId: tokenId,
+        liquidity: liquidity_,
+        amount0Min: 0,
+        amount1Min: 0,
+        deadline: block.timestamp
+    }));
+    npm.collect(CollectParams({
+        tokenId: tokenId,
+        recipient: address(this),
+        amount0Max: type(uint128).max,
+        amount1Max: type(uint128).max
+    }));
+}
+```
+
+Rules:
+- Pool slippage at the NFPM level is intentionally unprotected
+  (`amount0Min = amount1Min = 0`); slippage is enforced at the vault
+  layer via the function's `amountInMax`/`amountOutMin` parameters or
+  (for `flashSettle`) via the helper's own logic.
+- `collect` always pulls all owed amounts; the vault then classifies
+  on the freed delta.
+
+### 16.2 `_settleBuffersAndStake(liquidity_, posLiq, preBase, preQuote)`
+
+Internal helper used by `swap()` and `flashSwap()` to fill buffers
+and reduce active stake after a successful trade.
+
+```
+function _settleBuffersAndStake(
+    uint128 liquidity_,
+    uint128 posLiq,
+    uint256 preBase,
+    uint256 preQuote
+) internal {
+    address baseTok  = baseToken();
+    address quoteTok = quoteToken();
+
+    uint256 newFreeBase  = IERC20(baseTok).balanceOf(this)  - preBase;
+    uint256 newFreeQuote = IERC20(quoteTok).balanceOf(this) - preQuote;
+
+    uint256 unstakeBaseDelta  = mulDiv(B, liquidity_, posLiq);
+    uint256 unstakeQuoteDelta = mulDiv(Q, liquidity_, posLiq);
+
+    unstakeBufferBase  += unstakeBaseDelta;
+    unstakeBufferQuote += unstakeQuoteDelta;
+    rewardBufferBase   += newFreeBase  - unstakeBaseDelta;
+    rewardBufferQuote  += newFreeQuote - unstakeQuoteDelta;
+
+    stakedBase  -= unstakeBaseDelta;
+    stakedQuote -= unstakeQuoteDelta;
+    yieldTarget -= mulDiv(T, liquidity_, posLiq);
+}
+```
+
+Rules:
+- `newFreeBase` and `newFreeQuote` are the post-trade deltas, after
+  the executor's `tokenIn` has been pulled in and `tokenOut` has been
+  paid out. By case construction, both increments are
+  `≥ unstake*Delta`.
+- The reward-buffer increments may include executor overpayment in
+  Case 2 (extra quote) or Case 3 (extra base), plus all uncollected
+  fees from the position close.
+
+## 17. `unstake()` and `claimRewards()`
+
+Owner-only, `nonReentrant`. State must be `Staked` or `Settled`.
+
+```
+function unstake() external onlyOwner nonReentrant {
+    require(state == Staked || state == Settled);
+    uint256 ub = unstakeBufferBase;
+    uint256 uq = unstakeBufferQuote;
+    require(ub > 0 || uq > 0, NothingToUnstake);
+
+    unstakeBufferBase  = 0;
+    unstakeBufferQuote = 0;
+
+    if (ub > 0) IERC20(baseToken()).safeTransfer(owner, ub);
+    if (uq > 0) IERC20(quoteToken()).safeTransfer(owner, uq);
+    emit Unstake(owner, ub, uq);
+}
+
+function claimRewards() external onlyOwner nonReentrant {
+    require(state == Staked || state == Settled);
+    uint256 rb = rewardBufferBase;
+    uint256 rq = rewardBufferQuote;
+    require(rb > 0 || rq > 0, NothingToClaim);
+
+    rewardBufferBase  = 0;
+    rewardBufferQuote = 0;
+
+    if (rb > 0) IERC20(baseToken()).safeTransfer(owner, rb);
+    if (rq > 0) IERC20(quoteToken()).safeTransfer(owner, rq);
+    emit ClaimRewards(owner, rb, rq);
+}
+```
+
+Rules:
+- Both follow checks-effects-interactions (zero buffers before
+  transfer).
+- Both can be called multiple times across the vault's lifetime,
+  once per fill cycle.
+
+## 18. `multicall()`
+
+Use OpenZeppelin's `Multicall` mixin (existing project dependency). No
+modifications. Per-function state checks remain authoritative — the
+multicall layer does not bypass them.
+
+**Implementation note for EIP-1167 clones.** OZ `Multicall` uses
+`address(this).delegatecall(...)`. With a minimal proxy, this means:
+outer call → clone delegatecalls implementation → multicall does
+`address(this).delegatecall` on the inner data, which hits the clone
+(again), which delegatecalls implementation. Each inner call thus
+incurs an additional delegatecall hop. Functionally correct but
+slightly more gas per inner call than non-proxied multicall.
+
+Useful compositions:
+- `[stakeTopUp, setYieldTarget]` — owner adds capital and re-anchors
+  the yield rate atomically.
+- `[swap, swap]` — owner partial-closes in segments.
+- `[flashSettle, unstake, claimRewards]` — owner exits with helper
+  and immediately drains.
+- `[swap, unstake, claimRewards]` — owner self-executes a swap and
+  immediately drains.
+
+## 19. Event order summary
+
+For each settlement path, the canonical event sequence within a
+successful single-tx call:
+
+| Path | Events |
+|------|--------|
+| `swap()` | `Swap` |
+| `flashSwap()` | `FlashSwapInitiated` → (callback runs) → `Swap` |
+| `settle()` | `Settle` |
+| `flashSettle()` | `FlashSettleInitiated` → (callback runs) → `FlashSettle` |
+| `unstake()` | `Unstake` |
+| `claimRewards()` | `ClaimRewards` |
+
+`Swap` is shared between `swap()` and `flashSwap()`. The
+distinguisher for indexers is the presence of `FlashSwapInitiated` in
+the same tx for the flashSwap path.
+
+## 20. Invariants
+
+For all reachable states:
+
+1. `unstakeBufferBase + remainingPositionBase ≥ stakedBase`
+   (where `remainingPositionBase` is the principal still held by the
+   open UV3 position).
+2. Analogously for quote.
+3. `yieldTarget` is monotonically non-increasing across settlements
+   (T scales down with closures; the only way T grows is via top-up
+   or `setYieldTarget`).
+4. `state == Settled` ⇒ `positionLiquidity() == 0`.
+5. `state == Settled` ⇒ no further `swap`/`flashSwap`/`settle`/
+   `flashSettle` calls possible.
+6. `state ∈ {FlashSwapInProgress, FlashSettleInProgress}` ⇒ all
+   non-callback-completion entry points revert.
+7. `unstakeBufferBase + unstakeBufferQuote == 0` immediately after
+   `unstake()` completes (until refilled).
+8. `rewardBufferBase + rewardBufferQuote == 0` immediately after
+   `claimRewards()` completes (until refilled).
+
+## 21. Out of scope (do not implement)
+
+- No `cancelStake()` or any path from `Staked` back to `Empty`.
+- No ownership transfer of any kind.
+- No upgradability / proxy admin / migration of clones.
+- No range adjustment after initial `stake()` (no changes to
+  `tickLower`, `tickUpper`, no reposition). Top-up only adds liquidity
+  to the existing range.
+- No fee-only collection without close (fees are absorbed into
+  settlement; no separate `harvest()`).
+- No multi-position-per-vault.
+- No cross-chain logic. Single chain per deployment.
+- No external price oracle (Chainlink, etc.); no pool TWAP either —
+  the swap mechanic uses no oracle at all.
+- No 5%-discount Case-3 mechanic from SPEC-0003a (replaced by
+  bounty in `settle()`).
+- No two-step swap mechanic from SPEC-0003a (no `PrincipalSwapped`
+  state, no persisted `t_base`).
+- No `pendingBps` slot from SPEC-0003a.
+- No Uniswap V4 hooks.
+- No NFT burning after settlement.
+- No CoW / solver-network adapter — handled by a separate downstream
+  contract that wraps `flashSwap()`.
+- No automatic yield-rate re-anchoring on `setYieldTarget`.
+
+## 22. Testing — coverage targets
+
+### Initialization and stake
+- `initialize()` reverts on second call.
+- `initialize(address(0))` reverts.
+- Factory `createVault()` is atomic (cannot be front-run between
+  deploy and initialize).
+- `stake()` from non-`Empty` state reverts.
+- `stake()` from non-owner reverts.
+- `stake()` refunds unconsumed amounts.
+- Initial-stake `Stake` event includes correct `liquidityDelta`
+  matching the freshly-minted position liquidity.
+
+### Top-up
+- `stakeTopUp()` from `Empty` reverts.
+- `stakeTopUp()` adds correctly to `(B, Q)`.
+- T scales correctly: `T_new ≈ T_old × (Q + ΔQ) / Q`, with ceiling
+  rounding.
+- Top-up with `Q == 0` (initial out-of-range above) leaves T
+  unchanged.
+- Top-up out-of-range: one side fully refunded.
+- Top-up `Stake` event has `liquidityDelta` equal to the increase,
+  not the cumulative.
+
+### setYieldTarget
+- Settable in `Staked`; reverts in any other state.
+- Setting `T = 0` converts an Underwater position back to a
+  settle-able case (Case 1, 2, or 3).
+
+### quoteSwap / previewSettle
+- `state != Staked` returns `NotApplicable` / `(false, ...)`.
+- Case 1 → `NoSwapNeeded` / `(true, L, baseBounty, quoteBounty)`.
+- Case 2 → `Executable` with `bidToken == base, askToken == quote`.
+- Case 3 → `Executable` with `bidToken == quote, askToken == base`.
+- Case 4 → `Underwater` / `(false, L, 0, 0)`.
+- `Q + T` overflow → `Underwater` / `(false, L, 0, 0)`.
+- Boundary: `b == B && q == Q + T` → Case 1 with zero bounty.
+- Liquidity field always equals `positionLiquidity()` for any
+  Staked-state result.
+
+### swap (Cases 2, 3)
+- Case 2 with `liquidity == positionLiquidity` → `Settled`.
+- Case 2 with `liquidity < positionLiquidity` → `Staked` with
+  reduced `(B, Q, T)` and `positionLiquidity()` reduced by exactly
+  `liquidity`.
+- Case 3 analogously.
+- `tokenIn`/`tokenOut` mismatch → `TokenMismatch`.
+- `amountInMax` exceeded → `SlippageExceeded`.
+- `amountOutMin` not met → `SlippageExceeded`.
+- `recipient == address(0)` → `InvalidRecipient`.
+- `liquidity == 0` → `InvalidLiquidity`.
+- `liquidity > positionLiquidity()` → `InvalidLiquidity`.
+- `deadline` expired → `DeadlineExpired`.
+- Case 1 → `UseSettleInsteadOfSwap`.
+- Case 4 → `UseFlashSettleInsteadOfSwap`.
+- Two consecutive partial swaps yield correctly summed buffers.
+- Non-owner caller → `NotOwner`.
+
+### flashSwap (Cases 2, 3)
+- Case 2 success: callback returns `≥ amountInMin`, vault settles,
+  state → `Settled`, `Swap` event emitted.
+- Case 3 success analogously.
+- Callback returns < `amountInMin` → `InsufficientReturn`.
+- Callback reverts → outer revert.
+- Callback tries to call back into vault → revert (via state-lock
+  AND `nonReentrant`).
+- `tokenIn`/`tokenOut` mismatch → `TokenMismatch`.
+- `amountInMax` ≥ amountInMin enforced at boundary.
+- `callbackTarget == address(0)` → `InvalidCallbackTarget`.
+- Case 1 → `UseSettleInsteadOfFlashSwap`.
+- Case 4 → `UseFlashSettleInsteadOfFlashSwap`.
+- Permissionless: any address can call.
+- Overpayment flows to `rewardBuffer{quoteIfCase2,baseIfCase3}`.
+
+### settle (Case 1)
+- Case 1 success: bounty paid to recipient, buffers filled with
+  exact `(B, Q, T)`, state → `Settled`.
+- Boundary case `b == B && q == Q + T` succeeds with zero bounty.
+- Case 2 → `UseSwapInsteadOfSettle`.
+- Case 3 → `UseSwapInsteadOfSettle`.
+- Case 4 → `UseFlashSettleInsteadOfSettle`.
+- `recipient == address(0)` → `InvalidRecipient`.
+- `deadline` expired → `DeadlineExpired`.
+- Permissionless: any address can call.
+- `previewSettle()` agrees with what `settle()` would do.
+
+### flashSettle (any case)
+- Case 1: callback may return exactly `(B × frac, (Q+T) × frac)`;
+  surplus flows to reward buffer.
+- Case 2: callback receives base-heavy freed amount, returns
+  expected target; quote deficit covered from external source.
+- Case 3: callback receives quote-heavy freed amount, returns
+  expected target; base deficit covered from external source.
+- Case 4: callback receives below-target freed amount, must cover
+  both deficits.
+- Overpayment in any case flows to `rewardBuffer*`.
+- Underpayment on base → `InsufficientBaseReturned`.
+- Underpayment on quote → `InsufficientQuoteReturned`.
+- `liquidity == 0` or `> positionLiquidity()` → `InvalidLiquidity`.
+- `callbackTarget == address(0)` → `InvalidCallbackTarget`.
+- `liquidity == positionLiquidity()` transitions to `Settled`.
+- `liquidity < positionLiquidity()` returns to `Staked` with
+  reduced state.
+- Reentrancy: callback that re-enters vault → revert.
+- No auto-drain: buffers remain filled after `flashSettle` returns.
+- Non-owner caller → `NotOwner`.
+
+### Buffer drain
+- `unstake()` drains `unstakeBuffer*` and zeroes the slots.
+- `claimRewards()` drains `rewardBuffer*` and zeroes the slots.
+- Both callable in `Staked` (mid-lifecycle) and `Settled`.
+- Both revert if the relevant buffer is empty.
+- Both can be called multiple times across the lifecycle.
+- Owner sums to `Σ(stake deposits) + Σ(rewards)` minus
+  dust/rounding.
+
+### Reentrancy and token quirks
+- `nonReentrant` blocks re-entry into the same function.
+- All vault functions revert when called during
+  `FlashSwapInProgress` or `FlashSettleInProgress`.
+- ERC-777 / fee-on-transfer reentrancy attempt against any function
+  reverts.
+
+### Multicall
+- `[stakeTopUp, setYieldTarget]` works atomically.
+- `[swap, swap]` partial-segments work.
+- `[flashSettle, unstake, claimRewards]` works atomically.
+- `[swap, unstake, claimRewards]` works atomically.
+- Per-call state checks NOT bypassed by multicall.
+
+### Underwater scenarios
+- Case 4 (`b < B AND q < Q + T`) classified correctly.
+- Setting `T = 0` from Underwater converts to Case 1, 2, or 3.
+- `flashSettle` from Underwater succeeds with adequate helper
+  funding.
+
+---
+
+**End of spec.** Reach back to RFC-0003 only for clarification on the
+*why* of a decision; the *what* is fully specified here.

--- a/docs/positions/uniswapv3-staking-vault/ui-concept.md
+++ b/docs/positions/uniswapv3-staking-vault/ui-concept.md
@@ -1,0 +1,214 @@
+# UI Concept — `uniswapv3-staking-vault`
+
+> Phase 3 concept document for the Uniswap V3 Staking Vault integration,
+> per [how-to-implement-new-positions.md](../../how-to-implement-new-positions.md).
+> This document specifies the UI surface — card layout, detail page tabs,
+> add-position flow, and the backend requirements those surfaces produce.
+>
+> Reference inputs:
+> - [`mental-model.md`](./mental-model.md) — user-facing framing
+> - [`position-concept.md`](./position-concept.md) — Phase 1 (identity, lifecycle, economic invariant) and Phase 2 (metrics)
+> - [`docs/ui.md`](../../ui.md) — global UI templates for the existing position types (NFT, Vault Shares)
+>
+> Phase 4 (Automation Surface) for this position is not yet written.
+> Several decisions in this document — particularly the technical
+> realisation of the yield-target pause/resume mechanic — depend on
+> the Phase 4 outcome and are explicitly marked as such.
+
+## Multi-wallet handling (applies throughout this document)
+
+The user owns multiple wallets. `vault.owner()` may match any wallet
+in the user's wallet set; **`isOwnedByUser`** is the boolean derived
+from that match. The currently-connected wallet is a separate concern:
+**`isConnectedWalletOwner`** is `true` only when the connect-state
+matches `vault.owner()` exactly.
+
+These two states gate UI elements differently:
+
+- **Action visibility** is gated by `isOwnedByUser`. If the vault
+  belongs to no wallet of the user, owner-only actions are hidden;
+  what remains is read-only management (refresh, archive from list).
+- **Action execution** is gated by `isConnectedWalletOwner`. Owner-
+  only action buttons remain visible whenever `isOwnedByUser == true`,
+  regardless of which user wallet is currently connected. At click
+  time, if `isConnectedWalletOwner == false`, the action MUST first
+  open a `SwitchConnectedWalletPrompt` component prompting the user
+  to switch to the wallet matching `vault.owner()`. Only after the
+  switch completes does the action's actual modal or wizard open.
+
+**`SwitchConnectedWalletPrompt` does not exist today and must be
+built.** It is a reusable component, not vault-specific — every
+multi-wallet position type benefits from it, and the existing
+NFT/Vault-Share patterns silently assume single-wallet equivalence.
+This is a Phase 3 backend/frontend requirement (see §3.4).
+
+## 3.1 Card layout slots
+
+The card follows the standard three-region layout from [`docs/ui.md`](../../ui.md#per-card-layout): header (status + structural identification), metrics block, right-side common buttons; with a protocol-specific bottom action row beneath.
+
+### Slot 1 — Header status badges
+
+The upper badge row, rendered alongside the pair name. Vault-card badges:
+
+- **`In Range`** / **`Out of Range`** — pool price relative to the wrapped NFT's `[tickLower, tickUpper]` range, projected into quote via `isToken0Quote`. Same semantics as the NFT card, same green/red colouring. Per the position concept (§2.1.6), the wrapped-NFT range is the productivity range; "In Range" means the position is actively rebalancing and accruing fees.
+- **`Settled`** — when `vaultState == 'Settled'` (per Phase 1.2 forward-monotonic). Replaces the NFT pattern's `Closed` badge; the lifecycle semantics are different (forward-monotonic, not reopenable), so the name diverges deliberately.
+- **`Staking`** — neutral type-identifier, analogous to `Tokenized` on the existing Vault-Share card. Always present (except when `Settled`).
+- **`<n> days`** — age indicator computed from `positionOpenedAt`. Reused from existing card pattern, no protocol-specific behaviour.
+
+Badges deliberately **not** included:
+
+- `Burned` — the wrapped NFT may technically be burned after settlement and full drain, but this is irrelevant to the vault user. The vault clone's address is permanent (per SPEC §1) and is the user's reference, not the NFT.
+- `Underwater` — the underwater state is an internal vault condition that surfaces in the swap-status field; it does not warrant a card-level badge. Users see the consequence (in the unstake-wizard preview) where it matters operationally.
+- `Pending Partial` — the partial-unstake-pending state (`pendingBps > 0`) is a configuration detail surfaced in the detail page (§3.2 TBD), not on the card.
+- `Empty` — the empty state (`vaultState == 'Empty'`) is implicit in the metrics block (`Current Value: 0`) and the action row state.
+
+### Slot 2 — Header structural line
+
+Below the status badges. Vault-card structure:
+
+```
+uniswapv3-staking-vault • <chain> • <feeTier> • <truncatedVaultAddress> [copy] [explorer]   [owner-badge]
+```
+
+- **Protocol name** — `uniswapv3-staking-vault`, the discriminator from §1.1.
+- **Chain** — same chain badge as existing pattern (chain name + colour).
+- **Fee tier** — pool fee tier from `pool.fee()`, displayed as percent (e.g. `0.05%`).
+- **Identifier** — truncated vault address, with copy and explorer-link icons.
+- **Owner badge**: `Bottz-Icon` if `isOwnedByUser == true` (consistent regardless of which user wallet matches; the user is the owner). Truncated owner address in grey if `isOwnedByUser == false` (read-only watching of someone else's vault).
+
+The wrapped NFT's `tokenId` is **not** displayed on the card. It is an implementation detail (per §1.1) and lives in the Technical Details tab of the detail page (§3.2 TBD).
+
+### Slot 3 — Metrics block
+
+Five fields, replacing or reinterpreting the standard NFT slots:
+
+| Slot | Vault-card content |
+|---|---|
+| 1 | **`Current Value` (USDC) / `Current Stake` (Token-Pair)** — toggle-able, default `Current Value`. Shows mark-to-market in quote (per §2.1.1) or the staked inventory as a token-pair (e.g. `1 WETH / 2,000 USDC`). User toggle persists via localStorage, keyed on `positionHash`. |
+| 2 | **PnL Curve** — mini-sparkline of position value vs. base price, identical visualisation to the NFT card with vault-specific `computeCurrentValue` as input. Acceptable as a starting visualisation; vault-specific refinements (e.g. underwater-region marking at `T > 0`) are deferred. |
+| 3 | **Total PnL (USDC)** — `realizedPnl + unrealizedPnl + collectedYield + unclaimedYield` per the standard four-component decomposition (§2.3). Up/down arrow with red/green tinting, identical to NFT card. |
+| 4 | **`Claimable Funds` (USDC)** — combined value of both buffers: `(unstakeBufferBase + rewardBufferBase) × P_pool + unstakeBufferQuote + rewardBufferQuote`. Amber when > 0. The combined value avoids breaking the five-slot pattern; the per-buffer breakdown is available in the detail page. |
+| 5 | **`Yield Target` (USDC)** — `state.yieldTarget`, replacing the NFT card's `est. APR` slot. The vault has no continuous yield rate; the target is the meaningful number. When `yieldTarget == uint256.max`, displays as `–` or `Not set`. |
+
+**localStorage key convention** for the Slot 1 toggle: `vault-card-slot:<positionHash>`. Cleanup hook required when the position is deleted (see §3.4).
+
+### Slot 4 — Right-side common buttons
+
+| Button | Vault behaviour |
+|---|---|
+| **View Details** | Identical to NFT pattern. Navigates to detail page; stores current dashboard URL for back-navigation. |
+| **Refresh** | Identical to NFT pattern. `POST /refresh`. |
+| **3-dot menu** | Two items: **Reload History** (identical to existing pattern), **Delete Position** (with localStorage cleanup, see §3.4). **`Switch Quote Token` is dropped** — `isToken0Quote` is on-chain immutable per SPEC §1, and a switch would violate the vault's case-classification semantics. |
+
+### Slot 5 — Bottom action row
+
+The action row mirrors the NFT pattern as closely as the protocol allows. Owner-only buttons follow the multi-wallet handling described above.
+
+**Layout**:
+
+```
+[+ Stake More] [- Unstake] [$ Claim Funds]   ◇   [Pool Price] [Yield Target Component]   ◇   [Archive Position]
+```
+
+#### Position management buttons (left section)
+
+| Button | Visibility | Action |
+|---|---|---|
+| **`+ Stake More`** | Visible if `isOwnedByUser`. Always enabled when `vaultState != 'Settled'`. | Navigates to a top-up wizard page, analogous to the existing `IncreaseDepositPage` pattern. Atomic deposit + stake. |
+| **`- Unstake`** | Visible if `isOwnedByUser`. Enabled if `vaultState != 'Empty'`. | Opens the unstake wizard (specified below). |
+| **`$ Claim Funds`** | Visible if `isOwnedByUser`. Enabled if `claimableFunds > 0`. | Opens the claim-funds modal (specified below). |
+
+#### Unstake wizard
+
+The unstake wizard is status-centric, not configuration-centric: the user selects how much to unstake, and the wizard previews exactly what will happen (resulting swap, economic impact, claimable funds delta).
+
+**Step 1 — Configure & Preview**:
+
+- **Withdrawal slider** (0%–100% in basis points). The user picks one number.
+- **Status section** below the slider, live-updating as the slider moves:
+  - The resulting swap (`<base in> → <quote out>` or vice versa, with effective rate vs. spot, e.g. `1 WETH → 1,300 USDC, 700 USDC under spot`).
+  - Economic impact: realized PnL, claimable funds delta, with red/green tinting.
+  - Implicit T-mechanics are **not surfaced**: when the position is underwater, the wizard internally performs `setYieldTarget(0)` before the swap and restores `yieldTarget` to the proportional residual (`T_old × (1 − bps/10000)`) afterwards. This is pure mechanics; the user does not see it. The user sees only the resulting swap and its economic effect.
+- **Toggle row** below the status section, two states:
+  - Self-execute mode (default): _"You need <X> USDC additional funds, which will be returned in the same transaction. [ ] Use flashloan instead"_
+  - Flashloan mode (after toggle): _"Flash loan cost: <Y> USDC. [ ] No flashloan, self execute"_
+  - Toggling switches the entire status section to the alternative path and updates economic figures accordingly.
+
+**Step 2 — Execute Transaction**:
+
+A multicall, contents depending on the chosen path:
+
+- **Self-execute path**:
+  1. (conditional, if underwater) `setYieldTarget(0)`
+  2. `swap(bps)` with the user supplying deficit-side liquidity from their wallet
+  3. (conditional, if partial unstake and underwater) `setYieldTarget(T_old × (1 − bps/10000))`
+  4. `unstake()`
+  5. `claimRewards()`
+- **Flashloan path**:
+  1. `flashClose(bps)` (which auto-drains internally per SPEC §15)
+
+The wizard preview requires a backend service that simulates the post-action state for any given `bps` and path (self-execute vs. flashloan). This service does not exist today and is a Phase 3.4 requirement. See §3.4.
+
+#### Claim-funds modal
+
+A modal dialog with two checkboxes, allowing the user to drain principal and yield independently or together:
+
+- **`[ ] Claim Unstaked Funds`** — value: `unstakeBufferBase × P_pool + unstakeBufferQuote`. Defaults to checked if `unstakeBuffer*` is non-zero; disabled and unchecked if zero.
+- **`[ ] Claim Rewards`** — value: `rewardBufferBase × P_pool + rewardBufferQuote`. Defaults to checked if `rewardBuffer*` is non-zero; disabled and unchecked if zero.
+
+Execution is a multicall containing the user-selected drains. Critically, **the two ledger events remain separate**: a `STAKING_UNSTAKE` event for principal drain, a `STAKING_CLAIM_REWARDS` event for yield drain, each with its own `tokenValue` and accounting impact. The combined-modal UX is purely a transaction-batching convenience; the underlying domain separation (principal vs. yield) is preserved per the position concept (§2.3).
+
+#### Pool Price and Yield Target Component (middle section)
+
+Between the position-management buttons and the archive button, two informational/control elements:
+
+- **Pool Price** — live-updating display, identical to the NFT card's `Current Price` element. Reuse the existing component as-is.
+- **Yield Target Component** — vault-specific, structurally analogous to the NFT card's stop-loss/take-profit element. Three states:
+
+  | State | Display | Click targets |
+  |---|---|---|
+  | No target set (`yieldTarget == uint256.max`) | `+ Yield Target` button | Click opens a modal to set an initial value via `setYieldTarget(<value>)`. |
+  | Active target (`yieldTarget < uint256.max`, not paused) | `[Pause-Icon] | <value> USDC [Pen-Icon] | X` | **Pause-Icon**: pauses automation (mechanism TBD per Phase 4). **Centre section**: opens edit modal. **X**: removes target via `setYieldTarget(uint256.max)`. |
+  | Paused target | `[Resume-Icon] | <value> USDC [Pen-Icon] | X` | **Resume-Icon**: re-activates the previously-set target. Centre and X behave as in the active state. |
+
+  All click targets that trigger a wallet transaction display a **pending state** during transaction submission (e.g. a spinner overlay, with other targets disabled). The state changes only after the transaction confirms; if it fails or is cancelled, an error popup is shown and the component reverts.
+
+  **The technical realisation of pause/resume is a Phase 4 decision.** Three plausible architectures exist:
+  - On-chain `setYieldTarget(uint256.max)` plus off-chain memo of the previous value.
+  - On-chain `yieldTarget` unchanged, plus an off-chain automation flag that the solver/keeper layer respects.
+  - Hybrid: on-chain `uint256.max` plus off-chain notification to the automation layer.
+
+  Which architecture is correct depends on the Phase 4 outcome of how the vault's settlement automation is realised (constitutive permissionless `swap()`, plus possibly active solver-network registration). Phase 4 will fill this in; the UI specification above is stable across all three options.
+
+#### Archive button (right section)
+
+- **Archive Position** — visible when `vaultState == 'Settled' AND claimableFunds == 0`. Toggles `isArchived` via `useArchivePosition`. Identical to the existing pattern.
+
+#### Multi-wallet treatment summary
+
+`+ Stake More`, `- Unstake`, `$ Claim Funds`, and the Yield Target Component's three click targets all follow the multi-wallet handling defined at the top of this document. They are visible whenever `isOwnedByUser == true`; on click, if `isConnectedWalletOwner == false`, `SwitchConnectedWalletPrompt` opens before the actual action.
+
+`Archive Position`, `View Details`, `Refresh`, and the 3-dot-menu items are not owner-only — they manage the user's tracking record, not the on-chain vault — and have no `SwitchConnectedWalletPrompt` requirement.
+
+## 3.2 Detail page tabs
+
+*To be specified.* The detail page's seven canonical tabs (Overview, PnL Analysis, APR Analysis, Conversion, Automation, Accounting, Technical Details) need a per-tab decision: applies as-is, reinterpreted, or dropped. Several tabs interact with Phase 4 (Automation Surface), particularly the Automation tab; this section will be filled in once Phase 3.2 is walked.
+
+## 3.3 Add-position flow
+
+*To be specified.* The four canonical entry points (Create Wizard, Import by ID, Import by Address, Scan Wallet) need a per-entry decision. Notable in advance: the Create Wizard for the staking vault requires steps that have no NFT analog (yield target selection, atomic factory-deploy + initial-stake transaction); Scan Wallet relies on the factory's `VaultCreated` event indexing.
+
+## 3.4 Backend requirements derived
+
+This section consolidates the requirements that the lower phases (5+ in the renumbered guide) will need to fulfil. It will be expanded as §3.2 and §3.3 are walked.
+
+### Confirmed from §3.1
+
+- **`SwitchConnectedWalletPrompt` component.** Reusable across position types; not vault-specific. Must be built.
+- **localStorage cleanup hook on position delete.** When a position is deleted, the keys `vault-card-slot:<positionHash>` (and any future per-position UI preferences) must be removed.
+- **Unstake-wizard preview service.** A service that, given a vault position and a `bps` parameter, returns the simulated outcome for both the self-execute path and the flashloan path: resulting swap details, realized PnL, claimable funds delta, flash-loan fee estimate. This is a new service, parallel to the existing `simulate_position_at_price` for NFT positions, but with vault-specific economics.
+- **Yield-target pause/resume mechanic.** Phase 4 dependency; see §3.1 Slot 5. The UI specification is stable; the technical realisation is open.
+
+### TBD from §3.2 and §3.3
+
+To be filled in.

--- a/docs/positions/uniswapv3-staking-vault/ui-concept.md
+++ b/docs/positions/uniswapv3-staking-vault/ui-concept.md
@@ -76,7 +76,7 @@ uniswapv3-staking-vault • <chain> • <feeTier> • <truncatedVaultAddress> [c
 - **Identifier** — truncated vault address, with copy and explorer-link icons.
 - **Owner badge**: `Bottz-Icon` if `isOwnedByUser == true` (consistent regardless of which user wallet matches; the user is the owner). Truncated owner address in grey if `isOwnedByUser == false` (read-only watching of someone else's vault).
 
-The wrapped NFT's `tokenId` is **not** displayed on the card. It is an implementation detail (per §1.1) and lives in the Technical Details tab of the detail page (§3.2 TBD).
+The wrapped NFT's `tokenId` is **not** displayed on the card. It is an implementation detail (per §1.1) and lives in the Technical Details tab of the detail page (see §3.2).
 
 ### Slot 3 — Metrics block
 
@@ -192,7 +192,109 @@ Between the position-management buttons and the archive button, two informationa
 
 ## 3.2 Detail page tabs
 
-*To be specified.* The detail page's seven canonical tabs (Overview, PnL Analysis, APR Analysis, Conversion, Automation, Accounting, Technical Details) need a per-tab decision: applies as-is, reinterpreted, or dropped. Several tabs interact with Phase 4 (Automation Surface), particularly the Automation tab; this section will be filled in once Phase 3.2 is walked.
+The detail page has seven canonical tabs (see [`docs/ui.md` §Tabs](../../ui.md#tabs-common-to-both-types)). Each tab requires a per-protocol decision: applies as-is, reinterpreted, or dropped.
+
+This section is filled in incrementally as the tabs are walked. Two tabs are specified below; the others remain TBD.
+
+### Tab: Overview
+
+*To be specified.*
+
+### Tab: PnL Analysis
+
+*To be specified.*
+
+### Tab: APR Analysis
+
+*To be specified.*
+
+### Tab: Conversion → Swap
+
+*To be specified.* Tentative direction: the Conversion tab's premise (reconstructing AMM token-amount drift) does not apply to the vault, since token amounts are conserved by construction. The slot will be replaced by a Swap tab presenting the current `swapQuote` and the executor invitation. Final design depends on Phase 4 (Automation Surface).
+
+### Tab: Automation
+
+*To be specified.* Phase 4 dependency.
+
+### Tab: Accounting
+
+**Status: applies as-is, with vault-specific content.**
+
+The shared `PositionAccountingTab` component is reused without changes — it is protocol-agnostic. The vault integration provides:
+
+- A `useUniswapV3StakingVaultPositionAccounting` hook that fetches accounting data from the protocol-specific endpoint.
+- The `UniswapV3StakingVaultPostJournalEntriesRule` (per [position-concept.md §2.3](./position-concept.md#23-pnl-decomposition)) that produces journal entries from the five `STAKING_*` events.
+
+#### Balance Sheet section
+
+Three account classes appear in the vault-specific balance sheet:
+
+**Assets**
+- `1010 Staking Position at Cost` — active UV3 liquidity at acquisition cost.
+- `1020 Position Cash Holdings` — buffered tokens at disposal value.
+
+**Liabilities** (new class for the vault)
+- `2000 Pending Settlement` — obligation to owner for buffered tokens.
+
+**Equity**
+- Standard structure: Contributed Capital, Capital Returned, Retained Earnings (with Realized: Withdrawals, Realized: Yield, Realized: FX Effect as breakdown).
+
+The Pending Settlement liability is the visibility-anchor for buffered amounts: it ensures that a position with `$6,000` total economic value but `$2,000` returned to the owner shows correctly as `$6,000` total assets, `$4,000` pending settlement, `$2,000` net equity returned. Without the liability class, the buffered tokens would either appear as full equity (overstating returned capital) or vanish from the balance sheet (understating total position).
+
+#### P&L Statement section
+
+Four line items, all recognised at disposal time:
+
+- **Realized from Withdrawals** — the `B × ΔP` quantity from `STAKING_DISPOSE`, booked to `4100 Realized Gains` or `5000 Realized Losses`.
+- **Realized from Yield** — yield component from `STAKING_DISPOSE`, booked to `4400 Realized Yield`.
+- **Realized from FX Effect** — quote→USD conversion drift, booked to `4300 FX Gain / Loss`.
+- **Realized from Flash-Loan Fees** — present only if the on-chain pipeline can extract `flashLoanFee` separately (see [position-concept.md §2.3](./position-concept.md#staking_dispose-with-non-zero-flashloanfee)). Otherwise, the fee is implicit in Realized from Withdrawals and the row is omitted.
+
+The drain events (`STAKING_UNSTAKE`, `STAKING_CLAIM_REWARDS`) produce no P&L lines, since they are pure asset/liability movements.
+
+#### Journal Entries section
+
+Standard chronological list of journal entries, one per non-marker event. Each entry shows the date, a descriptive line referencing the event (e.g. `Vault disposal: uniswapv3-staking-vault/<chainId>/<vaultAddress>`), and the debit/credit lines per the account-mapping in [position-concept.md §2.3](./position-concept.md#account-mapping).
+
+`STAKING_CHANGE_CONFIG` events do not appear in the Journal Entries section, only in the Position Ledger (PnL Analysis tab, TBD).
+
+### Tab: Technical Details
+
+**Status: applies as-is.**
+
+The shared `PositionTechnicalDetailsTab` layout is reused: two columns, Vault Configuration (left, immutable) and Vault State (right, mutable). Each field renders as a read-only input with copy and (where applicable) explorer-link icons.
+
+#### Vault Configuration column
+
+Immutable fields from [position-concept.md §2.2](./position-concept.md#22-type-specific-metrics) plus the immutable owner address:
+
+- Vault Address (with explorer link)
+- Factory Address (with explorer link)
+- Wrapped NFT Token ID (with link to the NFT manager view on the explorer)
+- Pool Address (with explorer link)
+- Token0 Address, Token1 Address (with explorer links)
+- Fee Tier
+- Tick Spacing
+- Tick Lower, Tick Upper
+- Is Token0 Quote (Yes / No)
+- Price Range Lower, Price Range Upper (in quote)
+- Owner Address (with explorer link) — set immutably at clone initialisation per SPEC §1; conceptually belongs in Configuration despite being read from `vault.owner()` at runtime
+
+#### Vault State column
+
+Mutable fields from [position-concept.md §2.2](./position-concept.md#22-type-specific-metrics), excluding `swapQuote` (which is presented in the Automation tab where the executor invitation is the meaningful surface):
+
+- `vaultState` (Empty / Staking / Settled)
+- `swapStatus` (NotApplicable / NoSwapNeeded / Executable / Underwater)
+- `stakedBase`, `stakedQuote`
+- `yieldTarget`
+- `pendingBps`, `effectiveBps`
+- `unstakeBufferBase`, `unstakeBufferQuote`
+- `rewardBufferBase`, `rewardBufferQuote`
+- `sqrtPriceX96`, `currentTick`, `poolLiquidity`
+- `wrappedNftLiquidity`
+
+Wrapped-NFT internal accumulators (`feeGrowthInside*X128`, `tokensOwed*`, tick-level fee growth) are deliberately excluded from this tab. They are implementation details of how `currentValue` and `unclaimedYield` are computed and have no power-user value over what the wrapped NFT's explorer view already shows.
 
 ## 3.3 Add-position flow
 
@@ -209,6 +311,13 @@ This section consolidates the requirements that the lower phases (5+ in the renu
 - **Unstake-wizard preview service.** A service that, given a vault position and a `bps` parameter, returns the simulated outcome for both the self-execute path and the flashloan path: resulting swap details, realized PnL, claimable funds delta, flash-loan fee estimate. This is a new service, parallel to the existing `simulate_position_at_price` for NFT positions, but with vault-specific economics.
 - **Yield-target pause/resume mechanic.** Phase 4 dependency; see §3.1 Slot 5. The UI specification is stable; the technical realisation is open.
 
-### TBD from §3.2 and §3.3
+### Confirmed from §3.2 (Accounting & Technical Details)
+
+- **Chart of Accounts extension.** Four new accounts (`1010 Staking Position at Cost`, `1020 Position Cash Holdings`, `2000 Pending Settlement`, `4400 Realized Yield`) plus the new `2xxx` Liability class. Database migration required to extend the `account_definitions` table with the new entries. Final account codes are subject to alignment with existing conventions; the codes proposed here are suggestions.
+- **`UniswapV3StakingVaultPostJournalEntriesRule`.** New journal-posting rule consuming the five `STAKING_*` domain events and producing single-entry journal entries per the account mapping in [position-concept.md §2.3](./position-concept.md#account-mapping).
+- **`UniswapV3StakingVaultReconcileRule`.** New reconciliation rule checking the two invariants from [position-concept.md §2.3](./position-concept.md#reconciliation): `1010` balance equals `Position.costBasis`, and `1020` balance equals `2000` balance equals booked value of all four buffer slots.
+- **`useUniswapV3StakingVaultPositionAccounting` hook.** Frontend data hook for the Accounting tab.
+
+### TBD from §3.3 and remaining §3.2 tabs
 
 To be filled in.

--- a/docs/positions/uniswapv3-staking-vault/ui-concept.md
+++ b/docs/positions/uniswapv3-staking-vault/ui-concept.md
@@ -435,11 +435,90 @@ Wrapped-NFT internal accumulators (`feeGrowthInside*X128`, `tokensOwed*`, tick-l
 
 ## 3.3 Add-position flow
 
-*To be specified.* The four canonical entry points (Create Wizard, Import by ID, Import by Address, Scan Wallet) need a per-entry decision. Notable in advance: the Create Wizard for the staking vault requires steps that have no NFT analog (yield target selection, atomic factory-deploy + initial-stake transaction); Scan Wallet relies on the factory's `VaultCreated` event indexing.
+The Add Position dropdown (per [`docs/ui.md`](../../ui.md)) currently exposes four entry points: Create New Position, Import NFT by ID, Import Tokenized Position by Address, and Scan Wallet. This iteration specifies only the **Create New Position wizard** for the staking vault. The other three entry points are deferred to a separate iteration.
+
+### Approach: extend the existing Create Wizard, do not build a parallel one
+
+The existing four-step Create Wizard (Step 1: Select Pool → Step 2: Capital Allocation / Position Range / SL-TP Setup → Step 3: Acquire Required Tokens → Step 4: Execute Transactions) is reused as-is for the staking vault, with minimal targeted extensions.
+
+Rationale: the wizard's overall structure is shared by both position types — pool selection, base/quote/chain selection, capital allocation, and range selection are identical operations. Only the final transaction list differs materially. Building a parallel wizard would duplicate the majority of the surface for marginal gain. A future refactor of the Add Position flow may consolidate position-type handling more comprehensively as more position types are added; this iteration is deliberately pragmatic.
+
+### Step 1 — Select Pool: extension
+
+A new **Position Type** section is added to the Summary panel on the right, between `Selected Pool` and `Allocated Capital`:
+
+```
+Position Type
+[ Standard UniswapV3 ▾ ]
+   Standard UniswapV3
+   Uniswap V3 Staking Vault
+```
+
+Default: `Standard UniswapV3` (preserves existing behaviour). The selection is persisted across all subsequent wizard steps via the wizard's existing query-string state mechanism.
+
+Pool selection, base/quote token selection, and chain selection are unchanged — both position types operate on the same Uniswap V3 pool set.
+
+### Step 2 — Capital Allocation / Position Range / SL-TP Setup: per-tab treatment
+
+The three-tab structure of step 2 is preserved for visual consistency.
+
+**Capital Allocation tab** — identical for both position types. The wizard collects `(B, Q)` token amounts; for the staking vault these become the `(B, Q)` of the initial stake passed to `factory.createVault(...)`.
+
+**Position Range tab** — identical for both position types. The selected `[lowerTick, upperTick]` becomes the wrapped NFT's range, set immutably at vault creation.
+
+**SL/TP Setup tab** — when `Position Type == Staking Vault`, the tab is visible but inactive. It displays an info panel:
+
+> _**Stop-loss and take-profit are not applicable to staking vaults.** The vault's settlement is governed by a yield target instead, set in quote-token units. The yield target defaults to `uint256.max` (Not set) at creation, leaving the vault in the strong-guarantee state where principal recovery is structurally always honourable (per [position-concept.md §1.3](./position-concept.md#13-economic-invariant), Strong guarantee at T=0). It can be configured after creation via the position card's Yield Target Component (per [§3.1 Slot 5](#slot-5--bottom-action-row))._
+
+No yield-target input is collected in the wizard. The yield target is **only** configurable post-creation via the card's Yield Target Component. Rationale: keeping the wizard's `createVault()` call as a single atomic transaction (deploy + initial stake) without forcing the user to commit to a target before they've seen the position in their portfolio. The vault is fully usable in the `uint256.max` / Strong-guarantee state; the user is not blocked.
+
+The Summary panel's `Risk Profile` section adapts when `Position Type == Staking Vault`: the Stop Loss / Take Profit / Max Drawdown / Max Runup lines are replaced by a single line:
+
+```
+Yield Target    Not set
+                (configure after creation)
+```
+
+This is informational — no interaction.
+
+### Step 3 — Acquire Required Tokens: identical
+
+The wallet-balance check is token-and-amount based, which is independent of how the tokens will be consumed downstream. No change.
+
+### Step 4 — Execute Transactions: position-type-specific transaction list
+
+The transaction list differs based on `Position Type`:
+
+| Step | Standard UniswapV3 (existing) | Staking Vault (new) |
+|---|---|---|
+| 1 | Approve token0 → NPM | Approve token0 → Factory |
+| 2 | Approve token1 → NPM | Approve token1 → Factory |
+| 3 | Pool price drift check | Pool price drift check (identical) |
+| 4 | **Open** UniswapV3 Position (`NPM.mint(...)`) | **Create** Staking Vault (`factory.createVault(...)`) |
+
+The pool price drift check is a generic sanity pattern and runs identically for both position types.
+
+For the staking vault, the final transaction calls `factory.createVault(...)` which atomically deploys the EIP-1167 clone, initialises ownership (immutably setting `vault.owner()` to the connected wallet per SPEC §1), and performs the initial stake — closing the standard EIP-1167 front-running race per [position-concept.md §1.1](./position-concept.md#11-identity).
+
+The button label changes from `Open UniswapV3 Position` to `Create Staking Vault` accordingly. Approval targets change from NPM to Factory, but this is implementation detail not surfaced to the user beyond the transaction count being identical.
+
+The Summary panel's `Selected Pool` block remains identical; only the Risk Profile section reflects the position-type difference (configured in Step 2).
+
+### Post-creation handoff
+
+After successful execution of the final transaction, the wizard navigates to the position list. For a staking vault, the new card appears with `Yield Target: Not set` in Slot 5 of the bottom action row (per [§3.1 Slot 5](#slot-5--bottom-action-row)). The user can either leave the vault in the strong-guarantee state (the default) or click `+ Yield Target` on the card to enter the conditional-guarantee state with an explicit target.
+
+### What is deliberately not in the wizard
+
+- **Yield target input.** Out of scope for this iteration; configured post-creation only via the card's Yield Target Component. The default `uint256.max` is a fully functional state, not a placeholder.
+- **Partial-unstake-bps configuration.** Defaults to `0` (no pending partial); the user does not need to think about this at creation.
+- **Approval-target distinction in the UI.** The user does not see whether the approval target is the NPM or the Factory.
+- **Vault address preview.** Counterfactual (CREATE2-based) address computation could let the wizard show the upcoming vault address before creation. Out of scope; the address appears in the position card after the transaction confirms.
+- **Other entry points.** Import NFT by ID, Import Tokenized Position by Address, and Scan Wallet are deferred. The Import Tokenized entry point is a natural future extension for vault-by-address import; Scan Wallet would require indexing of the factory's `VaultCreated` events.
 
 ## 3.4 Backend requirements derived
 
-This section consolidates the requirements that the lower phases (5+ in the renumbered guide) will need to fulfil. It will be expanded as §3.2 and §3.3 are walked.
+This section consolidates the requirements that the lower phases (5+ in the renumbered guide) will need to fulfil.
 
 ### Confirmed from §3.1
 
@@ -469,6 +548,15 @@ This section consolidates the requirements that the lower phases (5+ in the renu
 
 - **Overview composition.** No new endpoints; the Overview tab composes from data already exposed for §3.1 (card metrics, vault state) and shares the range-visualisation component with the NFT pattern. A thin `useUniswapV3StakingVaultPositionOverview` aggregation hook is recommended for the page-level data fetch but is largely a composition over existing hooks.
 
-### TBD from §3.3 and remaining §3.2 tabs
+### Confirmed from §3.3 (Create Wizard extension)
 
-To be filled in.
+- **Wizard state extension.** A `positionType: 'standard' | 'staking_vault'` field added to the Create Wizard's query-string state and React state machine. Default `'standard'`. Persisted across all four wizard steps.
+- **Step 1 Position Type dropdown.** New Summary-panel section between `Selected Pool` and `Allocated Capital`, two options.
+- **Step 2 SL/TP tab inactivation.** When `positionType == 'staking_vault'`, the SL/TP Setup tab renders an info panel instead of the input fields. The Summary panel's Risk Profile section replaces the SL/TP lines with a single Yield Target informational line.
+- **Step 4 transaction-list resolver.** Produces the position-type-specific transaction list including approval targets (NPM for standard, Factory for staking vault) and the final mint vs. createVault call. Button label is parametrised on position type.
+- **Factory ABI integration.** `factory.createVault(pool, tickLower, tickUpper, baseAmount, quoteAmount, owner)` call construction, with `owner = connectedWallet.address`. Yield target is **not** a parameter — vault is initialised with `yieldTarget = uint256.max`.
+
+### TBD
+
+- Other Add-position entry points (Import NFT by ID, Import Tokenized by Address, Scan Wallet) — separate iteration.
+- The two Phase-4-dependent tabs in §3.2 (Conversion → Swap, Automation).

--- a/docs/positions/uniswapv3-staking-vault/ui-concept.md
+++ b/docs/positions/uniswapv3-staking-vault/ui-concept.md
@@ -58,8 +58,8 @@ The upper badge row, rendered alongside the pair name. Vault-card badges:
 Badges deliberately **not** included:
 
 - `Burned` — the wrapped NFT may technically be burned after settlement and full drain, but this is irrelevant to the vault user. The vault clone's address is permanent (per SPEC §1) and is the user's reference, not the NFT.
-- `Underwater` — the underwater state is an internal vault condition that surfaces in the swap-status field; it does not warrant a card-level badge. Users see the consequence (in the unstake-wizard preview) where it matters operationally.
-- `Pending Partial` — the partial-unstake-pending state (`pendingBps > 0`) is a configuration detail surfaced in the detail page (§3.2 TBD), not on the card.
+- `Underwater` — the underwater state is an internal vault condition that surfaces in the Overview tab's Position State block via the `swapStatus` indicator (see §3.2, Overview tab); it does not warrant a card-level badge.
+- `Pending Partial` — the partial-unstake-pending state (`pendingBps > 0`) is surfaced in the Overview tab's Position State block (see §3.2), not on the card.
 - `Empty` — the empty state (`vaultState == 'Empty'`) is implicit in the metrics block (`Current Value: 0`) and the action row state.
 
 ### Slot 2 — Header structural line
@@ -194,11 +194,60 @@ Between the position-management buttons and the archive button, two informationa
 
 The detail page has seven canonical tabs (see [`docs/ui.md` §Tabs](../../ui.md#tabs-common-to-both-types)). Each tab requires a per-protocol decision: applies as-is, reinterpreted, or dropped.
 
-This section is filled in incrementally as the tabs are walked. Four tabs are specified below; the others remain TBD.
+This section is filled in incrementally as the tabs are walked. Five tabs are specified below; the two remaining (Conversion → Swap, Automation) are Phase 4 dependent.
 
 ### Tab: Overview
 
-*To be specified.*
+**Status: applies as-is, with a vault-specific Position State block.**
+
+The Overview tab follows the existing pattern: a hero summary at the top, the price-range visualisation as the centrepiece, and supporting blocks below. The vault-specific addition is the Position State block, which surfaces operational status that has no NFT analog.
+
+#### Hero Summary section
+
+A compact top row with the four headline metrics, presented at larger size than on the card:
+
+- **Current Value** — `currentValue` in quote, prominent
+- **Total PnL** — `realizedPnl + unrealizedPnl + collectedYield + unclaimedYield`, with arrow and red/green tinting
+- **Cost Basis** — `costBasis` in quote
+- **Yield Target** — `state.yieldTarget` (or `Not set` if `uint256.max`)
+
+These are the same metrics as the card's Slot 3 block, recomposed for the larger detail-page surface.
+
+#### Range Visualisation section
+
+The shared range-visualisation component is reused as-is. Shows:
+
+- The wrapped NFT's `[priceRangeLower, priceRangeUpper]` band
+- The current pool price as a marker
+- In-Range / Out-of-Range status, colour-coded consistently with the Slot 1 badge
+
+No vault-specific adaptations. The range is displayed because the wrapped NFT does have a real range, even though the user's settlement is gated by yield-target satisfaction rather than range-crossings.
+
+#### Position State block (vault-specific)
+
+A four-indicator grid surfacing the operational state. Each indicator with concise styling:
+
+| Indicator | Possible values |
+|---|---|
+| **Vault State** | `Empty` / `Staking` / `Settled` (neutral colour) |
+| **Swap Status** | `NotApplicable` / `NoSwapNeeded` / `Executable` (green) / `Underwater` (red) |
+| **Yield Target** | `Not set` / `<value> USDC active` / `<value> USDC paused` (single-row presentation combining value and pause state) |
+| **Pending Unstake** | `None` / `<X>% pending` |
+
+The Underwater condition surfaces here as one of the four Swap Status values, in red. No separate warning box and no card-level badge — the red Swap Status indicator carries the information without overdramatising. Underwater is a user-caused condition (the user set `T`), not a system emergency.
+
+#### Buffer Holdings section
+
+The per-buffer breakdown that the card combines into a single Claimable Funds value:
+
+| | Base | Quote | Total Value |
+|---|---|---|---|
+| Unstake Buffer | `<base>` | `<quote>` | `$<value>` |
+| Reward Buffer | `<base>` | `<quote>` | `$<value>` |
+
+Below the table, a **Claim Funds** quick-action button that opens the same modal as the card's `$ Claim Funds` action (see [§3.1 Slot 5](#slot-5--bottom-action-row)). This is convenience for the user already in the detail page; the button is duplicated by design — card buttons serve the list context, detail-page buttons serve the detail context.
+
+The button follows the same multi-wallet handling as on the card: visible if `isOwnedByUser`, opens `SwitchConnectedWalletPrompt` if `isConnectedWalletOwner == false`.
 
 ### Tab: PnL Analysis
 
@@ -415,6 +464,10 @@ This section consolidates the requirements that the lower phases (5+ in the renu
 
 - **Position Ledger query for the vault** must return all five `STAKING_*` event types, including PnL-neutral events (`STAKING_UNSTAKE`, `STAKING_CLAIM_REWARDS`, `STAKING_CHANGE_CONFIG`). The `useUniswapV3StakingVaultPositionEvents` hook (or equivalent) feeds the Position Ledger table; the `STAKING_CHANGE_CONFIG` events are sourced from the ledger like any other event despite producing no journal entry.
 - **PnL Breakdown computation hook.** A `useUniswapV3StakingVaultPositionPnL` hook (or extension of an existing PnL hook with vault-discriminator support) feeding the two-card Realized/Unrealized breakdown.
+
+### Confirmed from §3.2 (Overview)
+
+- **Overview composition.** No new endpoints; the Overview tab composes from data already exposed for §3.1 (card metrics, vault state) and shares the range-visualisation component with the NFT pattern. A thin `useUniswapV3StakingVaultPositionOverview` aggregation hook is recommended for the page-level data fetch but is largely a composition over existing hooks.
 
 ### TBD from §3.3 and remaining §3.2 tabs
 

--- a/docs/positions/uniswapv3-staking-vault/ui-concept.md
+++ b/docs/positions/uniswapv3-staking-vault/ui-concept.md
@@ -194,7 +194,7 @@ Between the position-management buttons and the archive button, two informationa
 
 The detail page has seven canonical tabs (see [`docs/ui.md` §Tabs](../../ui.md#tabs-common-to-both-types)). Each tab requires a per-protocol decision: applies as-is, reinterpreted, or dropped.
 
-This section is filled in incrementally as the tabs are walked. Two tabs are specified below; the others remain TBD.
+This section is filled in incrementally as the tabs are walked. Three tabs are specified below; the others remain TBD.
 
 ### Tab: Overview
 
@@ -206,7 +206,47 @@ This section is filled in incrementally as the tabs are walked. Two tabs are spe
 
 ### Tab: APR Analysis
 
-*To be specified.*
+**Status: reinterpreted.**
+
+The shared APR-Analysis tab structure is reused, but the Unrealized-APR card is dropped because the vault has no continuous yield-accumulation between settlements. Yield is recognised at disposal events; between disposals the position has zero realised yield, and there is no meaningful live projection of "yield in flight" comparable to NFT `tokensOwed`.
+
+#### APR Breakdown section
+
+Single-card layout (instead of the NFT pattern's two-card Realized/Unrealized split):
+
+- **Total APR** — header line, e.g. `Total APR: 12.4% (over 47.3 days)`. Equals the Realized APR below; no Unrealized component contributes.
+- **Realized APR** card with the breakdown:
+  - Total Yield Collected — `collectedYield` from [position-concept.md §2.1.4](./position-concept.md#21-common-metric-mapping)
+  - Time-Weighted Cost Basis — weighted average of `costBasis` across all completed periods
+  - Active Days — sum of days across all completed periods (see Pause handling below)
+  - `= Realized APR` — `(Total Yield Collected / Time-Weighted Cost Basis) × (365 / Active Days)`
+
+The Unrealized-APR card from the NFT pattern is omitted entirely. The vault's yield mechanic does not support a "yield in flight" estimate: between disposals, no yield is accumulating in any meaningful sense — the yield substance materialises atomically at the `swap()` or `flashClose()` moment.
+
+#### APR Periods section
+
+Chronological list of completed APR periods. Each period spans from one bracket event to the next.
+
+**Bracket events**: `STAKING_DEPOSIT` and `STAKING_DISPOSE` only. Per [position-concept.md §2.1.5](./position-concept.md#21-common-metric-mapping), `STAKING_CLAIM_REWARDS` does not bracket because it is a pure asset/liability movement, not a recognition event — `collectedYield` was already incremented at the prior `STAKING_DISPOSE`.
+
+Per period, the table shows:
+
+- Start event (date, type)
+- End event (date, type)
+- Cost Basis (the average during the period)
+- Yield Collected (= `collectedYield` recognised at the period's end event, if it was a `STAKING_DISPOSE`; otherwise zero)
+- Days
+- APR
+
+If no APR periods exist yet (the position has had no `STAKING_DISPOSE` events), the section displays a hint: _"No completed APR periods yet. Periods are computed at disposal events."_ — analogous to the NFT pattern's empty-state.
+
+#### Pause-phase treatment in APR computation
+
+When the owner pauses the yield-target component (per [§3.1 Slot 5](#slot-5--bottom-action-row), Yield Target Component pause/resume), the position remains staked and capital remains committed, but no settlement can occur. Pause phases **count toward `Active Days`** in the APR computation.
+
+Rationale: APR's definition is `(yield / capital × time)`, and capital is committed throughout the pause. Excluding pause phases would overstate the effective return. If the owner chooses to forgo settlement opportunities, the resulting lower APR should be visible — it reflects an investment decision with consequences.
+
+This treatment is independent of the underlying technical realisation of pause/resume (Phase 4 dependency, see [§3.1 Slot 5](#slot-5--bottom-action-row)).
 
 ### Tab: Conversion → Swap
 
@@ -317,6 +357,11 @@ This section consolidates the requirements that the lower phases (5+ in the renu
 - **`UniswapV3StakingVaultPostJournalEntriesRule`.** New journal-posting rule consuming the five `STAKING_*` domain events and producing single-entry journal entries per the account mapping in [position-concept.md §2.3](./position-concept.md#account-mapping).
 - **`UniswapV3StakingVaultReconcileRule`.** New reconciliation rule checking the two invariants from [position-concept.md §2.3](./position-concept.md#reconciliation): `1010` balance equals `Position.costBasis`, and `1020` balance equals `2000` balance equals booked value of all four buffer slots.
 - **`useUniswapV3StakingVaultPositionAccounting` hook.** Frontend data hook for the Accounting tab.
+
+### Confirmed from §3.2 (APR Analysis)
+
+- **APR period bracketing on STAKING_DEPOSIT and STAKING_DISPOSE only.** The `position_apr_periods` table population logic must skip `STAKING_CLAIM_REWARDS` events when forming periods. Pause phases (yield-target paused) are counted as Active Days regardless of pause-resume mechanism (Phase 4).
+- **APR computation hook.** A `useUniswapV3StakingVaultPositionApr` hook (or extension of an existing APR hook with vault-discriminator support) feeding the single-card APR breakdown plus the periods list.
 
 ### TBD from §3.3 and remaining §3.2 tabs
 

--- a/docs/positions/uniswapv3-staking-vault/ui-concept.md
+++ b/docs/positions/uniswapv3-staking-vault/ui-concept.md
@@ -194,7 +194,7 @@ Between the position-management buttons and the archive button, two informationa
 
 The detail page has seven canonical tabs (see [`docs/ui.md` §Tabs](../../ui.md#tabs-common-to-both-types)). Each tab requires a per-protocol decision: applies as-is, reinterpreted, or dropped.
 
-This section is filled in incrementally as the tabs are walked. Three tabs are specified below; the others remain TBD.
+This section is filled in incrementally as the tabs are walked. Four tabs are specified below; the others remain TBD.
 
 ### Tab: Overview
 
@@ -202,7 +202,55 @@ This section is filled in incrementally as the tabs are walked. Three tabs are s
 
 ### Tab: PnL Analysis
 
-*To be specified.*
+**Status: reinterpreted, with the Position Ledger acting as the full audit trail of position events.**
+
+The shared PnL-Analysis tab structure is reused: a PnL Breakdown section followed by the Position Ledger.
+
+#### PnL Breakdown section
+
+Two-card layout (consistent with NFT/Vault-Share pattern):
+
+**Realized PnL** card (recognised, lifetime-to-date):
+- Realized from Withdrawals — `B × ΔP` component cumulated from `STAKING_DISPOSE` events
+- Realized from Yield — `collectedYield` cumulated from `STAKING_DISPOSE` events
+- Realized from FX Effect — quote→USD conversion drift
+- Realized from Flash-Loan Fees — only if pipeline can extract `flashLoanFee` (see Phase 5 dependency)
+- = Subtotal
+
+All four lines map directly to accounting accounts (see Accounting tab and [position-concept.md §2.3](./position-concept.md#account-mapping)). The Realized PnL card includes all yield that has been recognised at the disposal — even if the corresponding tokens still sit in the reward buffer waiting to be drained. This is consistent with the disposal-time recognition rule from [position-concept.md §2.1.4](./position-concept.md#21-common-metric-mapping).
+
+**Unrealized PnL** card (live mark-to-market):
+- Current Position Value — `currentValue`
+- Cost Basis — `costBasis`
+- = Subtotal: `currentValue − costBasis` = `unrealizedPnl`
+
+Unlike the NFT pattern, the Unrealized card does not have a separate "Unclaimed Fees" line. The vault has no continuous fee accumulation; what the NFT pattern would call "unclaimed" is in the vault either already-recognised (in the reward buffer post-disposal) or not yet existing (no disposal has occurred). Buffer-tokens at-cost are baked into both `currentValue` (mark-to-market) and the Pending Settlement liability that offsets them.
+
+#### Position Ledger section
+
+The Position Ledger is the chronological audit trail of all events affecting the position, including PnL-neutral events. Five event types appear:
+
+- **`STAKING_DEPOSIT`** — initial stake or top-up; affects cost basis
+- **`STAKING_DISPOSE`** — settlement (swap or flashClose); recognises PnL and yield
+- **`STAKING_UNSTAKE`** — drain of unstake-buffer; PnL-neutral
+- **`STAKING_CLAIM_REWARDS`** — drain of reward-buffer; PnL-neutral
+- **`STAKING_CHANGE_CONFIG`** — owner-intent change (yield target, partial-unstake bps); PnL-neutral
+
+All events render with identical visual treatment, consistent with the existing NFT/Vault-Share Position Ledger. PnL-neutral events display `0` or `—` in the Realized PnL column; the chronological context makes their role clear.
+
+Table columns: **Date & Time**, **Event Type**, **Value**, **Realized PnL**, **Details**, **Transaction**.
+
+**Details column content** per event type:
+
+| Event Type | Details column |
+|---|---|
+| `STAKING_DEPOSIT` | `+<base> + <quote> staked` (token amounts consumed) |
+| `STAKING_DISPOSE` | `bps: <X>, principal: $<Y>, yield: $<Z>` (settlement summary, optional flash-loan fee if extractable) |
+| `STAKING_UNSTAKE` | `<base> + <quote> drained` (token amounts) |
+| `STAKING_CLAIM_REWARDS` | `<base> + <quote> drained` (token amounts) |
+| `STAKING_CHANGE_CONFIG` | `<param>: <oldValue> → <newValue>` (e.g. `yieldTarget: 400 USDC → 600 USDC`) |
+
+The Transaction column links to the on-chain explorer for the transaction hash, identical to the NFT pattern.
 
 ### Tab: APR Analysis
 
@@ -296,7 +344,7 @@ The drain events (`STAKING_UNSTAKE`, `STAKING_CLAIM_REWARDS`) produce no P&L lin
 
 Standard chronological list of journal entries, one per non-marker event. Each entry shows the date, a descriptive line referencing the event (e.g. `Vault disposal: uniswapv3-staking-vault/<chainId>/<vaultAddress>`), and the debit/credit lines per the account-mapping in [position-concept.md §2.3](./position-concept.md#account-mapping).
 
-`STAKING_CHANGE_CONFIG` events do not appear in the Journal Entries section, only in the Position Ledger (PnL Analysis tab, TBD).
+`STAKING_CHANGE_CONFIG` events do not appear in the Journal Entries section, only in the Position Ledger (PnL Analysis tab).
 
 ### Tab: Technical Details
 
@@ -362,6 +410,11 @@ This section consolidates the requirements that the lower phases (5+ in the renu
 
 - **APR period bracketing on STAKING_DEPOSIT and STAKING_DISPOSE only.** The `position_apr_periods` table population logic must skip `STAKING_CLAIM_REWARDS` events when forming periods. Pause phases (yield-target paused) are counted as Active Days regardless of pause-resume mechanism (Phase 4).
 - **APR computation hook.** A `useUniswapV3StakingVaultPositionApr` hook (or extension of an existing APR hook with vault-discriminator support) feeding the single-card APR breakdown plus the periods list.
+
+### Confirmed from §3.2 (PnL Analysis)
+
+- **Position Ledger query for the vault** must return all five `STAKING_*` event types, including PnL-neutral events (`STAKING_UNSTAKE`, `STAKING_CLAIM_REWARDS`, `STAKING_CHANGE_CONFIG`). The `useUniswapV3StakingVaultPositionEvents` hook (or equivalent) feeds the Position Ledger table; the `STAKING_CHANGE_CONFIG` events are sourced from the ledger like any other event despite producing no journal entry.
+- **PnL Breakdown computation hook.** A `useUniswapV3StakingVaultPositionPnL` hook (or extension of an existing PnL hook with vault-discriminator support) feeding the two-card Realized/Unrealized breakdown.
 
 ### TBD from §3.3 and remaining §3.2 tabs
 


### PR DESCRIPTION
## Summary
Docs-only branch covering the UniswapV3 staking vault product across mental model, position concept, RFC, spec, and UI concept. No code changes.

Adds under `docs/positions/uniswapv3-staking-vault/`:
- `mental-model.md` — high-level framing
- `position-concept.md` — Phase 1 position concept
- `rfc-0003-staking-vault.md` — RFC-0003
- `spec-0003b-staking-vault.md` — SPEC-0003b draft (incl. Phase 3.2 APR/PnL/Overview tabs and Phase 3.3 Create Wizard)
- `ui-concept.md` — Phase 3 UI concept

## Test plan
- [ ] Markdown renders correctly on GitHub
- [ ] Internal links between the new docs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)