### PR TITLE
fix: extend close-order processing to uniswapv3-vault positions

### DIFF
--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/close-orders/[closeOrderHash]/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/close-orders/[closeOrderHash]/route.ts
@@ -1,0 +1,194 @@
+/**
+ * Single Vault Close Order Endpoint (by semantic identifier)
+ *
+ * GET /api/v1/positions/uniswapv3-vault/:chainId/:vaultAddress/:ownerAddress/close-orders/:closeOrderHash
+ *
+ * Vault counterpart of the NFT route
+ * /api/v1/positions/uniswapv3/:chainId/:nftId/close-orders/:closeOrderHash —
+ * same response shape, same error codes.
+ *
+ * Authentication: Required (session only)
+ *
+ * Note: no PUT/PATCH/DELETE — the UI calls the contract directly via Wagmi, and
+ * the event subscriber (UniswapV3ProcessCloseOrderEventsRule) handles all DB writes.
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { withAuth } from '@/middleware/with-auth';
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  ApiErrorCode,
+  ErrorCodeToHttpStatus,
+  CloseOrderHashSchema,
+} from '@midcurve/api-shared';
+import { normalizeAddress } from '@midcurve/shared';
+import { serializeCloseOrder } from '@/lib/serializers';
+import { apiLogger, apiLog } from '@/lib/logger';
+import {
+  getUniswapV3CloseOrderService,
+  getUniswapV3VaultPositionService,
+} from '@/lib/services';
+import { createPreflightResponse } from '@/lib/cors';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Path params schema.
+ *
+ * Addresses are normalized to EIP-55 so a lowercase address in the URL resolves
+ * the same position as a checksummed one — the position hash is built from
+ * checksummed addresses.
+ */
+const PathParamsSchema = z.object({
+  chainId: z.string().regex(/^\d+$/).transform(Number),
+  vaultAddress: z
+    .string()
+    .regex(/^0x[0-9a-fA-F]{40}$/)
+    .transform((value) => normalizeAddress(value)),
+  ownerAddress: z
+    .string()
+    .regex(/^0x[0-9a-fA-F]{40}$/)
+    .transform((value) => normalizeAddress(value)),
+  closeOrderHash: CloseOrderHashSchema,
+});
+
+/**
+ * Handle CORS preflight
+ */
+export async function OPTIONS(request: NextRequest): Promise<Response> {
+  return createPreflightResponse(request.headers.get('origin'));
+}
+
+/**
+ * GET /api/v1/positions/uniswapv3-vault/:chainId/:vaultAddress/:ownerAddress/close-orders/:closeOrderHash
+ *
+ * Get a specific vault close order by its semantic identifier.
+ *
+ * Path parameters:
+ * - chainId: EVM chain ID
+ * - vaultAddress: Vault (ERC-20 share token) address
+ * - ownerAddress: Share holder address
+ * - closeOrderHash: Semantic identifier (e.g., "sl@-12345", "tp@201120")
+ */
+export async function GET(
+  request: NextRequest,
+  {
+    params,
+  }: {
+    params: Promise<{
+      chainId: string;
+      vaultAddress: string;
+      ownerAddress: string;
+      closeOrderHash: string;
+    }>;
+  }
+): Promise<Response> {
+  return withAuth(request, async (user, requestId) => {
+    const startTime = Date.now();
+
+    try {
+      // 1. Parse and validate path parameters
+      const resolvedParams = await params;
+      const paramsValidation = PathParamsSchema.safeParse(resolvedParams);
+
+      if (!paramsValidation.success) {
+        apiLog.validationError(apiLogger, requestId, paramsValidation.error.errors);
+
+        const errorResponse = createErrorResponse(
+          ApiErrorCode.VALIDATION_ERROR,
+          'Invalid path parameters',
+          paramsValidation.error.errors
+        );
+
+        apiLog.requestEnd(apiLogger, requestId, 400, Date.now() - startTime);
+
+        return NextResponse.json(errorResponse, {
+          status: ErrorCodeToHttpStatus[ApiErrorCode.VALIDATION_ERROR],
+        });
+      }
+
+      const { chainId, vaultAddress, ownerAddress, closeOrderHash } =
+        paramsValidation.data;
+
+      // 2. Find vault position by positionHash
+      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const position = await getUniswapV3VaultPositionService().findByPositionHash(
+        user.id,
+        positionHash
+      );
+
+      if (!position) {
+        const errorResponse = createErrorResponse(
+          ApiErrorCode.POSITION_NOT_FOUND,
+          'Vault position not found',
+          `No vault position found for chainId ${chainId}, vaultAddress ${vaultAddress} and ownerAddress ${ownerAddress}`
+        );
+
+        apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+
+        return NextResponse.json(errorResponse, {
+          status: ErrorCodeToHttpStatus[ApiErrorCode.POSITION_NOT_FOUND],
+        });
+      }
+
+      apiLog.businessOperation(
+        apiLogger,
+        requestId,
+        'get',
+        'close-order',
+        closeOrderHash,
+        { chainId, vaultAddress, ownerAddress, positionId: position.id }
+      );
+
+      // 3. Find close order by position + hash
+      const order = await getUniswapV3CloseOrderService().findByPositionAndHash(
+        position.id,
+        closeOrderHash
+      );
+
+      if (!order) {
+        const errorResponse = createErrorResponse(
+          ApiErrorCode.NOT_FOUND,
+          'Close order not found',
+          `No close order found with hash ${closeOrderHash}`
+        );
+
+        apiLog.requestEnd(apiLogger, requestId, 404, Date.now() - startTime);
+
+        return NextResponse.json(errorResponse, {
+          status: ErrorCodeToHttpStatus[ApiErrorCode.NOT_FOUND],
+        });
+      }
+
+      // 4. Serialize and return
+      const serialized = serializeCloseOrder(order);
+      const response = createSuccessResponse(serialized);
+
+      apiLog.requestEnd(apiLogger, requestId, 200, Date.now() - startTime);
+
+      return NextResponse.json(response, { status: 200 });
+    } catch (error) {
+      apiLog.methodError(
+        apiLogger,
+        'GET /api/v1/positions/uniswapv3-vault/:chainId/:vaultAddress/:ownerAddress/close-orders/:closeOrderHash',
+        error,
+        { requestId }
+      );
+
+      const errorResponse = createErrorResponse(
+        ApiErrorCode.INTERNAL_SERVER_ERROR,
+        'Failed to get close order',
+        error instanceof Error ? error.message : String(error)
+      );
+
+      apiLog.requestEnd(apiLogger, requestId, 500, Date.now() - startTime);
+
+      return NextResponse.json(errorResponse, {
+        status: ErrorCodeToHttpStatus[ApiErrorCode.INTERNAL_SERVER_ERROR],
+      });
+    }
+  });
+}

--- a/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/close-order-event-types.ts
+++ b/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/close-order-event-types.ts
@@ -28,5 +28,17 @@ export type {
   OrderValidUntilUpdatedEvent,
   OrderSlippageUpdatedEvent,
   OrderSwapIntentUpdatedEvent,
+  OrderSharesUpdatedPayload,
+  // Vault variants — same payloads, vault/owner identifiers in the envelope
+  VaultOrderRegisteredEvent,
+  VaultOrderCancelledEvent,
+  VaultOrderExecutedEvent,
+  VaultOrderOperatorUpdatedEvent,
+  VaultOrderPayoutUpdatedEvent,
+  VaultOrderTriggerTickUpdatedEvent,
+  VaultOrderValidUntilUpdatedEvent,
+  VaultOrderSlippageUpdatedEvent,
+  VaultOrderSwapIntentUpdatedEvent,
+  VaultOrderSharesUpdatedEvent,
   AnyCloseOrderEvent,
 } from '@midcurve/services';

--- a/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.test.ts
+++ b/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.test.ts
@@ -1,0 +1,638 @@
+/**
+ * UniswapV3ProcessCloseOrderEventsRule — unit tests
+ *
+ * Issue #77 acceptance criteria, vault variant:
+ *  1. Registering a stop-loss on a vault position creates exactly one row with
+ *     protocol 'uniswapv3-vault', linked to the correct vault position
+ *  2. Two owners on the same vault hold their own LOWER/UPPER slots
+ *  3. Re-registration on an occupied slot replaces the previous order
+ *  4. Cancellation removes the row and logs the cancellation
+ *  5. Execution removes the row, preserves execution data, drops the subscription
+ *  6. Trigger-tick, slippage, operator, payout, valid-until, swap-intent and
+ *     shares updates land in the stored order
+ *  7. Replaying the same event twice produces no duplicate rows
+ * 10. A message no handler can process is dead-lettered, not acked
+ *
+ * No live RabbitMQ, no live Prisma. The database module is mocked and the rule's
+ * own service instances are replaced after construction.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// =============================================================================
+// MODULE MOCKS
+// =============================================================================
+
+const { prismaMock, txMock } = vi.hoisted(() => {
+  const txMock = {
+    position: {
+      findUnique: vi.fn<(args: unknown) => Promise<unknown>>(),
+      findMany: vi.fn<(args: { where: Record<string, unknown> }) => Promise<Array<{ id: string; config: Record<string, unknown> }>>>(),
+    },
+  };
+  return {
+    txMock,
+    prismaMock: {
+      position: { findUnique: vi.fn(), findMany: vi.fn() },
+      $transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb(txMock)),
+    },
+  };
+});
+vi.mock('@midcurve/database', () => ({
+  prisma: prismaMock,
+}));
+
+import { ContractTriggerMode, ContractSwapDirection } from '@midcurve/shared';
+import { getDomainEventPublisher } from '@midcurve/services';
+import { UniswapV3ProcessCloseOrderEventsRule } from './uniswapv3-process-close-order-events';
+
+// =============================================================================
+// FIXTURES
+// =============================================================================
+
+const CHAIN_ID = 42161;
+const VAULT = '0x13d13B15BbE9b06C0279a7aB5f0a898EA3f25A40';
+const OWNER_A = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+const OWNER_B = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
+const POOL = '0xC6962004f452bE9203591991D15f6b388e09E8D0';
+const CLOSER = '0x13d13B15BbE9b06C0279a7aB5f0a898EA3f25A40';
+const OPERATOR = '0x1111111111111111111111111111111111111111';
+const PAYOUT = '0x2222222222222222222222222222222222222222';
+const NFT_ID = '12345';
+
+const VAULT_POSITION_A = 'pos_vault_owner_a';
+const VAULT_POSITION_B = 'pos_vault_owner_b';
+const NFT_POSITION = 'pos_nft';
+
+const TRIGGER_TICK = -201_120;
+
+function identityHash(owner: string, triggerMode: ContractTriggerMode): string {
+  return `uniswapv3-vault/${CHAIN_ID}/${VAULT}/${owner}/${triggerMode}`;
+}
+
+/** Envelope shared by every vault event */
+function vaultEnvelope(owner: string, triggerMode: 'LOWER' | 'UPPER' = 'LOWER') {
+  return {
+    chainId: CHAIN_ID,
+    contractAddress: CLOSER,
+    vaultAddress: VAULT,
+    ownerAddress: owner,
+    triggerMode,
+    blockNumber: '300000000',
+    transactionHash: '0xdeadbeef',
+    logIndex: 3,
+    receivedAt: '2026-08-08T00:00:00.000Z',
+  };
+}
+
+function vaultRegistered(owner = OWNER_A, triggerMode: 'LOWER' | 'UPPER' = 'LOWER') {
+  return {
+    type: 'close-order.registered.uniswapv3-vault',
+    ...vaultEnvelope(owner, triggerMode),
+    payload: {
+      owner,
+      pool: POOL,
+      operator: OPERATOR,
+      payout: PAYOUT,
+      triggerTick: TRIGGER_TICK,
+      validUntil: '1800000000',
+      slippageBps: 100,
+      swapDirection: 'NONE',
+      swapSlippageBps: 0,
+      shares: '1000000000000000000',
+    },
+  } as never;
+}
+
+function nftRegistered() {
+  return {
+    type: 'close-order.registered.uniswapv3',
+    chainId: CHAIN_ID,
+    contractAddress: CLOSER,
+    nftId: NFT_ID,
+    triggerMode: 'LOWER',
+    blockNumber: '300000000',
+    transactionHash: '0xfeedface',
+    logIndex: 1,
+    receivedAt: '2026-08-08T00:00:00.000Z',
+    payload: {
+      owner: OWNER_A,
+      pool: POOL,
+      operator: OPERATOR,
+      payout: PAYOUT,
+      triggerTick: TRIGGER_TICK,
+      validUntil: '1800000000',
+      slippageBps: 100,
+      swapDirection: 'NONE',
+      swapSlippageBps: 0,
+    },
+  } as never;
+}
+
+function vaultEvent(type: string, payload: Record<string, unknown>, owner = OWNER_A) {
+  return { type, ...vaultEnvelope(owner), payload } as never;
+}
+
+/** A stored CloseOrder row as the rule sees it */
+function storedVaultOrder(
+  overrides: Partial<Record<string, unknown>> = {},
+): Record<string, unknown> {
+  return {
+    id: 'ord_vault_1',
+    protocol: 'uniswapv3-vault',
+    positionId: VAULT_POSITION_A,
+    orderIdentityHash: identityHash(OWNER_A, ContractTriggerMode.LOWER),
+    closeOrderHash: 'sl@-201120',
+    automationState: 'monitoring',
+    config: { chainId: CHAIN_ID, vaultAddress: VAULT, ownerAddress: OWNER_A, triggerMode: ContractTriggerMode.LOWER, contractAddress: CLOSER },
+    state: { triggerTick: TRIGGER_TICK, slippageBps: 100 },
+    ...overrides,
+  };
+}
+
+const VAULT_POSITION_CONFIG = {
+  chainId: CHAIN_ID,
+  vaultAddress: VAULT,
+  ownerAddress: OWNER_A,
+  poolAddress: POOL,
+};
+
+// =============================================================================
+// SERVICE MOCKS
+// =============================================================================
+
+/** A position stand-in exposing what buildOrderTag reads */
+const positionStub = {
+  isToken0Quote: false,
+  pool: { token0: { decimals: 18 }, token1: { decimals: 6 } },
+};
+
+type OrderRow = Record<string, unknown>;
+
+/** The CreateCloseOrderInput shape, as the rule hands it to the service */
+interface CreateInput {
+  protocol: string;
+  positionId: string;
+  orderIdentityHash: string;
+  closeOrderHash?: string;
+  config: Record<string, unknown>;
+  state: Record<string, unknown>;
+}
+
+type FindOrder = (hash: string, tx?: unknown) => Promise<OrderRow | null>;
+type UpsertOrder = (input: CreateInput, tx?: unknown) => Promise<OrderRow>;
+type LogCall = (
+  positionId: string,
+  orderId: string,
+  context: Record<string, unknown>,
+  tx?: unknown,
+) => Promise<void>;
+
+function buildRule() {
+  const order = {
+    findByOrderIdentityHash: vi.fn<FindOrder>(async () => null),
+    upsertByIdentityHash: vi.fn<UpsertOrder>(async (input) => ({
+      ...storedVaultOrder(),
+      id: 'ord_created',
+      protocol: input.protocol,
+      positionId: input.positionId,
+      orderIdentityHash: input.orderIdentityHash,
+    })),
+    create: vi.fn(),
+    delete: vi.fn(async () => undefined),
+    mergeState: vi.fn(async () => storedVaultOrder()),
+    updateCloseOrderHash: vi.fn(async () => storedVaultOrder()),
+  };
+
+  const log = {
+    logOrderCreated: vi.fn<LogCall>(async () => undefined),
+    logOrderRegistered: vi.fn<LogCall>(async () => undefined),
+    logOrderCancelled: vi.fn<LogCall>(async () => undefined),
+    logOrderExecuted: vi.fn<LogCall>(async () => undefined),
+    logOrderModified: vi.fn<LogCall>(async () => undefined),
+  };
+
+  const subscription = {
+    ensureOrderSubscription: vi.fn(async () => undefined),
+    removeOrderSubscription: vi.fn(async () => undefined),
+  };
+
+  const nftPosition = { findById: vi.fn(async () => positionStub) };
+  const vaultPosition = { findById: vi.fn(async () => positionStub) };
+
+  const rule = new UniswapV3ProcessCloseOrderEventsRule({
+    orderService: order as never,
+    automationLogService: log as never,
+    automationSubscriptionService: subscription as never,
+    positionService: nftPosition as never,
+    vaultPositionService: vaultPosition as never,
+  });
+
+  return { rule, mocks: { order, log, subscription, nftPosition, vaultPosition } };
+}
+
+function processEvent(rule: UniswapV3ProcessCloseOrderEventsRule, event: unknown): Promise<void> {
+  return (rule as never as { processEvent(e: unknown): Promise<void> }).processEvent(event);
+}
+
+// =============================================================================
+// TESTS
+// =============================================================================
+
+describe('UniswapV3ProcessCloseOrderEventsRule — vault orders', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (cb: (tx: unknown) => unknown) => cb(txMock));
+    txMock.position.findMany.mockResolvedValue([
+      { id: VAULT_POSITION_A, config: VAULT_POSITION_CONFIG },
+    ]);
+    txMock.position.findUnique.mockResolvedValue({
+      id: VAULT_POSITION_A,
+      config: VAULT_POSITION_CONFIG,
+    });
+    Object.assign(getDomainEventPublisher(), { publishDirect: vi.fn(async () => undefined) });
+  });
+
+  // AC 1
+  it('creates exactly one row with protocol uniswapv3-vault, linked to the vault position', async () => {
+    const { rule, mocks } = buildRule();
+
+    await processEvent(rule, vaultRegistered());
+
+    expect(mocks.order.upsertByIdentityHash).toHaveBeenCalledTimes(1);
+    const input = mocks.order.upsertByIdentityHash.mock.calls[0]![0];
+    expect(input.protocol).toBe('uniswapv3-vault');
+    expect(input.positionId).toBe(VAULT_POSITION_A);
+    expect(input.orderIdentityHash).toBe(identityHash(OWNER_A, ContractTriggerMode.LOWER));
+    expect(input.closeOrderHash).toBe(`sl@${TRIGGER_TICK}`);
+    expect(input.config).toMatchObject({
+      chainId: CHAIN_ID,
+      vaultAddress: VAULT,
+      ownerAddress: OWNER_A,
+      triggerMode: ContractTriggerMode.LOWER,
+      contractAddress: CLOSER,
+    });
+    // Shares stay a string end to end
+    expect(input.state.shares).toBe('1000000000000000000');
+  });
+
+  it('matches the vault position on chain, vault address AND owner', async () => {
+    const { rule } = buildRule();
+
+    await processEvent(rule, vaultRegistered(OWNER_B));
+
+    const where = txMock.position.findMany.mock.calls[0]![0].where;
+    expect(where.protocol).toBe('uniswapv3-vault');
+    expect(where.AND).toEqual([
+      { config: { path: ['chainId'], equals: CHAIN_ID } },
+      { config: { path: ['vaultAddress'], equals: VAULT } },
+      { config: { path: ['ownerAddress'], equals: OWNER_B } },
+    ]);
+  });
+
+  // AC 2
+  it('gives two owners on the same vault their own slots', async () => {
+    const { rule, mocks } = buildRule();
+    txMock.position.findMany
+      .mockResolvedValueOnce([{ id: VAULT_POSITION_A, config: VAULT_POSITION_CONFIG }])
+      .mockResolvedValueOnce([{ id: VAULT_POSITION_B, config: { ...VAULT_POSITION_CONFIG, ownerAddress: OWNER_B } }]);
+
+    await processEvent(rule, vaultRegistered(OWNER_A));
+    await processEvent(rule, vaultRegistered(OWNER_B));
+
+    const hashes = mocks.order.upsertByIdentityHash.mock.calls.map((c) => c[0]!.orderIdentityHash);
+    expect(hashes).toEqual([
+      identityHash(OWNER_A, ContractTriggerMode.LOWER),
+      identityHash(OWNER_B, ContractTriggerMode.LOWER),
+    ]);
+    expect(new Set(hashes).size).toBe(2);
+
+    const positionIds = mocks.order.upsertByIdentityHash.mock.calls.map((c) => c[0]!.positionId);
+    expect(positionIds).toEqual([VAULT_POSITION_A, VAULT_POSITION_B]);
+  });
+
+  it('gives LOWER and UPPER their own slots on one position', async () => {
+    const { rule, mocks } = buildRule();
+
+    await processEvent(rule, vaultRegistered(OWNER_A, 'LOWER'));
+    await processEvent(rule, vaultRegistered(OWNER_A, 'UPPER'));
+
+    const hashes = mocks.order.upsertByIdentityHash.mock.calls.map((c) => c[0]!.orderIdentityHash);
+    expect(hashes).toEqual([
+      identityHash(OWNER_A, ContractTriggerMode.LOWER),
+      identityHash(OWNER_A, ContractTriggerMode.UPPER),
+    ]);
+  });
+
+  // AC 3
+  it('replaces the previous order when re-registering on an occupied slot', async () => {
+    const { rule, mocks } = buildRule();
+    const stale = storedVaultOrder({ id: 'ord_old', automationState: 'failed' });
+    mocks.order.findByOrderIdentityHash.mockResolvedValueOnce(stale);
+
+    await processEvent(rule, vaultRegistered());
+
+    expect(mocks.order.delete).toHaveBeenCalledWith('ord_old', txMock);
+    expect(mocks.order.upsertByIdentityHash).toHaveBeenCalledTimes(1);
+    expect(mocks.order.upsertByIdentityHash.mock.calls[0]![0].orderIdentityHash).toBe(
+      identityHash(OWNER_A, ContractTriggerMode.LOWER),
+    );
+  });
+
+  // AC 7
+  it('does not create a second row when the same registration is replayed', async () => {
+    const { rule, mocks } = buildRule();
+    mocks.order.findByOrderIdentityHash.mockResolvedValueOnce(
+      storedVaultOrder({ automationState: 'monitoring' }),
+    );
+
+    await processEvent(rule, vaultRegistered());
+
+    expect(mocks.order.upsertByIdentityHash).not.toHaveBeenCalled();
+    expect(mocks.order.delete).not.toHaveBeenCalled();
+    expect(mocks.log.logOrderCreated).not.toHaveBeenCalled();
+  });
+
+  // AC 4
+  it('deletes the row and logs the cancellation on OrderCancelled', async () => {
+    const { rule, mocks } = buildRule();
+    mocks.order.findByOrderIdentityHash.mockResolvedValue(storedVaultOrder());
+
+    await processEvent(rule, vaultEvent('close-order.cancelled.uniswapv3-vault', { owner: OWNER_A }));
+
+    expect(mocks.log.logOrderCancelled).toHaveBeenCalledTimes(1);
+    expect(mocks.order.delete).toHaveBeenCalledWith('ord_vault_1', txMock);
+    expect(mocks.subscription.removeOrderSubscription).toHaveBeenCalledWith('ord_vault_1');
+  });
+
+  // AC 5
+  it('deletes the row, preserves execution data and drops the subscription on OrderExecuted', async () => {
+    const { rule, mocks } = buildRule();
+    mocks.order.findByOrderIdentityHash.mockResolvedValue(storedVaultOrder());
+
+    await processEvent(
+      rule,
+      vaultEvent('close-order.executed.uniswapv3-vault', {
+        owner: OWNER_A,
+        payout: PAYOUT,
+        executionTick: TRIGGER_TICK,
+        sharesClosed: '1000000000000000000',
+        amount0Out: '500',
+        amount1Out: '600',
+      }),
+    );
+
+    expect(mocks.log.logOrderExecuted).toHaveBeenCalledTimes(1);
+    const context = mocks.log.logOrderExecuted.mock.calls[0]![2] as Record<string, unknown>;
+    expect(context.amount0Out).toBe('500');
+    expect(context.amount1Out).toBe('600');
+    expect(mocks.order.delete).toHaveBeenCalledWith('ord_vault_1', txMock);
+    expect(mocks.subscription.removeOrderSubscription).toHaveBeenCalledWith('ord_vault_1');
+  });
+
+  // AC 6
+  describe('config updates land in the stored order', () => {
+    it('operator', async () => {
+      const { rule, mocks } = buildRule();
+      mocks.order.findByOrderIdentityHash.mockResolvedValue(storedVaultOrder());
+
+      await processEvent(
+        rule,
+        vaultEvent('close-order.operator-updated.uniswapv3-vault', {
+          oldOperator: OPERATOR,
+          newOperator: OWNER_B,
+        }),
+      );
+
+      expect(mocks.order.mergeState).toHaveBeenCalledWith('ord_vault_1', { operatorAddress: OWNER_B }, txMock);
+    });
+
+    it('payout', async () => {
+      const { rule, mocks } = buildRule();
+      mocks.order.findByOrderIdentityHash.mockResolvedValue(storedVaultOrder());
+
+      await processEvent(
+        rule,
+        vaultEvent('close-order.payout-updated.uniswapv3-vault', {
+          oldPayout: PAYOUT,
+          newPayout: OWNER_B,
+        }),
+      );
+
+      expect(mocks.order.mergeState).toHaveBeenCalledWith('ord_vault_1', { payoutAddress: OWNER_B }, txMock);
+    });
+
+    it('trigger tick, recalculating the closeOrderHash', async () => {
+      const { rule, mocks } = buildRule();
+      mocks.order.findByOrderIdentityHash.mockResolvedValue(storedVaultOrder());
+
+      await processEvent(
+        rule,
+        vaultEvent('close-order.trigger-tick-updated.uniswapv3-vault', {
+          oldTick: TRIGGER_TICK,
+          newTick: -100,
+        }),
+      );
+
+      expect(mocks.order.updateCloseOrderHash).toHaveBeenCalledWith(
+        'ord_vault_1',
+        'sl@-100',
+        { triggerTick: -100 },
+        txMock,
+      );
+    });
+
+    it('valid-until', async () => {
+      const { rule, mocks } = buildRule();
+      mocks.order.findByOrderIdentityHash.mockResolvedValue(storedVaultOrder());
+
+      await processEvent(
+        rule,
+        vaultEvent('close-order.valid-until-updated.uniswapv3-vault', {
+          oldValidUntil: '1800000000',
+          newValidUntil: '1900000000',
+        }),
+      );
+
+      expect(mocks.order.mergeState).toHaveBeenCalledWith(
+        'ord_vault_1',
+        { validUntil: new Date(1_900_000_000 * 1000).toISOString() },
+        txMock,
+      );
+    });
+
+    it('slippage', async () => {
+      const { rule, mocks } = buildRule();
+      mocks.order.findByOrderIdentityHash.mockResolvedValue(storedVaultOrder());
+
+      await processEvent(
+        rule,
+        vaultEvent('close-order.slippage-updated.uniswapv3-vault', {
+          oldSlippageBps: 100,
+          newSlippageBps: 250,
+        }),
+      );
+
+      expect(mocks.order.mergeState).toHaveBeenCalledWith('ord_vault_1', { slippageBps: 250 }, txMock);
+    });
+
+    it('swap intent', async () => {
+      const { rule, mocks } = buildRule();
+      mocks.order.findByOrderIdentityHash.mockResolvedValue(storedVaultOrder());
+
+      await processEvent(
+        rule,
+        vaultEvent('close-order.swap-intent-updated.uniswapv3-vault', {
+          oldDirection: 'NONE',
+          newDirection: 'TOKEN0_TO_1',
+          swapSlippageBps: 50,
+        }),
+      );
+
+      expect(mocks.order.mergeState).toHaveBeenCalledWith(
+        'ord_vault_1',
+        { swapDirection: ContractSwapDirection.TOKEN0_TO_1, swapSlippageBps: 50 },
+        txMock,
+      );
+    });
+
+    it('shares (vault only), kept as a string', async () => {
+      const { rule, mocks } = buildRule();
+      mocks.order.findByOrderIdentityHash.mockResolvedValue(storedVaultOrder());
+
+      await processEvent(
+        rule,
+        vaultEvent('close-order.shares-updated.uniswapv3-vault', {
+          oldShares: '1000000000000000000',
+          newShares: '2500000000000000000',
+        }),
+      );
+
+      expect(mocks.order.mergeState).toHaveBeenCalledWith(
+        'ord_vault_1',
+        { shares: '2500000000000000000' },
+        txMock,
+      );
+      expect(mocks.log.logOrderModified).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('builds the order tag from the vault position, not the NFT position service', async () => {
+    const { rule, mocks } = buildRule();
+    mocks.order.findByOrderIdentityHash.mockResolvedValue(storedVaultOrder());
+
+    await processEvent(rule, vaultEvent('close-order.cancelled.uniswapv3-vault', { owner: OWNER_A }));
+
+    expect(mocks.vaultPosition.findById).toHaveBeenCalledWith(VAULT_POSITION_A, txMock);
+    expect(mocks.nftPosition.findById).not.toHaveBeenCalled();
+  });
+
+  it('skips an event for a share holder we do not track, without writing anything', async () => {
+    const { rule, mocks } = buildRule();
+    txMock.position.findMany.mockResolvedValue([]);
+
+    await processEvent(rule, vaultRegistered(OWNER_B));
+
+    expect(mocks.order.upsertByIdentityHash).not.toHaveBeenCalled();
+    expect(mocks.log.logOrderCreated).not.toHaveBeenCalled();
+  });
+
+  it('refuses to guess when several positions match the same vault and owner', async () => {
+    const { rule } = buildRule();
+    txMock.position.findMany.mockResolvedValue([
+      { id: VAULT_POSITION_A, config: VAULT_POSITION_CONFIG },
+      { id: VAULT_POSITION_B, config: VAULT_POSITION_CONFIG },
+    ]);
+
+    await expect(processEvent(rule, vaultRegistered())).rejects.toThrow(/Ambiguous vault position/);
+  });
+});
+
+describe('UniswapV3ProcessCloseOrderEventsRule — NFT orders still work', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (cb: (tx: unknown) => unknown) => cb(txMock));
+    txMock.position.findMany.mockResolvedValue([
+      { id: NFT_POSITION, config: { chainId: CHAIN_ID, nftId: Number(NFT_ID), poolAddress: POOL } },
+    ]);
+    Object.assign(getDomainEventPublisher(), { publishDirect: vi.fn(async () => undefined) });
+  });
+
+  it('keeps the NFT identity hash unchanged (no addresses, no migration)', async () => {
+    const { rule, mocks } = buildRule();
+
+    await processEvent(rule, nftRegistered());
+
+    const input = mocks.order.upsertByIdentityHash.mock.calls[0]![0];
+    expect(input.protocol).toBe('uniswapv3');
+    expect(input.orderIdentityHash).toBe(`uniswapv3/${CHAIN_ID}/${NFT_ID}/${ContractTriggerMode.LOWER}`);
+    expect(input.config).toMatchObject({ chainId: CHAIN_ID, nftId: NFT_ID, contractAddress: CLOSER });
+    expect(input.state.shares).toBeUndefined();
+  });
+});
+
+// AC 10
+describe('UniswapV3ProcessCloseOrderEventsRule — unroutable messages', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.$transaction.mockImplementation(async (cb: (tx: unknown) => unknown) => cb(txMock));
+  });
+
+  it('throws on an event type no handler covers', async () => {
+    const { rule } = buildRule();
+
+    await expect(
+      processEvent(rule, { type: 'close-order.teleported.uniswapv3-vault', chainId: CHAIN_ID }),
+    ).rejects.toThrow(/Unknown close order event type/);
+  });
+
+  it('throws on an event carrying neither nftId nor vaultAddress', async () => {
+    const { rule } = buildRule();
+
+    await expect(
+      processEvent(rule, {
+        type: 'close-order.cancelled.uniswapv3',
+        chainId: CHAIN_ID,
+        triggerMode: 'LOWER',
+        transactionHash: '0xabc',
+        payload: { owner: OWNER_A },
+      }),
+    ).rejects.toThrow(/neither nftId nor vaultAddress/);
+  });
+
+  it('dead-letters instead of acking when a message cannot be processed', async () => {
+    const { rule } = buildRule();
+    const channel = { ack: vi.fn(), nack: vi.fn() };
+    (rule as never as Record<string, unknown>).channel = channel;
+
+    const msg = {
+      content: Buffer.from(JSON.stringify({ type: 'close-order.teleported.uniswapv3-vault' })),
+      fields: { routingKey: 'closer.vault.42161.0xabc.0' },
+    };
+
+    await (rule as never as { handleMessage(m: unknown): Promise<void> }).handleMessage(msg);
+
+    expect(channel.nack).toHaveBeenCalledWith(msg, false, false);
+    expect(channel.ack).not.toHaveBeenCalled();
+  });
+
+  it('acks an event that is understood but does not concern us', async () => {
+    const { rule, mocks } = buildRule();
+    const channel = { ack: vi.fn(), nack: vi.fn() };
+    (rule as never as Record<string, unknown>).channel = channel;
+    mocks.order.findByOrderIdentityHash.mockResolvedValue(null);
+
+    const msg = {
+      content: Buffer.from(
+        JSON.stringify(vaultEvent('close-order.cancelled.uniswapv3-vault', { owner: OWNER_A })),
+      ),
+      fields: { routingKey: `closer.vault.${CHAIN_ID}.${VAULT}.0` },
+    };
+
+    await (rule as never as { handleMessage(m: unknown): Promise<void> }).handleMessage(msg);
+
+    expect(channel.ack).toHaveBeenCalledWith(msg);
+    expect(channel.nack).not.toHaveBeenCalled();
+    expect(mocks.order.delete).not.toHaveBeenCalled();
+  });
+});

--- a/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.test.ts
+++ b/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.test.ts
@@ -386,8 +386,40 @@ describe('UniswapV3ProcessCloseOrderEventsRule — vault orders', () => {
     const context = mocks.log.logOrderExecuted.mock.calls[0]![2] as Record<string, unknown>;
     expect(context.amount0Out).toBe('500');
     expect(context.amount1Out).toBe('600');
+    // The row is deleted right after — the log is the only place the vault
+    // quantity survives, so it has to reach the context (string, not bigint)
+    expect(context.sharesClosed).toBe('1000000000000000000');
     expect(mocks.order.delete).toHaveBeenCalledWith('ord_vault_1', txMock);
     expect(mocks.subscription.removeOrderSubscription).toHaveBeenCalledWith('ord_vault_1');
+  });
+
+  it('omits sharesClosed for an NFT execution rather than writing a placeholder', async () => {
+    const { rule, mocks } = buildRule();
+    mocks.order.findByOrderIdentityHash.mockResolvedValue(
+      storedVaultOrder({ protocol: 'uniswapv3' }),
+    );
+
+    await processEvent(rule, {
+      type: 'close-order.executed.uniswapv3',
+      chainId: CHAIN_ID,
+      contractAddress: CLOSER,
+      nftId: NFT_ID,
+      triggerMode: 'LOWER',
+      blockNumber: '300000000',
+      transactionHash: '0xfeedface',
+      logIndex: 1,
+      receivedAt: '2026-08-08T00:00:00.000Z',
+      payload: {
+        owner: OWNER_A,
+        payout: PAYOUT,
+        executionTick: TRIGGER_TICK,
+        amount0Out: '500',
+        amount1Out: '600',
+      },
+    } as never);
+
+    const context = mocks.log.logOrderExecuted.mock.calls[0]![2] as Record<string, unknown>;
+    expect('sharesClosed' in context).toBe(false);
   });
 
   // AC 6

--- a/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.ts
+++ b/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.ts
@@ -860,6 +860,11 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
             amount0Out: event.payload.amount0Out,
             amount1Out: event.payload.amount1Out,
             executionFeeBps: 0,
+            // Vault-specific: how much of the position was closed. The row is
+            // about to be deleted, so the log is the only place this survives.
+            ...(event.payload.sharesClosed !== undefined
+              ? { sharesClosed: event.payload.sharesClosed }
+              : {}),
           } satisfies OrderExecutedContext,
           tx
         );

--- a/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.ts
+++ b/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.ts
@@ -1,25 +1,40 @@
 /**
  * UniswapV3 Process Close Order Events Rule
  *
- * Subscribes to UniswapV3 and UniswapV3-Vault close order lifecycle events
+ * Subscribes to UniswapV3 (NFT) and UniswapV3-Vault close order lifecycle events
  * from the onchain-data service and synchronizes the database with on-chain state.
  *
+ * Both protocol variants run through the same handlers. What differs is only the
+ * order identity and the position lookup:
+ * - NFT:   identity "uniswapv3/{chainId}/{nftId}/{triggerMode}", position by nftId
+ * - Vault: identity "uniswapv3-vault/{chainId}/{vault}/{owner}/{triggerMode}",
+ *          position by vault address + owner address (a vault is an ERC-20, so
+ *          several owners can hold their own orders on the same vault)
+ *
  * DB lifecycle driven by on-chain events:
- * - OrderRegistered → INSERT new order (automationState=monitoring)
+ * - OrderRegistered → ensure the identity slot holds this order (upsert)
  * - OrderCancelled → DELETE order from DB
  * - OrderExecuted → DELETE order from DB (execution data preserved in AutomationLog)
  * - Re-registration at same slot → DELETE old + INSERT new
  *
- * Config-change events (9 total):
+ * Config-change events:
  * - OrderOperatorUpdated: Update operatorAddress
  * - OrderPayoutUpdated: Update payoutAddress
  * - OrderTriggerTickUpdated: Update triggerTick + recalculate closeOrderHash
  * - OrderValidUntilUpdated: Update validUntil
  * - OrderSlippageUpdated: Update slippageBps
  * - OrderSwapIntentUpdated: Update swapDirection + swapSlippageBps
+ * - OrderSharesUpdated (vault only): Update shares
  *
  * Any config-change event on a failed order resets it to monitoring,
  * allowing the user to reactivate failed orders by updating any field.
+ *
+ * Message disposition — the two cases must stay distinguishable:
+ * - Understood but not ours (no matching position, no matching order): logged at
+ *   info/warn and acked. For a vault this is the normal case, since anyone can
+ *   hold shares and register an order.
+ * - Cannot be interpreted (unknown event type, missing identifiers, ambiguous
+ *   position): logged at error and dead-lettered to the DLQ.
  */
 
 import type { ConsumeMessage } from 'amqplib';
@@ -30,11 +45,15 @@ import {
   AutomationSubscriptionService,
   AutomationLogService,
   UniswapV3PositionService,
+  UniswapV3VaultPositionService,
+  createCloseOrderIdentityHash,
   deriveCloseOrderHashFromTick,
   generateOrderTagFromTick,
   getDomainEventPublisher,
   createDomainEvent,
   EXCHANGE_CLOSE_ORDER_EVENTS,
+  EXCHANGE_CLOSE_ORDER_EVENTS_DLX,
+  CLOSE_ORDER_DLQ_MESSAGE_TTL_MS,
 } from '@midcurve/services';
 import type {
   OrderCreatedContext,
@@ -49,6 +68,7 @@ import type {
 import {
   ContractTriggerMode,
   ContractSwapDirection,
+  normalizeAddress,
 } from '@midcurve/shared';
 
 /** Transaction client type — subset of PrismaClient usable inside $transaction */
@@ -67,14 +87,33 @@ import type {
   OrderValidUntilUpdatedEvent,
   OrderSlippageUpdatedEvent,
   OrderSwapIntentUpdatedEvent,
+  VaultOrderRegisteredEvent,
+  VaultOrderCancelledEvent,
+  VaultOrderExecutedEvent,
+  VaultOrderOperatorUpdatedEvent,
+  VaultOrderPayoutUpdatedEvent,
+  VaultOrderTriggerTickUpdatedEvent,
+  VaultOrderValidUntilUpdatedEvent,
+  VaultOrderSlippageUpdatedEvent,
+  VaultOrderSwapIntentUpdatedEvent,
+  VaultOrderSharesUpdatedEvent,
 } from './close-order-event-types';
 
 // =============================================================================
 // Constants
 // =============================================================================
 
-/** Queue name for this rule's consumption */
-const QUEUE_NAME = 'business-logic.uniswapv3-process-close-order-events';
+/**
+ * Queue name for this rule's consumption.
+ *
+ * v2: the v1 queue was declared without a dead-letter exchange, so nacked
+ * messages were dropped. Queue arguments are immutable in RabbitMQ, so adding
+ * the DLX means declaring a new queue and letting the old one drain.
+ */
+const QUEUE_NAME = 'business-logic.uniswapv3-process-close-order-events.v2';
+
+/** Dead-letter queue for messages this rule cannot interpret */
+const DLQ_NAME = 'business-logic.uniswapv3-process-close-order-events.dlq';
 
 /** Routing pattern for UniswapV3 NFT close order events (4 segments: closer.chainId.nftId.triggerMode) */
 const UNISWAPV3_ROUTING_PATTERN = 'closer.*.*.*';
@@ -83,11 +122,94 @@ const UNISWAPV3_ROUTING_PATTERN = 'closer.*.*.*';
 const UNISWAPV3_VAULT_ROUTING_PATTERN = 'closer.vault.*.*.*';
 
 // =============================================================================
+// Event Type Unions (NFT + vault variant of the same lifecycle event)
+// =============================================================================
+
+type RegisteredEvent = OrderRegisteredEvent | VaultOrderRegisteredEvent;
+type CancelledEvent = OrderCancelledEvent | VaultOrderCancelledEvent;
+type ExecutedEvent = OrderExecutedEvent | VaultOrderExecutedEvent;
+type OperatorUpdatedEvent = OrderOperatorUpdatedEvent | VaultOrderOperatorUpdatedEvent;
+type PayoutUpdatedEvent = OrderPayoutUpdatedEvent | VaultOrderPayoutUpdatedEvent;
+type TriggerTickUpdatedEvent =
+  | OrderTriggerTickUpdatedEvent
+  | VaultOrderTriggerTickUpdatedEvent;
+type ValidUntilUpdatedEvent =
+  | OrderValidUntilUpdatedEvent
+  | VaultOrderValidUntilUpdatedEvent;
+type SlippageUpdatedEvent = OrderSlippageUpdatedEvent | VaultOrderSlippageUpdatedEvent;
+type SwapIntentUpdatedEvent =
+  | OrderSwapIntentUpdatedEvent
+  | VaultOrderSwapIntentUpdatedEvent;
+
+/**
+ * Thrown for messages this rule cannot interpret. Dead-lettered, never acked —
+ * as opposed to events that are understood but don't concern us.
+ */
+class UnroutableCloseOrderEventError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnroutableCloseOrderEventError';
+  }
+}
+
+// =============================================================================
 // String → Numeric Enum Mapping
 // =============================================================================
 
-function createOrderIdentityHash(chainId: number, nftId: string, triggerMode: number): string {
-  return `uniswapv3/${chainId}/${nftId}/${triggerMode}`;
+/** Vault events carry a vault address + owner instead of an nftId */
+function isVaultEvent(event: AnyCloseOrderEvent): boolean {
+  return event.vaultAddress !== undefined;
+}
+
+/**
+ * Builds the order identity hash for an event, via the helper shared with
+ * UniswapV3CloseOrderService.refresh() — the other writer of these rows.
+ */
+function orderIdentityHashForEvent(event: AnyCloseOrderEvent): string {
+  const triggerMode = parseTriggerMode(event.triggerMode);
+
+  if (isVaultEvent(event)) {
+    if (!event.ownerAddress) {
+      throw new UnroutableCloseOrderEventError(
+        `Vault close order event missing ownerAddress: type=${event.type} ` +
+          `vault=${event.vaultAddress} tx=${event.transactionHash}`
+      );
+    }
+    return createCloseOrderIdentityHash({
+      protocol: 'uniswapv3-vault',
+      chainId: event.chainId,
+      vaultAddress: event.vaultAddress!,
+      ownerAddress: event.ownerAddress,
+      triggerMode,
+    });
+  }
+
+  if (!event.nftId) {
+    throw new UnroutableCloseOrderEventError(
+      `Close order event has neither nftId nor vaultAddress: type=${event.type} ` +
+        `tx=${event.transactionHash}`
+    );
+  }
+
+  return createCloseOrderIdentityHash({
+    protocol: 'uniswapv3',
+    chainId: event.chainId,
+    nftId: event.nftId,
+    triggerMode,
+  });
+}
+
+/** Log context identifying the position an event refers to, for either protocol */
+function eventIdentityContext(event: AnyCloseOrderEvent): Record<string, unknown> {
+  return {
+    type: event.type,
+    chainId: event.chainId,
+    ...(isVaultEvent(event)
+      ? { vaultAddress: event.vaultAddress, ownerAddress: event.ownerAddress }
+      : { nftId: event.nftId }),
+    triggerMode: event.triggerMode,
+    txHash: event.transactionHash,
+  };
 }
 
 function parseTriggerMode(s: TriggerModeString): ContractTriggerMode {
@@ -104,6 +226,18 @@ function parseSwapDirection(s: SwapDirectionString): ContractSwapDirection {
 // Rule Implementation
 // =============================================================================
 
+/**
+ * Injectable collaborators. Production passes none; tests pass stubs so the rule
+ * can be exercised without RPC configuration.
+ */
+export interface UniswapV3ProcessCloseOrderEventsRuleDependencies {
+  orderService?: UniswapV3CloseOrderService;
+  automationSubscriptionService?: AutomationSubscriptionService;
+  automationLogService?: AutomationLogService;
+  positionService?: UniswapV3PositionService;
+  vaultPositionService?: UniswapV3VaultPositionService;
+}
+
 export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
   readonly ruleName = 'uniswapv3-process-close-order-events';
   readonly ruleDescription =
@@ -114,13 +248,21 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
   private automationSubscriptionService: AutomationSubscriptionService;
   private automationLogService: AutomationLogService;
   private positionService: UniswapV3PositionService;
+  private vaultPositionService: UniswapV3VaultPositionService;
 
-  constructor() {
+  constructor(dependencies: UniswapV3ProcessCloseOrderEventsRuleDependencies = {}) {
     super();
-    this.orderService = new UniswapV3CloseOrderService({ prisma });
-    this.automationSubscriptionService = new AutomationSubscriptionService({ prisma });
-    this.automationLogService = new AutomationLogService({ prisma });
-    this.positionService = new UniswapV3PositionService({ prisma });
+    this.orderService =
+      dependencies.orderService ?? new UniswapV3CloseOrderService({ prisma });
+    this.automationSubscriptionService =
+      dependencies.automationSubscriptionService ??
+      new AutomationSubscriptionService({ prisma });
+    this.automationLogService =
+      dependencies.automationLogService ?? new AutomationLogService({ prisma });
+    this.positionService =
+      dependencies.positionService ?? new UniswapV3PositionService({ prisma });
+    this.vaultPositionService =
+      dependencies.vaultPositionService ?? new UniswapV3VaultPositionService({ prisma });
   }
 
   // ===========================================================================
@@ -140,10 +282,28 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
       autoDelete: false,
     });
 
+    // Dead-letter topology: messages we cannot interpret land in the DLQ instead
+    // of being discarded, which is what made vault event loss invisible.
+    await this.channel.assertExchange(EXCHANGE_CLOSE_ORDER_EVENTS_DLX, 'fanout', {
+      durable: true,
+      autoDelete: false,
+    });
+    await this.channel.assertQueue(DLQ_NAME, {
+      durable: true,
+      autoDelete: false,
+      arguments: {
+        'x-message-ttl': CLOSE_ORDER_DLQ_MESSAGE_TTL_MS,
+      },
+    });
+    await this.channel.bindQueue(DLQ_NAME, EXCHANGE_CLOSE_ORDER_EVENTS_DLX, '');
+
     // Assert queue and bind to close order events exchange for both UniswapV3 variants
     await this.channel.assertQueue(QUEUE_NAME, {
       durable: true,
       autoDelete: false,
+      arguments: {
+        'x-dead-letter-exchange': EXCHANGE_CLOSE_ORDER_EVENTS_DLX,
+      },
     });
     await this.channel.bindQueue(
       QUEUE_NAME,
@@ -192,56 +352,66 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
     try {
       const event = JSON.parse(msg.content.toString()) as AnyCloseOrderEvent;
 
-      this.logger.debug(
-        {
-          type: event.type,
-          chainId: event.chainId,
-          nftId: event.nftId,
-          triggerMode: event.triggerMode,
-          txHash: event.transactionHash,
-        },
-        'Processing close order event'
-      );
+      this.logger.debug(eventIdentityContext(event), 'Processing close order event');
 
       await this.processEvent(event);
       this.channel.ack(msg);
     } catch (error) {
       this.logger.error(
         {
+          routingKey: msg.fields.routingKey,
+          unroutable: error instanceof UnroutableCloseOrderEventError,
           error: error instanceof Error ? error.message : String(error),
           stack: error instanceof Error ? error.stack : undefined,
         },
-        'Error processing close order event'
+        'Error processing close order event — dead-lettering'
       );
-      // Dead-letter the message, don't requeue (prevents infinite retry loops)
+      // Dead-letter the message, don't requeue (prevents infinite retry loops).
+      // The queue is declared with x-dead-letter-exchange, so this lands in the DLQ.
       this.channel.nack(msg, false, false);
     }
   }
 
+  /**
+   * Dispatches to the handler for the event's lifecycle type. NFT and vault
+   * variants of the same event share a handler — identity and position lookup
+   * are the only protocol-specific parts, and both are resolved inside.
+   */
   private async processEvent(event: AnyCloseOrderEvent): Promise<void> {
     switch (event.type) {
       case 'close-order.registered.uniswapv3':
+      case 'close-order.registered.uniswapv3-vault':
         return this.handleRegistered(event);
       case 'close-order.cancelled.uniswapv3':
+      case 'close-order.cancelled.uniswapv3-vault':
         return this.handleCancelled(event);
       case 'close-order.executed.uniswapv3':
+      case 'close-order.executed.uniswapv3-vault':
         return this.handleExecuted(event);
       case 'close-order.operator-updated.uniswapv3':
+      case 'close-order.operator-updated.uniswapv3-vault':
         return this.handleOperatorUpdated(event);
       case 'close-order.payout-updated.uniswapv3':
+      case 'close-order.payout-updated.uniswapv3-vault':
         return this.handlePayoutUpdated(event);
       case 'close-order.trigger-tick-updated.uniswapv3':
+      case 'close-order.trigger-tick-updated.uniswapv3-vault':
         return this.handleTriggerTickUpdated(event);
       case 'close-order.valid-until-updated.uniswapv3':
+      case 'close-order.valid-until-updated.uniswapv3-vault':
         return this.handleValidUntilUpdated(event);
       case 'close-order.slippage-updated.uniswapv3':
+      case 'close-order.slippage-updated.uniswapv3-vault':
         return this.handleSlippageUpdated(event);
       case 'close-order.swap-intent-updated.uniswapv3':
+      case 'close-order.swap-intent-updated.uniswapv3-vault':
         return this.handleSwapIntentUpdated(event);
+      case 'close-order.shares-updated.uniswapv3-vault':
+        return this.handleSharesUpdated(event);
       default:
-        this.logger.warn(
-          { type: (event as AnyCloseOrderEvent).type },
-          'Unknown close order event type'
+        // Not "understood but not ours" — we cannot interpret this at all.
+        throw new UnroutableCloseOrderEventError(
+          `Unknown close order event type: ${(event as AnyCloseOrderEvent).type}`
         );
     }
   }
@@ -258,28 +428,18 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
     event: AnyCloseOrderEvent,
     tx?: TxClient
   ): Promise<CloseOrder | null> {
-    if (!event.nftId) throw new Error('UniswapV3 close order event missing nftId');
-    const triggerMode = parseTriggerMode(event.triggerMode);
-    const orderIdentityHash = createOrderIdentityHash(
-      event.chainId,
-      event.nftId,
-      triggerMode
-    );
+    const orderIdentityHash = orderIdentityHashForEvent(event);
     const order = await this.orderService.findByOrderIdentityHash(
       orderIdentityHash,
       tx
     );
 
     if (!order) {
-      this.logger.warn(
-        {
-          chainId: event.chainId,
-          nftId: event.nftId,
-          triggerMode: event.triggerMode,
-          orderIdentityHash,
-          eventType: event.type,
-        },
-        'No matching close order found for event'
+      // Understood, but not ours — e.g. an order registered by a share holder we
+      // don't track, or an event for an order already removed. Not a fault.
+      this.logger.info(
+        { ...eventIdentityContext(event), orderIdentityHash },
+        'No matching close order found for event, skipping'
       );
     }
 
@@ -287,20 +447,73 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
   }
 
   /**
-   * Finds a position by nftId and chainId using Prisma JSON path filtering.
+   * Finds the position an event refers to.
+   *
+   * NFT:   by nftId + chainId.
+   * Vault: by vault address + owner address + chainId — a vault is an ERC-20, so
+   *        the owner is part of the position discriminator.
+   *
+   * Returns null when we simply don't track this position. Throws when the match
+   * is ambiguous: a CloseOrder row points at exactly one position, so more than
+   * one candidate is a state we cannot represent and must not guess at.
    */
-  private async findPositionByNftIdAndChain(
-    nftId: string,
-    chainId: number,
+  private async findPositionForEvent(
+    event: AnyCloseOrderEvent,
     tx?: TxClient
   ): Promise<{ id: string; config: Record<string, unknown> } | null> {
     const db = tx ?? prisma;
+
+    if (isVaultEvent(event)) {
+      if (!event.ownerAddress) {
+        throw new UnroutableCloseOrderEventError(
+          `Vault close order event missing ownerAddress: type=${event.type} ` +
+            `vault=${event.vaultAddress} tx=${event.transactionHash}`
+        );
+      }
+
+      // Position config stores both addresses EIP-55 checksummed
+      const vaultAddress = normalizeAddress(event.vaultAddress!);
+      const ownerAddress = normalizeAddress(event.ownerAddress);
+
+      const positions = await db.position.findMany({
+        where: {
+          protocol: 'uniswapv3-vault',
+          AND: [
+            { config: { path: ['chainId'], equals: event.chainId } },
+            { config: { path: ['vaultAddress'], equals: vaultAddress } },
+            { config: { path: ['ownerAddress'], equals: ownerAddress } },
+          ],
+        },
+        select: { id: true, config: true },
+      });
+
+      if (positions.length > 1) {
+        throw new UnroutableCloseOrderEventError(
+          `Ambiguous vault position for close order event: ${positions.length} matches ` +
+            `for chainId=${event.chainId} vault=${vaultAddress} owner=${ownerAddress} ` +
+            `(ids: ${positions.map((p) => p.id).join(', ')})`
+        );
+      }
+
+      const match = positions[0];
+      return match
+        ? { id: match.id, config: match.config as Record<string, unknown> }
+        : null;
+    }
+
+    if (!event.nftId) {
+      throw new UnroutableCloseOrderEventError(
+        `Close order event has neither nftId nor vaultAddress: type=${event.type} ` +
+          `tx=${event.transactionHash}`
+      );
+    }
+
     const positions = await db.position.findMany({
       where: {
         protocol: 'uniswapv3',
         config: {
           path: ['nftId'],
-          equals: parseInt(nftId, 10),
+          equals: parseInt(event.nftId, 10),
         },
       },
       select: { id: true, config: true },
@@ -308,7 +521,7 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
 
     const match = positions.find((p) => {
       const config = p.config as { chainId: number };
-      return config.chainId === chainId;
+      return config.chainId === event.chainId;
     });
 
     return match ? { id: match.id, config: match.config as Record<string, unknown> } : null;
@@ -329,10 +542,15 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
 
     if (triggerTick === null || triggerTick === undefined) return null;
 
-    const position = await this.positionService.findById(order.positionId, tx);
+    // Protocol-specific service; both expose isToken0Quote and pool token decimals
+    const position =
+      order.protocol === 'uniswapv3-vault'
+        ? await this.vaultPositionService.findById(order.positionId, tx)
+        : await this.positionService.findById(order.positionId, tx);
+
     if (!position) {
       this.logger.warn(
-        { positionId: order.positionId, orderId: order.id },
+        { positionId: order.positionId, orderId: order.id, protocol: order.protocol },
         'Cannot build order tag: position not found'
       );
       return null;
@@ -357,31 +575,36 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
    * Builds a CreateCloseOrderInput from a registered event.
    * Packs protocol-specific data into config/state JSON.
    */
-  private buildCreateInput(
-    event: OrderRegisteredEvent,
-    positionId: string,
-  ) {
-    if (!event.nftId) throw new Error('UniswapV3 close order event missing nftId');
+  private buildCreateInput(event: RegisteredEvent, positionId: string) {
     const triggerMode = parseTriggerMode(event.triggerMode);
     const { payload } = event;
+    const isVault = isVaultEvent(event);
 
-    const orderIdentityHash = createOrderIdentityHash(
-      event.chainId,
-      event.nftId,
-      triggerMode
-    );
+    // Config must match byte for byte what UniswapV3CloseOrderService.refresh()
+    // writes — it is the other writer of these rows.
+    const config = isVault
+      ? {
+          chainId: event.chainId,
+          vaultAddress: normalizeAddress(event.vaultAddress!),
+          ownerAddress: normalizeAddress(event.ownerAddress!),
+          triggerMode,
+          contractAddress: event.contractAddress,
+        }
+      : {
+          chainId: event.chainId,
+          nftId: event.nftId,
+          triggerMode,
+          contractAddress: event.contractAddress,
+        };
 
     return {
-      protocol: 'uniswapv3' as const,
+      protocol: (isVault ? 'uniswapv3-vault' : 'uniswapv3') as
+        | 'uniswapv3-vault'
+        | 'uniswapv3',
       positionId,
-      orderIdentityHash,
+      orderIdentityHash: orderIdentityHashForEvent(event),
       closeOrderHash: deriveCloseOrderHashFromTick(triggerMode, payload.triggerTick),
-      config: {
-        chainId: event.chainId,
-        nftId: event.nftId,
-        triggerMode,
-        contractAddress: event.contractAddress,
-      },
+      config,
       state: {
         triggerTick: payload.triggerTick,
         slippageBps: payload.slippageBps,
@@ -392,6 +615,8 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
         validUntil: new Date(Number(payload.validUntil) * 1000).toISOString(),
         swapDirection: parseSwapDirection(payload.swapDirection),
         swapSlippageBps: payload.swapSlippageBps,
+        // Vault share amount covered by the order (bigint as string)
+        ...(payload.shares !== undefined ? { shares: payload.shares } : {}),
         registrationTxHash: event.transactionHash,
         registeredAt: new Date().toISOString(),
         lastSyncBlock: parseInt(event.blockNumber, 10),
@@ -413,16 +638,9 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
    * 2. Order already exists (terminal or stale) → DELETE old, INSERT new (re-registration)
    * 3. No order exists → find position, INSERT new order
    */
-  private async handleRegistered(event: OrderRegisteredEvent): Promise<void> {
-    if (!event.nftId) throw new Error('UniswapV3 close order event missing nftId');
-    const { chainId, nftId, triggerMode, transactionHash, payload } = event as OrderRegisteredEvent & { nftId: string };
-    const triggerModeNum = parseTriggerMode(triggerMode);
-
-    const orderIdentityHash = createOrderIdentityHash(
-      chainId,
-      nftId,
-      triggerModeNum
-    );
+  private async handleRegistered(event: RegisteredEvent): Promise<void> {
+    const { chainId, transactionHash, payload } = event;
+    const orderIdentityHash = orderIdentityHashForEvent(event);
 
     const result = await prisma.$transaction(async (tx) => {
       // Check if order already exists at this identity slot
@@ -456,34 +674,37 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
         );
       }
 
-      // Find the position for this nftId + chainId
+      // Find the position this order belongs to
       const position = existingOrder
         ? await tx.position.findUnique({
             where: { id: existingOrder.positionId },
             select: { id: true, config: true },
           })
-        : await this.findPositionByNftIdAndChain(nftId, chainId, tx);
+        : await this.findPositionForEvent(event, tx);
 
       if (!position) {
-        this.logger.warn(
-          { chainId, nftId },
+        // A share holder we don't track can register an order on a vault we do
+        // track — expected, not a fault.
+        this.logger.info(
+          eventIdentityContext(event),
           'No position found for registered close order event, skipping'
         );
         return null;
       }
 
-      // INSERT new order
+      // Ensure the identity slot holds this order (idempotent against the
+      // concurrent writer, UniswapV3CloseOrderService.refresh())
       const createInput = this.buildCreateInput(event, position.id);
-      const created = await this.orderService.create(createInput, tx);
+      const created = await this.orderService.upsertByIdentityHash(createInput, tx);
 
       const isNew = !existingOrder;
 
       this.logger.info(
         {
+          ...eventIdentityContext(event),
           orderId: created.id,
           positionId: position.id,
-          nftId,
-          triggerMode,
+          protocol: created.protocol,
           isNew,
         },
         isNew
@@ -555,7 +776,7 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
    * DB lifecycle: on-chain cancellation → DELETE from DB.
    * Removes the pool subscription if no more monitoring orders reference that pool.
    */
-  private async handleCancelled(event: OrderCancelledEvent): Promise<void> {
+  private async handleCancelled(event: CancelledEvent): Promise<void> {
     const cancelResult = await prisma.$transaction(async (tx) => {
       const order = await this.resolveOrder(event, tx);
       if (!order) return null;
@@ -619,7 +840,7 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
    * DB lifecycle: on-chain execution → DELETE from DB.
    * Execution data is captured in AutomationLog before deletion.
    */
-  private async handleExecuted(event: OrderExecutedEvent): Promise<void> {
+  private async handleExecuted(event: ExecutedEvent): Promise<void> {
     const result = await prisma.$transaction(async (tx) => {
       const order = await this.resolveOrder(event, tx);
       if (!order) return null;
@@ -735,7 +956,7 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
    * Handles OrderOperatorUpdated events.
    */
   private async handleOperatorUpdated(
-    event: OrderOperatorUpdatedEvent
+    event: OperatorUpdatedEvent
   ): Promise<void> {
     const result = await prisma.$transaction(async (tx) => {
       const order = await this.resolveOrder(event, tx);
@@ -778,7 +999,7 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
    * Handles OrderPayoutUpdated events.
    */
   private async handlePayoutUpdated(
-    event: OrderPayoutUpdatedEvent
+    event: PayoutUpdatedEvent
   ): Promise<void> {
     const result = await prisma.$transaction(async (tx) => {
       const order = await this.resolveOrder(event, tx);
@@ -824,7 +1045,7 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
    * No more isToken0Quote/sqrtPriceX96 logic — tick is stored directly.
    */
   private async handleTriggerTickUpdated(
-    event: OrderTriggerTickUpdatedEvent
+    event: TriggerTickUpdatedEvent
   ): Promise<void> {
     const result = await prisma.$transaction(async (tx) => {
       const order = await this.resolveOrder(event, tx);
@@ -883,7 +1104,7 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
    * Handles OrderValidUntilUpdated events.
    */
   private async handleValidUntilUpdated(
-    event: OrderValidUntilUpdatedEvent
+    event: ValidUntilUpdatedEvent
   ): Promise<void> {
     const result = await prisma.$transaction(async (tx) => {
       const order = await this.resolveOrder(event, tx);
@@ -930,7 +1151,7 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
    * Handles OrderSlippageUpdated events.
    */
   private async handleSlippageUpdated(
-    event: OrderSlippageUpdatedEvent
+    event: SlippageUpdatedEvent
   ): Promise<void> {
     const result = await prisma.$transaction(async (tx) => {
       const order = await this.resolveOrder(event, tx);
@@ -978,7 +1199,7 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
    * Handles OrderSwapIntentUpdated events.
    */
   private async handleSwapIntentUpdated(
-    event: OrderSwapIntentUpdatedEvent
+    event: SwapIntentUpdatedEvent
   ): Promise<void> {
     const result = await prisma.$transaction(async (tx) => {
       const order = await this.resolveOrder(event, tx);
@@ -1006,6 +1227,58 @@ export class UniswapV3ProcessCloseOrderEventsRule extends BusinessRule {
           {
             orderTag,
             changes: 'swap intent',
+            chainId: event.chainId,
+          } satisfies OrderModifiedContext,
+          tx
+        );
+      }
+
+      return { orderId: order.id, positionId: order.positionId, orderIdentityHash: order.orderIdentityHash };
+    });
+
+    if (result) {
+      this.publishModifiedEvent(result.orderId, result.positionId, result.orderIdentityHash);
+    }
+  }
+
+  /**
+   * Handles OrderSharesUpdated events (vault only).
+   *
+   * The executor reads the share amount from the chain at execution time, so the
+   * stored value is display state — but a stored value that silently goes stale
+   * is the failure mode this rule exists to remove.
+   */
+  private async handleSharesUpdated(
+    event: VaultOrderSharesUpdatedEvent
+  ): Promise<void> {
+    const result = await prisma.$transaction(async (tx) => {
+      const order = await this.resolveOrder(event, tx);
+      if (!order) return null;
+
+      // Share amounts are bigint — keep them as strings end to end
+      await this.orderService.mergeState(
+        order.id,
+        { shares: event.payload.newShares },
+        tx
+      );
+
+      this.logger.info(
+        {
+          orderId: order.id,
+          oldShares: event.payload.oldShares,
+          newShares: event.payload.newShares,
+        },
+        'Close order shares updated'
+      );
+
+      const orderTag = await this.buildOrderTag(order, tx);
+      if (orderTag) {
+        await this.automationLogService.logOrderModified(
+          order.positionId,
+          order.id,
+          {
+            orderTag,
+            changes: 'shares',
             chainId: event.chainId,
           } satisfies OrderModifiedContext,
           tx

--- a/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.ts
+++ b/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.ts
@@ -114,13 +114,30 @@ import type {
  * autoDelete: false, and still bound to close-order-events with both routing
  * patterns; a topic exchange delivers to every matching binding, so it keeps
  * receiving every close order event with nobody consuming it, and grows until
- * the disk does. Unbind or delete it as part of the deploy:
+ * the disk does.
  *
- *   rabbitmqadmin delete queue name=business-logic.uniswapv3-process-close-order-events
+ * Two phases, in this order. The first is reversible and stops the bleeding;
+ * the second needs a human looking at the queue depth.
  *
- * This is not done from code on purpose: deleting a queue that may still hold
- * unprocessed v1 messages is destructive, and mid-rolling-deploy is the worst
- * moment to decide that.
+ *   1. Unbind — accumulation stops immediately, nothing is lost:
+ *      rabbitmqadmin delete binding source=close-order-events \
+ *        destination=business-logic.uniswapv3-process-close-order-events \
+ *        destination_type=queue properties_key='closer.*.*.*'
+ *      rabbitmqadmin delete binding source=close-order-events \
+ *        destination=business-logic.uniswapv3-process-close-order-events \
+ *        destination_type=queue properties_key='closer.vault.*.*.*'
+ *
+ *   2. Check the depth, then decide:
+ *      rabbitmqadmin list queues name messages
+ *      Empty → delete it. Non-empty → shovel into the v2 queue first, since
+ *      those are real events that were never processed; discarding them is a
+ *      choice, not a cleanup.
+ *      rabbitmqadmin delete queue name=business-logic.uniswapv3-process-close-order-events
+ *
+ * Not done from code on purpose: the unbind would be safe to automate, but
+ * collapsing it together with the delete would hide an irreversible action
+ * behind a reversible one, and mid-rolling-deploy is the worst moment for the
+ * code to decide what happens to unprocessed messages.
  */
 const QUEUE_NAME = 'business-logic.uniswapv3-process-close-order-events.v2';
 

--- a/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.ts
+++ b/apps/midcurve-business-logic/src/rules/close-orders/uniswapv3/uniswapv3-process-close-order-events.ts
@@ -108,7 +108,19 @@ import type {
  *
  * v2: the v1 queue was declared without a dead-letter exchange, so nacked
  * messages were dropped. Queue arguments are immutable in RabbitMQ, so adding
- * the DLX means declaring a new queue and letting the old one drain.
+ * the DLX means declaring a new queue.
+ *
+ * DEPLOY STEP — the v1 queue does not drain, it fills. It is durable,
+ * autoDelete: false, and still bound to close-order-events with both routing
+ * patterns; a topic exchange delivers to every matching binding, so it keeps
+ * receiving every close order event with nobody consuming it, and grows until
+ * the disk does. Unbind or delete it as part of the deploy:
+ *
+ *   rabbitmqadmin delete queue name=business-logic.uniswapv3-process-close-order-events
+ *
+ * This is not done from code on purpose: deleting a queue that may still hold
+ * unprocessed v1 messages is destructive, and mid-rolling-deploy is the worst
+ * moment to decide that.
  */
 const QUEUE_NAME = 'business-logic.uniswapv3-process-close-order-events.v2';
 

--- a/apps/midcurve-onchain-data/src/catchup/close-order-catchup.ts
+++ b/apps/midcurve-onchain-data/src/catchup/close-order-catchup.ts
@@ -16,12 +16,19 @@
  * for eth_getLogs filtering, and decodes logs using the V100 ABI.
  */
 
-import { EvmConfig, EvmBlockService, CacheService } from '@midcurve/services';
-import { UniswapV3PositionCloserV100Abi } from '@midcurve/shared';
+import {
+  EvmConfig,
+  EvmBlockService,
+  CacheService,
+  closeOrderRoutingKeyForEvent,
+} from '@midcurve/services';
+import {
+  UniswapV3PositionCloserV100Abi,
+  UniswapV3VaultPositionCloserV100Abi,
+} from '@midcurve/shared';
 import { keccak256, toHex } from 'viem';
 import { onchainDataLogger } from '../lib/logger';
 import { getRabbitMQConnection } from '../mq/connection-manager';
-import { buildCloseOrderRoutingKey } from '../mq/topology';
 import {
   buildCloseOrderEvent,
   serializeCloseOrderEvent,
@@ -135,39 +142,54 @@ async function getFinalizedBlockNumber(chainId: number): Promise<bigint> {
 // ============================================================
 
 /**
- * Compute keccak256 event signatures for the 8 lifecycle events.
- * We extract them by decoding the ABI entry names at import time.
+ * Lifecycle events the fallback path replays.
+ *
+ * OrderExecuted is included: half a safety net is worse than a known-missing
+ * one. OrderSharesUpdated is vault-only and simply absent from the NFT ABI.
  */
 const LIFECYCLE_EVENT_NAMES = new Set([
   'OrderRegistered',
   'OrderCancelled',
+  'OrderExecuted',
   'OrderOperatorUpdated',
   'OrderPayoutUpdated',
   'OrderTriggerTickUpdated',
   'OrderValidUntilUpdated',
   'OrderSlippageUpdated',
   'OrderSwapIntentUpdated',
+  'OrderSharesUpdated',
 ]);
 
 /**
- * Compute event signatures from the ABI.
+ * Compute event signatures from the ABIs.
  * viem's decodeEventLog handles this internally, but for eth_getLogs
  * topics[0] filtering we need the keccak256 hashes.
+ *
+ * Both closer ABIs are covered: the vault events carry different parameter
+ * types, so their topic0 differs and an NFT-only filter excludes every vault
+ * event even when the vault closer address is being polled.
  */
 function computeEventSignatures(): `0x${string}`[] {
-  const signatures: `0x${string}`[] = [];
+  const signatures = new Set<`0x${string}`>();
 
-  for (const item of UniswapV3PositionCloserV100Abi) {
-    if (item.type !== 'event') continue;
-    if (!LIFECYCLE_EVENT_NAMES.has(item.name)) continue;
+  const abis = [
+    UniswapV3PositionCloserV100Abi,
+    UniswapV3VaultPositionCloserV100Abi,
+  ] as const;
 
-    // Build canonical event signature string: EventName(type1,type2,...)
-    const params = item.inputs.map((input: { type: string }) => input.type).join(',');
-    const sig = `${item.name}(${params})`;
-    signatures.push(keccak256(toHex(sig)));
+  for (const abi of abis) {
+    for (const item of abi) {
+      if (item.type !== 'event') continue;
+      if (!LIFECYCLE_EVENT_NAMES.has(item.name)) continue;
+
+      // Build canonical event signature string: EventName(type1,type2,...)
+      const params = item.inputs.map((input: { type: string }) => input.type).join(',');
+      const sig = `${item.name}(${params})`;
+      signatures.add(keccak256(toHex(sig)));
+    }
   }
 
-  return signatures;
+  return Array.from(signatures);
 }
 
 const LIFECYCLE_EVENT_SIGNATURES = computeEventSignatures();
@@ -318,9 +340,9 @@ export async function executeCloseOrderCatchUpNonFinalized(
     const mq = getRabbitMQConnection();
 
     for (const { event } of events) {
-      if (!event || !event.nftId) continue;
+      if (!event) continue;
       try {
-        const routingKey = buildCloseOrderRoutingKey(chainId, event.nftId, event.triggerMode);
+        const routingKey = closeOrderRoutingKeyForEvent(event);
         const content = serializeCloseOrderEvent(event);
         await mq.publishCloseOrderEvent(routingKey, content);
         publishedCount++;
@@ -329,6 +351,8 @@ export async function executeCloseOrderCatchUpNonFinalized(
           chainId,
           eventType: event.type,
           nftId: event.nftId,
+          vaultAddress: event.vaultAddress,
+          ownerAddress: event.ownerAddress,
           error: error instanceof Error ? error.message : String(error),
         }, 'Failed to publish non-finalized close order catch-up event');
       }
@@ -401,9 +425,9 @@ export async function executeCloseOrderCatchUpFinalized(
     const mq = getRabbitMQConnection();
 
     for (const { event } of events) {
-      if (!event || !event.nftId) continue;
+      if (!event) continue;
       try {
-        const routingKey = buildCloseOrderRoutingKey(chainId, event.nftId, event.triggerMode);
+        const routingKey = closeOrderRoutingKeyForEvent(event);
         const content = serializeCloseOrderEvent(event);
         await mq.publishCloseOrderEvent(routingKey, content);
         publishedCount++;
@@ -412,6 +436,8 @@ export async function executeCloseOrderCatchUpFinalized(
           chainId,
           eventType: event.type,
           nftId: event.nftId,
+          vaultAddress: event.vaultAddress,
+          ownerAddress: event.ownerAddress,
           error: error instanceof Error ? error.message : String(error),
         }, 'Failed to publish finalized close order catch-up event');
       }

--- a/apps/midcurve-onchain-data/src/polling/uniswap-v3-closer.ts
+++ b/apps/midcurve-onchain-data/src/polling/uniswap-v3-closer.ts
@@ -157,12 +157,27 @@ export class UniswapV3CloserPollingBatch {
       const mq = getRabbitMQConnection();
       let publishedCount = 0;
 
+      // Per-event isolation: one unusable event must not take the rest of the
+      // batch down with it. Matches the catch-up publishers.
       for (const { event } of events) {
         if (!event) continue;
-        const routingKey = closeOrderRoutingKeyForEvent(event);
-        const content = serializeCloseOrderEvent(event);
-        await mq.publishCloseOrderEvent(routingKey, content);
-        publishedCount++;
+        try {
+          const routingKey = closeOrderRoutingKeyForEvent(event);
+          const content = serializeCloseOrderEvent(event);
+          await mq.publishCloseOrderEvent(routingKey, content);
+          publishedCount++;
+        } catch (error) {
+          log.warn({
+            chainId: this.chainId,
+            eventType: event.type,
+            nftId: event.nftId,
+            vaultAddress: event.vaultAddress,
+            ownerAddress: event.ownerAddress,
+            txHash: event.transactionHash,
+            error: error instanceof Error ? error.message : String(error),
+            msg: 'Failed to publish close order event from poll, skipping',
+          });
+        }
       }
 
       log.info({

--- a/apps/midcurve-onchain-data/src/polling/uniswap-v3-closer.ts
+++ b/apps/midcurve-onchain-data/src/polling/uniswap-v3-closer.ts
@@ -11,10 +11,9 @@
  * and publishes decoded domain events to RabbitMQ.
  */
 
-import { EvmConfig } from '@midcurve/services';
+import { EvmConfig, closeOrderRoutingKeyForEvent } from '@midcurve/services';
 import { onchainDataLogger } from '../lib/logger';
 import { getRabbitMQConnection } from '../mq/connection-manager';
-import { buildCloseOrderRoutingKey } from '../mq/topology';
 import {
   serializeCloseOrderEvent,
 } from '../mq/close-order-messages';
@@ -159,8 +158,8 @@ export class UniswapV3CloserPollingBatch {
       let publishedCount = 0;
 
       for (const { event } of events) {
-        if (!event || !event.nftId) continue;
-        const routingKey = buildCloseOrderRoutingKey(this.chainId, event.nftId, event.triggerMode);
+        if (!event) continue;
+        const routingKey = closeOrderRoutingKeyForEvent(event);
         const content = serializeCloseOrderEvent(event);
         await mq.publishCloseOrderEvent(routingKey, content);
         publishedCount++;

--- a/apps/midcurve-onchain-data/src/workers/uniswapv3/uniswapv3-close-order-poller.ts
+++ b/apps/midcurve-onchain-data/src/workers/uniswapv3/uniswapv3-close-order-poller.ts
@@ -1,8 +1,9 @@
 /**
  * CloseOrderSubscriber Worker
  *
- * Loads active UniswapV3PositionCloser contracts from the SharedContract registry,
- * creates polling batches, and manages their lifecycle.
+ * Loads active UniswapV3PositionCloser and UniswapV3VaultPositionCloser contracts
+ * from the SharedContract registry, creates polling batches, and manages their
+ * lifecycle.
  * Publishes incoming lifecycle events (registration, cancellation, config updates)
  * to RabbitMQ as structured domain events.
  *
@@ -144,14 +145,22 @@ export class CloseOrderSubscriber {
   // ===========================================================================
 
   /**
-   * Load active UniswapV3PositionCloser contracts from SharedContract registry,
-   * grouped by chain ID.
+   * Load active closer contracts from the SharedContract registry, grouped by
+   * chain ID.
+   *
+   * Both the NFT closer and the vault closer are loaded — the fallback path has
+   * to cover direct contract interaction for either protocol.
    */
   private async loadActiveContracts(): Promise<Map<number, CloserContractInfo[]>> {
     priceLog.methodEntry(log, 'loadActiveContracts');
 
     const sharedContractService = new SharedContractService();
     const contractsByChain = new Map<number, CloserContractInfo[]>();
+
+    const CLOSER_CONTRACT_NAMES = [
+      SharedContractNameEnum.UNISWAP_V3_POSITION_CLOSER,
+      SharedContractNameEnum.UNISWAP_V3_VAULT_POSITION_CLOSER,
+    ];
 
     for (const chainId of SUPPORTED_CHAIN_IDS) {
       if (!isSupportedChain(chainId)) continue;
@@ -166,50 +175,53 @@ export class CloseOrderSubscriber {
           continue;
         }
 
-        const contract = await sharedContractService.findLatestByChainAndName(
-          chainId,
-          SharedContractNameEnum.UNISWAP_V3_POSITION_CLOSER
-        );
+        for (const contractName of CLOSER_CONTRACT_NAMES) {
+          const contract = await sharedContractService.findLatestByChainAndName(
+            chainId,
+            contractName
+          );
 
-        if (!contract) {
-          log.info({ chainId, msg: 'No active UniswapV3PositionCloser contract for chain' });
-          continue;
+          if (!contract) {
+            log.info({ chainId, contractName, msg: 'No active closer contract for chain' });
+            continue;
+          }
+
+          const config = contract.config as EvmSmartContractConfigData;
+
+          if (!config.address) {
+            log.warn({ chainId, contractId: contract.id, contractName, msg: 'Contract config missing address' });
+            continue;
+          }
+
+          if (!contractsByChain.has(chainId)) {
+            contractsByChain.set(chainId, []);
+          }
+
+          contractsByChain.get(chainId)!.push({
+            address: config.address,
+            chainId,
+          });
+
+          // Track for catch-up
+          if (!this.contractsByChain.has(chainId)) {
+            this.contractsByChain.set(chainId, []);
+          }
+          this.contractsByChain.get(chainId)!.push(config.address);
+
+          log.info({
+            chainId,
+            contractName,
+            address: config.address,
+            contractId: contract.id,
+            version: `${contract.interfaceVersionMajor}.${contract.interfaceVersionMinor}`,
+            msg: 'Loaded closer contract',
+          });
         }
-
-        const config = contract.config as EvmSmartContractConfigData;
-
-        if (!config.address) {
-          log.warn({ chainId, contractId: contract.id, msg: 'Contract config missing address' });
-          continue;
-        }
-
-        if (!contractsByChain.has(chainId)) {
-          contractsByChain.set(chainId, []);
-        }
-
-        contractsByChain.get(chainId)!.push({
-          address: config.address,
-          chainId,
-        });
-
-        // Track for catch-up
-        if (!this.contractsByChain.has(chainId)) {
-          this.contractsByChain.set(chainId, []);
-        }
-        this.contractsByChain.get(chainId)!.push(config.address);
-
-        log.info({
-          chainId,
-          address: config.address,
-          contractId: contract.id,
-          version: `${contract.interfaceVersionMajor}.${contract.interfaceVersionMinor}`,
-          msg: 'Loaded closer contract',
-        });
       } catch (error) {
         log.warn({
           chainId,
           error: error instanceof Error ? error.message : String(error),
-          msg: 'Failed to load closer contract for chain',
+          msg: 'Failed to load closer contracts for chain',
         });
       }
     }

--- a/packages/midcurve-services/src/events/close-order-event-decoder.test.ts
+++ b/packages/midcurve-services/src/events/close-order-event-decoder.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Close order event decoding and routing — vault variant
+ *
+ * Covers the mechanism that made the fallback path NFT-only (issue #77):
+ * the vault events carry different parameter types, so their topic0 differs
+ * from the NFT events, and an eth_getLogs filter built from the NFT ABI alone
+ * excludes every vault event even when the vault closer address is polled.
+ *
+ * apps/midcurve-onchain-data has no test infrastructure, so the parts of that
+ * path which live in this package are pinned here: the topic0 divergence, the
+ * decode (including the owner, without which position resolution is
+ * impossible), and the routing key.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { encodeEventTopics, encodeAbiParameters, keccak256, toHex } from 'viem';
+import {
+  UniswapV3PositionCloserV100Abi,
+  UniswapV3VaultPositionCloserV100Abi,
+} from '@midcurve/shared';
+import {
+  buildCloseOrderEvent,
+  closeOrderRoutingKeyForEvent,
+  type RawEventLog,
+} from './close-order-event-decoder.js';
+
+const CHAIN_ID = 42161;
+const CLOSER = '0x13d13B15BbE9b06C0279a7aB5f0a898EA3f25A40';
+const VAULT = '0x7eBA4a00B7991a99A5F7FC7C9C50F2f0d0dFFEe8';
+const OWNER = '0x31bB7b5b7ddf4ad0fc90261Dffe655CDdAeed941';
+const POOL = '0xC6962004f452bE9203591991D15f6b388e09E8D0';
+const OPERATOR = '0x1111111111111111111111111111111111111111';
+const PAYOUT = '0x2222222222222222222222222222222222222222';
+
+/** topic0 for an event name, computed from an ABI the way eth_getLogs needs it */
+function topic0(abi: readonly unknown[], name: string): string {
+  const item = (abi as Array<{ type: string; name: string; inputs: Array<{ type: string }> }>).find(
+    (i) => i.type === 'event' && i.name === name,
+  );
+  if (!item) throw new Error(`event ${name} not in ABI`);
+  return keccak256(toHex(`${item.name}(${item.inputs.map((i) => i.type).join(',')})`));
+}
+
+/**
+ * A real vault OrderRegistered log, ABI-encoded.
+ *
+ * Indexed args go to topics, the rest to data — built from the ABI item itself
+ * so it stays correct if the event's parameter list ever shifts.
+ */
+function vaultRegisteredLog(): RawEventLog {
+  const args: Record<string, unknown> = {
+    vault: VAULT,
+    triggerMode: 0,
+    owner: OWNER,
+    pool: POOL,
+    operator: OPERATOR,
+    payout: PAYOUT,
+    triggerTick: -201_120,
+    shares: 1_000_000_000_000_000_000n,
+    validUntil: 1_800_000_000n,
+    slippageBps: 100,
+    swapDirection: 0,
+    swapSlippageBps: 0,
+  };
+
+  const item = (
+    UniswapV3VaultPositionCloserV100Abi as unknown as Array<{
+      type: string;
+      name: string;
+      inputs: Array<{ type: string; name: string; indexed?: boolean }>;
+    }>
+  ).find((i) => i.type === 'event' && i.name === 'OrderRegistered')!;
+
+  const topics = encodeEventTopics({
+    abi: UniswapV3VaultPositionCloserV100Abi,
+    eventName: 'OrderRegistered',
+    args: Object.fromEntries(
+      item.inputs.filter((i) => i.indexed).map((i) => [i.name, args[i.name]]),
+    ),
+  } as never);
+
+  const unindexed = item.inputs.filter((i) => !i.indexed);
+  const data = encodeAbiParameters(
+    unindexed.map((i) => ({ type: i.type, name: i.name })),
+    unindexed.map((i) => args[i.name]),
+  );
+
+  return {
+    address: CLOSER,
+    topics: topics as [`0x${string}`, ...`0x${string}`[]],
+    data,
+    blockNumber: 492_389_530n,
+    transactionHash: '0xabc0000000000000000000000000000000000000000000000000000000000001',
+    logIndex: 4,
+  };
+}
+
+describe('vault close order events', () => {
+  it('has a different topic0 from the NFT event of the same name', () => {
+    // This is why an NFT-only topic filter silently excluded every vault event
+    expect(topic0(UniswapV3VaultPositionCloserV100Abi, 'OrderRegistered')).not.toBe(
+      topic0(UniswapV3PositionCloserV100Abi, 'OrderRegistered'),
+    );
+  });
+
+  it('is matched by the topic0 of the log it produces', () => {
+    const log = vaultRegisteredLog();
+    expect(log.topics[0]).toBe(topic0(UniswapV3VaultPositionCloserV100Abi, 'OrderRegistered'));
+  });
+
+  it('decodes to a vault event carrying vault, owner and shares', () => {
+    const event = buildCloseOrderEvent(CHAIN_ID, CLOSER, vaultRegisteredLog());
+
+    expect(event).not.toBeNull();
+    expect(event!.type).toBe('close-order.registered.uniswapv3-vault');
+    expect(event!.vaultAddress).toBe(VAULT);
+    // Without the owner, a vault event cannot be resolved to a position at all
+    expect(event!.ownerAddress).toBe(OWNER);
+    expect(event!.nftId).toBeUndefined();
+    expect(event!.triggerMode).toBe('LOWER');
+
+    const payload = event!.payload as { owner: string; shares?: string; triggerTick: number };
+    expect(payload.owner).toBe(OWNER);
+    expect(payload.triggerTick).toBe(-201_120);
+    // bigint stays a string across the wire
+    expect(payload.shares).toBe('1000000000000000000');
+  });
+
+  it('routes on the vault key shape, not the NFT one', () => {
+    const event = buildCloseOrderEvent(CHAIN_ID, CLOSER, vaultRegisteredLog());
+    expect(closeOrderRoutingKeyForEvent(event!)).toBe(
+      `closer.vault.${CHAIN_ID}.${VAULT}.LOWER`,
+    );
+  });
+
+  it('refuses to route an event with no identifiers rather than dropping it silently', () => {
+    expect(() =>
+      closeOrderRoutingKeyForEvent({
+        type: 'close-order.registered.uniswapv3',
+        chainId: CHAIN_ID,
+        contractAddress: CLOSER,
+        triggerMode: 'LOWER',
+        blockNumber: '1',
+        transactionHash: '0xdead',
+        logIndex: 0,
+        receivedAt: new Date(0).toISOString(),
+        payload: {},
+      } as never),
+    ).toThrow(/neither nftId nor vaultAddress/);
+  });
+});

--- a/packages/midcurve-services/src/events/close-order-event-decoder.ts
+++ b/packages/midcurve-services/src/events/close-order-event-decoder.ts
@@ -147,6 +147,8 @@ export interface OrderRegisteredPayload {
   slippageBps: number;
   swapDirection: SwapDirectionString;
   swapSlippageBps: number;
+  /** Vault shares covered by the order (vault variant only, bigint as string) */
+  shares?: string;
 }
 
 export interface OrderCancelledPayload {
@@ -161,6 +163,8 @@ export interface OrderExecutedPayload {
   amount0Out: string;
   /** Amount of token1 received (as string for bigint) */
   amount1Out: string;
+  /** Vault shares closed by the execution (vault variant only, bigint as string) */
+  sharesClosed?: string;
 }
 
 export interface OrderOperatorUpdatedPayload {
@@ -473,6 +477,17 @@ export function buildCloseOrderEvent(
 export const EXCHANGE_CLOSE_ORDER_EVENTS = 'close-order-events';
 
 /**
+ * Dead-letter exchange for close order lifecycle events.
+ *
+ * Consumers bind their queue to this via x-dead-letter-exchange so that a message
+ * no handler can interpret ends up somewhere visible instead of being discarded.
+ */
+export const EXCHANGE_CLOSE_ORDER_EVENTS_DLX = 'close-order-events-dlx';
+
+/** Retention for dead-lettered close order events (7 days) */
+export const CLOSE_ORDER_DLQ_MESSAGE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
  * Build a routing key for close order lifecycle events.
  * NFT format:   closer.{chainId}.{nftId}.{triggerMode}
  * Vault format:  closer.vault.{chainId}.{vaultAddress}.{triggerMode}
@@ -487,6 +502,36 @@ export function buildCloseOrderRoutingKey(
     return `closer.vault.${chainId}.${identifier}.${triggerMode}`;
   }
   return `closer.${chainId}.${identifier}.${triggerMode}`;
+}
+
+/**
+ * Build the routing key for a decoded close order event, picking the NFT or
+ * vault key shape from the event's own identifiers.
+ *
+ * Every publisher (receipt extraction, fallback poller, catch-up) must use this
+ * instead of hand-rolling the key — the NFT-only variants silently dropped every
+ * vault event.
+ *
+ * @throws if the event carries neither an nftId nor a vaultAddress
+ */
+export function closeOrderRoutingKeyForEvent(event: AnyCloseOrderEvent): string {
+  if (event.vaultAddress) {
+    return buildCloseOrderRoutingKey(
+      event.chainId,
+      event.vaultAddress,
+      event.triggerMode,
+      'vault'
+    );
+  }
+
+  if (event.nftId) {
+    return buildCloseOrderRoutingKey(event.chainId, event.nftId, event.triggerMode);
+  }
+
+  throw new Error(
+    `Close order event has neither nftId nor vaultAddress: type=${event.type} ` +
+      `tx=${event.transactionHash} logIndex=${event.logIndex}`
+  );
 }
 
 // ============================================================

--- a/packages/midcurve-services/src/events/index.ts
+++ b/packages/midcurve-services/src/events/index.ts
@@ -195,12 +195,16 @@ export {
   // Functions
   buildCloseOrderEvent,
   buildCloseOrderRoutingKey,
+  closeOrderRoutingKeyForEvent,
   serializeCloseOrderEvent,
   triggerModeToString,
   swapDirectionToString,
   // Constants
   EXCHANGE_CLOSE_ORDER_EVENTS,
+  EXCHANGE_CLOSE_ORDER_EVENTS_DLX,
+  CLOSE_ORDER_DLQ_MESSAGE_TTL_MS,
   CLOSER_LIFECYCLE_EVENT_ABIS,
+  VAULT_CLOSER_LIFECYCLE_EVENT_ABIS,
 } from './close-order-event-decoder.js';
 
 export type {
@@ -230,6 +234,18 @@ export type {
   OrderValidUntilUpdatedEvent,
   OrderSlippageUpdatedEvent,
   OrderSwapIntentUpdatedEvent,
+  // Typed events (vault variant)
+  VaultOrderRegisteredEvent,
+  VaultOrderCancelledEvent,
+  VaultOrderExecutedEvent,
+  VaultOrderOperatorUpdatedEvent,
+  VaultOrderPayoutUpdatedEvent,
+  VaultOrderTriggerTickUpdatedEvent,
+  VaultOrderValidUntilUpdatedEvent,
+  VaultOrderSlippageUpdatedEvent,
+  VaultOrderSwapIntentUpdatedEvent,
+  VaultOrderSharesUpdatedEvent,
+  OrderSharesUpdatedPayload,
   AnyCloseOrderEvent,
   // Raw log type
   RawEventLog,

--- a/packages/midcurve-services/src/services/close-order/uniswapv3-close-order-service.ts
+++ b/packages/midcurve-services/src/services/close-order/uniswapv3-close-order-service.ts
@@ -33,6 +33,7 @@ import type { ServiceLogger } from '../../logging/index.js';
 import type { PrismaTransactionClient } from '../../clients/prisma/index.js';
 import { EvmConfig } from '../../config/evm.js';
 import { deriveCloseOrderHashFromTick } from '../../utils/automation/close-order-hash.js';
+import { createCloseOrderIdentityHash } from '../../utils/automation/close-order-identity.js';
 import { SharedContractService } from '../automation/shared-contract-service.js';
 import type {
   CreateCloseOrderInput,
@@ -309,10 +310,22 @@ export class UniswapV3CloseOrderService {
               chainId, contractAddress, BigInt(nftId!), triggerMode, blockNumber,
             );
 
-        // Protocol-specific identity hash
+        // Protocol-specific identity hash — shared with the on-chain event rule,
+        // which is the other writer of these rows.
         const orderIdentityHash = isVault
-          ? `uniswapv3-vault/${chainId}/${vaultAddress!.toLowerCase()}/${ownerAddress!.toLowerCase()}/${triggerMode}`
-          : `uniswapv3/${chainId}/${nftId}/${triggerMode}`;
+          ? createCloseOrderIdentityHash({
+              protocol: 'uniswapv3-vault',
+              chainId,
+              vaultAddress: vaultAddress!,
+              ownerAddress: ownerAddress!,
+              triggerMode,
+            })
+          : createCloseOrderIdentityHash({
+              protocol: 'uniswapv3',
+              chainId,
+              nftId: nftId!,
+              triggerMode,
+            });
         const existingOrder = await this.findByOrderIdentityHash(orderIdentityHash, tx);
         const isActive = onChain !== null && onChain.status === OnChainOrderStatus.ACTIVE;
 
@@ -478,6 +491,59 @@ export class UniswapV3CloseOrderService {
       return result;
     } catch (error) {
       log.methodError(this.logger, 'create', error as Error, { input });
+      throw error;
+    }
+  }
+
+  /**
+   * Ensures the identity slot holds exactly this order.
+   *
+   * Registration is not "insert a row", it is "this slot now holds this order" —
+   * so it is expressed as an upsert on the unique orderIdentityHash. Two writers
+   * exist for these rows (the on-chain event rule and refresh()); whichever wins
+   * the race, the slot ends up with the same content instead of one of them
+   * failing on the unique constraint.
+   */
+  async upsertByIdentityHash(
+    input: CreateCloseOrderInput,
+    tx?: PrismaTransactionClient,
+  ): Promise<CloseOrder> {
+    log.methodEntry(this.logger, 'upsertByIdentityHash', {
+      positionId: input.positionId,
+      protocol: input.protocol,
+      orderIdentityHash: input.orderIdentityHash,
+    });
+
+    try {
+      const db = tx ?? this.prisma;
+
+      const mutableFields = {
+        positionId: input.positionId,
+        sharedContractId: input.sharedContractId,
+        closeOrderHash: input.closeOrderHash,
+        automationState: input.automationState ?? 'monitoring',
+        config: input.config as Prisma.InputJsonValue,
+        state: input.state as Prisma.InputJsonValue,
+      };
+
+      const result = await db.closeOrder.upsert({
+        where: { orderIdentityHash: input.orderIdentityHash },
+        create: {
+          protocol: input.protocol,
+          orderIdentityHash: input.orderIdentityHash,
+          ...mutableFields,
+        },
+        update: mutableFields,
+      });
+
+      this.logger.info(
+        { id: result.id, positionId: result.positionId, protocol: result.protocol },
+        'Close order slot ensured',
+      );
+      log.methodExit(this.logger, 'upsertByIdentityHash', { id: result.id });
+      return result;
+    } catch (error) {
+      log.methodError(this.logger, 'upsertByIdentityHash', error as Error, { input });
       throw error;
     }
   }

--- a/packages/midcurve-services/src/services/types/automation/automation-input.ts
+++ b/packages/midcurve-services/src/services/types/automation/automation-input.ts
@@ -125,6 +125,12 @@ export interface OrderExecutedContext extends OrderLogContext {
   amount0Out: string;
   amount1Out: string;
   executionFeeBps: number;
+  /**
+   * Vault shares closed by the execution (vault orders only, bigint as string).
+   * The vault-specific quantity of the execution — without it the log cannot
+   * say how much of the position was closed.
+   */
+  sharesClosed?: string;
 }
 
 /**

--- a/packages/midcurve-services/src/utils/automation/close-order-identity.test.ts
+++ b/packages/midcurve-services/src/utils/automation/close-order-identity.test.ts
@@ -1,0 +1,168 @@
+/**
+ * createCloseOrderIdentityHash — unit tests
+ *
+ * This helper is the contract between the two writers of CloseOrder rows (the
+ * on-chain event rule and UniswapV3CloseOrderService.refresh()). If they ever
+ * disagree on a single character, the same slot produces two rows and collides
+ * on @@unique([positionId, closeOrderHash]) — so the shape is pinned here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ContractTriggerMode } from '@midcurve/shared';
+import { createCloseOrderIdentityHash } from './close-order-identity.js';
+
+const CHAIN_ID = 42161;
+const VAULT_CHECKSUMMED = '0x13d13B15BbE9b06C0279a7aB5f0a898EA3f25A40';
+const OWNER_CHECKSUMMED = '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48';
+
+describe('createCloseOrderIdentityHash', () => {
+  describe('uniswapv3 (NFT)', () => {
+    it('builds "uniswapv3/{chainId}/{nftId}/{triggerMode}"', () => {
+      expect(
+        createCloseOrderIdentityHash({
+          protocol: 'uniswapv3',
+          chainId: CHAIN_ID,
+          nftId: '12345',
+          triggerMode: ContractTriggerMode.LOWER,
+        }),
+      ).toBe('uniswapv3/42161/12345/0');
+    });
+
+    it('accepts a numeric nftId and both trigger modes', () => {
+      expect(
+        createCloseOrderIdentityHash({
+          protocol: 'uniswapv3',
+          chainId: 1,
+          nftId: 42,
+          triggerMode: ContractTriggerMode.UPPER,
+        }),
+      ).toBe('uniswapv3/1/42/1');
+    });
+
+    it('throws when the nftId is missing', () => {
+      expect(() =>
+        createCloseOrderIdentityHash({
+          protocol: 'uniswapv3',
+          chainId: CHAIN_ID,
+          nftId: '',
+          triggerMode: ContractTriggerMode.LOWER,
+        }),
+      ).toThrow(/requires nftId/);
+    });
+  });
+
+  describe('uniswapv3-vault', () => {
+    it('builds "uniswapv3-vault/{chainId}/{vault}/{owner}/{triggerMode}"', () => {
+      expect(
+        createCloseOrderIdentityHash({
+          protocol: 'uniswapv3-vault',
+          chainId: CHAIN_ID,
+          vaultAddress: VAULT_CHECKSUMMED,
+          ownerAddress: OWNER_CHECKSUMMED,
+          triggerMode: ContractTriggerMode.LOWER,
+        }),
+      ).toBe(
+        `uniswapv3-vault/42161/${VAULT_CHECKSUMMED}/${OWNER_CHECKSUMMED}/0`,
+      );
+    });
+
+    it('normalizes addresses to EIP-55, whatever casing the caller passes', () => {
+      const fromLowercase = createCloseOrderIdentityHash({
+        protocol: 'uniswapv3-vault',
+        chainId: CHAIN_ID,
+        vaultAddress: VAULT_CHECKSUMMED.toLowerCase(),
+        ownerAddress: OWNER_CHECKSUMMED.toLowerCase(),
+        triggerMode: ContractTriggerMode.UPPER,
+      });
+      const fromChecksummed = createCloseOrderIdentityHash({
+        protocol: 'uniswapv3-vault',
+        chainId: CHAIN_ID,
+        vaultAddress: VAULT_CHECKSUMMED,
+        ownerAddress: OWNER_CHECKSUMMED,
+        triggerMode: ContractTriggerMode.UPPER,
+      });
+
+      expect(fromLowercase).toBe(fromChecksummed);
+      expect(fromLowercase).toContain(VAULT_CHECKSUMMED);
+      expect(fromLowercase).toContain(OWNER_CHECKSUMMED);
+    });
+
+    it('separates owners on the same vault — two holders, two slots', () => {
+      const other = '0xaf88d065e77c8cC2239327C5EDb3A432268e5831';
+
+      const first = createCloseOrderIdentityHash({
+        protocol: 'uniswapv3-vault',
+        chainId: CHAIN_ID,
+        vaultAddress: VAULT_CHECKSUMMED,
+        ownerAddress: OWNER_CHECKSUMMED,
+        triggerMode: ContractTriggerMode.LOWER,
+      });
+      const second = createCloseOrderIdentityHash({
+        protocol: 'uniswapv3-vault',
+        chainId: CHAIN_ID,
+        vaultAddress: VAULT_CHECKSUMMED,
+        ownerAddress: other,
+        triggerMode: ContractTriggerMode.LOWER,
+      });
+
+      expect(first).not.toBe(second);
+    });
+
+    it('separates trigger modes — one LOWER and one UPPER slot per position', () => {
+      const lower = createCloseOrderIdentityHash({
+        protocol: 'uniswapv3-vault',
+        chainId: CHAIN_ID,
+        vaultAddress: VAULT_CHECKSUMMED,
+        ownerAddress: OWNER_CHECKSUMMED,
+        triggerMode: ContractTriggerMode.LOWER,
+      });
+      const upper = createCloseOrderIdentityHash({
+        protocol: 'uniswapv3-vault',
+        chainId: CHAIN_ID,
+        vaultAddress: VAULT_CHECKSUMMED,
+        ownerAddress: OWNER_CHECKSUMMED,
+        triggerMode: ContractTriggerMode.UPPER,
+      });
+
+      expect(lower).not.toBe(upper);
+    });
+
+    it('matches the address casing of the vault position hash', () => {
+      // Position hash: uniswapv3-vault/{chainId}/{vaultAddress}/{ownerAddress}
+      const positionHash = `uniswapv3-vault/${CHAIN_ID}/${VAULT_CHECKSUMMED}/${OWNER_CHECKSUMMED}`;
+      const identityHash = createCloseOrderIdentityHash({
+        protocol: 'uniswapv3-vault',
+        chainId: CHAIN_ID,
+        vaultAddress: VAULT_CHECKSUMMED.toLowerCase(),
+        ownerAddress: OWNER_CHECKSUMMED.toLowerCase(),
+        triggerMode: ContractTriggerMode.LOWER,
+      });
+
+      expect(identityHash).toBe(`${positionHash}/0`);
+    });
+
+    it('throws when the owner address is missing', () => {
+      expect(() =>
+        createCloseOrderIdentityHash({
+          protocol: 'uniswapv3-vault',
+          chainId: CHAIN_ID,
+          vaultAddress: VAULT_CHECKSUMMED,
+          ownerAddress: '',
+          triggerMode: ContractTriggerMode.LOWER,
+        }),
+      ).toThrow(/requires vaultAddress and ownerAddress/);
+    });
+
+    it('throws on a malformed address rather than storing it', () => {
+      expect(() =>
+        createCloseOrderIdentityHash({
+          protocol: 'uniswapv3-vault',
+          chainId: CHAIN_ID,
+          vaultAddress: '0xnope',
+          ownerAddress: OWNER_CHECKSUMMED,
+          triggerMode: ContractTriggerMode.LOWER,
+        }),
+      ).toThrow();
+    });
+  });
+});

--- a/packages/midcurve-services/src/utils/automation/close-order-identity.ts
+++ b/packages/midcurve-services/src/utils/automation/close-order-identity.ts
@@ -1,0 +1,79 @@
+/**
+ * Close Order Identity Hash
+ *
+ * The identity of a close order is the pair (position, triggerMode). The hash
+ * encodes only what determines the position, plus the trigger mode:
+ *
+ * - NFT:   "uniswapv3/{chainId}/{nftId}/{triggerMode}"
+ * - Vault: "uniswapv3-vault/{chainId}/{vaultAddress}/{ownerAddress}/{triggerMode}"
+ *
+ * A vault is an ERC-20 whose shares can be held by several owners, each able to
+ * hold their own orders — so the vault discriminator comprises vault address AND
+ * owner address, matching the vault position hash
+ * "uniswapv3-vault/{chainId}/{vaultAddress}/{ownerAddress}".
+ *
+ * Addresses are EIP-55 checksummed, exactly as in the position hash. This is the
+ * single place where that normalization happens: every writer of a CloseOrder row
+ * (the on-chain event rule and UniswapV3CloseOrderService.refresh()) must go
+ * through here, or the same slot ends up with two differently-cased hashes and
+ * collides on the @@unique([positionId, closeOrderHash]) constraint.
+ */
+
+import { normalizeAddress } from '@midcurve/shared';
+import type { ContractTriggerMode } from '@midcurve/shared';
+
+/** Identity components for a UniswapV3 NFT close order */
+export interface NftCloseOrderIdentity {
+  protocol: 'uniswapv3';
+  chainId: number;
+  nftId: string | number;
+  triggerMode: ContractTriggerMode | number;
+}
+
+/** Identity components for a UniswapV3 vault close order */
+export interface VaultCloseOrderIdentity {
+  protocol: 'uniswapv3-vault';
+  chainId: number;
+  vaultAddress: string;
+  ownerAddress: string;
+  triggerMode: ContractTriggerMode | number;
+}
+
+export type CloseOrderIdentity = NftCloseOrderIdentity | VaultCloseOrderIdentity;
+
+/**
+ * Builds the unique identity hash for a close order.
+ *
+ * @throws if a vault identity is missing the vault or owner address, or if either
+ *         address is not a valid EVM address (normalizeAddress throws)
+ */
+export function createCloseOrderIdentityHash(identity: CloseOrderIdentity): string {
+  if (identity.protocol === 'uniswapv3-vault') {
+    const { chainId, vaultAddress, ownerAddress, triggerMode } = identity;
+
+    if (!vaultAddress || !ownerAddress) {
+      throw new Error(
+        `Vault close order identity requires vaultAddress and ownerAddress ` +
+          `(chainId=${chainId}, triggerMode=${triggerMode})`,
+      );
+    }
+
+    return [
+      'uniswapv3-vault',
+      chainId,
+      normalizeAddress(vaultAddress),
+      normalizeAddress(ownerAddress),
+      triggerMode,
+    ].join('/');
+  }
+
+  const { chainId, nftId, triggerMode } = identity;
+
+  if (nftId === undefined || nftId === null || nftId === '') {
+    throw new Error(
+      `NFT close order identity requires nftId (chainId=${chainId}, triggerMode=${triggerMode})`,
+    );
+  }
+
+  return ['uniswapv3', chainId, nftId, triggerMode].join('/');
+}

--- a/packages/midcurve-services/src/utils/automation/index.ts
+++ b/packages/midcurve-services/src/utils/automation/index.ts
@@ -3,4 +3,5 @@
  */
 
 export * from './close-order-hash.js';
+export * from './close-order-identity.js';
 export * from './order-tag.js';


### PR DESCRIPTION
Closes #77

Vault close orders now reach the database. Implemented per the decisions in [this comment](https://github.com/0xNedAlbo/midcurve-finance/issues/77#issuecomment-5225632075).

## What was broken

`processEvent` switched on the full event type string and matched only `close-order.*.uniswapv3`. Every `…-vault` event fell through to `default` → `warn` → **`ack`**: acknowledged and discarded, never reaching `resolveOrder` or `handleRegistered`. The queue was also declared without `x-dead-letter-exchange`, so the `nack` path in the catch block dropped messages as well. Nothing surfaced either loss.

## Commits

| Commit | Scope |
|---|---|
| `8bc5f7bb` | `@midcurve/services` — shared identity + routing helpers, `upsertByIdentityHash`, shares typing, close-order DLX |
| `0fab181e` | business-logic — the actual fix, plus tests |
| `c4ae2bc6` | onchain-data — fallback poller and catch-up cover the vault closer |
| `ac9bd6a7` | api — single vault close-order endpoint |
| `34de883b` | review: restore per-event isolation in the poll loop |
| `9941038d` | review: keep `sharesClosed` in the vault execution log |
| `c1b5b0d4` | review: correct the v1 queue note — it fills, it does not drain |

## Decisions applied

- **Q1 — EIP-55.** `createCloseOrderIdentityHash()` is the one place that decides the hash shape and normalizes addresses; `refresh()` now calls it instead of lowercasing its own template literal. NFT hashes contain no address and are untouched.
- **Q2 — disposition split.** *Understood, doesn't concern us* (no matching position, no matching order) → `info` + ack. *Cannot be interpreted* (unknown type, missing identifiers, ambiguous position) → `error` + DLQ. An untracked share holder is the normal case for a vault, so it does not log at `warn`.
- **Q4 — `OrderSharesUpdated` handled**, merging `state.shares` (string, per the bigint rule) and writing an `ORDER_MODIFIED` log entry.
- **Q5 — `OrderExecuted` added to the poller's topic filter.** It was missing for *both* protocols, so the fallback path had never replayed an execution.
- **Q6 — new queue name.** `…-process-close-order-events.v2`, with `x-dead-letter-exchange` → `close-order-events-dlx` → `…-process-close-order-events.dlq` (7-day TTL). The v1 queue must be deleted at deploy time — it fills rather than drains, see deploy steps.
- **Q7 — asymmetry kept.** The rule still does not set `sharedContractId`; NFT behaviour unchanged. Filed as follow-up.
- **Q8 — new endpoint normalizes its path addresses.** Siblings unchanged; filed as follow-up.
- **R2 — registration is an upsert.** `upsertByIdentityHash()` states the operation as "this slot now holds this order", so whichever of the two writers wins the race, the slot ends up with the same content. No `try/catch`, no P2002 handling.
- **R4 — out of scope.** No dedupe key on the automation log. Filed as follow-up.

Also injected the rule's collaborators (defaults unchanged in production) — constructing `UniswapV3PositionService` calls `EvmConfig.getInstance()`, which throws without `initAppConfig()`, so the rule was untestable otherwise.

## Verification

- `pnpm typecheck` — 14/14 tasks pass
- `pnpm build` — 11/11 pass; the new route appears in the API route table
- business-logic: 36 tests pass (24 new)
- services: 199 tests pass (10 new on the identity helper)

The new rule tests map onto the acceptance criteria: one row with `protocol: 'uniswapv3-vault'` linked to the right position (1); two owners on one vault get separate slots, and LOWER/UPPER stay separate (2); re-registration replaces (3); cancel and execute delete the row, log, and drop the subscription (4, 5); all seven update events land in `state` (6); a replayed registration creates nothing (7); an uninterpretable message nacks while an understood-but-not-ours message acks (10). Plus: `sharesClosed` reaches the execution log context for a vault order and is omitted entirely for an NFT one, the order tag is built from the vault position service rather than the NFT one, and the NFT identity hash is pinned unchanged.

**AC 8 is not unit-tested** — the fallback poller needs a chain. Manual verification steps are below; I have not run them yet.

## Deploy steps

Both are required. Neither is hygiene.

### 1. Delete legacy vault close-order rows — before or with the deploy, never after

```sql
DELETE FROM close_orders WHERE protocol = 'uniswapv3-vault';
```

This is load-bearing. `upsertByIdentityHash` keys on `orderIdentityHash`, but the collision risk sits on the *other* constraint, `@@unique([positionId, closeOrderHash])`. A legacy lowercase row is invisible to the upsert's key, so the upsert inserts a second row for the same slot and then dies on `positionId + closeOrderHash` — dead-lettered, and dead-lettered again on every replay. The upsert protects against the race between the two writers; it does not protect against the old data. Rows deleted here are re-derived by `refresh()`, which is why deleting them is safe.

Scoped to `protocol = 'uniswapv3-vault'` on purpose — NFT identity hashes contain no address and must not be touched. The dev database holds zero close-order rows of either protocol.

### 2. Delete the v1 queue

```
rabbitmqadmin delete queue name=business-logic.uniswapv3-process-close-order-events
```

The v1 queue does **not** drain. It is durable, `autoDelete: false`, and still bound to `close-order-events` with both routing patterns; a topic exchange delivers to every matching binding, so from the moment the service moves to `.v2` the old queue receives every close-order event with nobody consuming it, and grows until the disk does. Do this at deploy time, not "eventually".

Not done from code on purpose: deleting a queue that may still hold unprocessed v1 messages is destructive, and mid-rolling-deploy is the worst moment to decide that. Say the word if you would rather the rule unbind it at startup.

## Manual verification still owed (AC 8 + Q3)

On Arbitrum against `UniswapV3VaultPositionCloser` `0x13d13B15BbE9b06C0279a7aB5f0a898EA3f25A40`:

1. Register a stop-loss on a vault position through the wizard → confirm exactly one `close_orders` row with `protocol='uniswapv3-vault'` and an EIP-55 identity hash.
2. Register directly against the contract, without the UI, and wait for a poll cycle → confirm the row appears (AC 8).
3. While doing so, record whether the reconciliation path (`UniswapV3VaultPositionService.refresh()` → `closeOrderService.refresh()`) also produces the row. Its `catch` downgrades any failure to a `warn`, and per Q3 we left that behaviour alone — this settles empirically whether a second bug hides there.
4. Confirm the dead-letter path end to end by publishing an uninterpretable message to `close-order-events` and checking it lands in `…-process-close-order-events.dlq`. `onStartup` is the one part of the DLX wiring no test covers.

I will post the results on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
