### PR TITLE
fix: resolve vault positions from lowercase addresses in the path

### DIFF
--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/apr/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/apr/route.ts
@@ -16,6 +16,7 @@ import {
   ErrorCodeToHttpStatus,
   GetUniswapV3VaultPositionParamsSchema,
 } from '@midcurve/api-shared';
+import { UniswapV3VaultPosition } from '@midcurve/shared';
 import type { AprPeriodsResponse, AprPeriodData, AprSummaryData } from '@midcurve/api-shared';
 import { serializeBigInt } from '@/lib/serializers';
 import { apiLogger, apiLog } from '@/lib/logger';
@@ -48,7 +49,7 @@ export async function GET(
       }
 
       const { chainId, vaultAddress, ownerAddress } = validation.data;
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
 
       const dbPosition = await getUniswapV3VaultPositionService().findByPositionHash(user.id, positionHash);
 

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/close-orders/[closeOrderHash]/automation-state/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/close-orders/[closeOrderHash]/automation-state/route.ts
@@ -9,7 +9,6 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
 import { withAuth } from '@/middleware/with-auth';
 import {
   createSuccessResponse,
@@ -18,7 +17,9 @@ import {
   ErrorCodeToHttpStatus,
   CloseOrderHashSchema,
   SetAutomationStateBodySchema,
+  GetUniswapV3VaultPositionParamsSchema,
 } from '@midcurve/api-shared';
+import { UniswapV3VaultPosition } from '@midcurve/shared';
 import { serializeCloseOrder } from '@/lib/serializers';
 import { apiLogger, apiLog } from '@/lib/logger';
 import {
@@ -30,10 +31,11 @@ import { createPreflightResponse } from '@/lib/cors';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-const PathParamsSchema = z.object({
-  chainId: z.string().regex(/^\d+$/).transform(Number),
-  vaultAddress: z.string().regex(/^0x[0-9a-fA-F]{40}$/),
-  ownerAddress: z.string().regex(/^0x[0-9a-fA-F]{40}$/),
+/**
+ * The shared vault position path (which normalizes both addresses to EIP-55)
+ * plus the close order identifier.
+ */
+const PathParamsSchema = GetUniswapV3VaultPositionParamsSchema.extend({
   closeOrderHash: CloseOrderHashSchema,
 });
 
@@ -74,7 +76,7 @@ export async function PATCH(
       const { chainId, vaultAddress, ownerAddress, closeOrderHash } = paramsValidation.data;
       const { automationState } = bodyValidation.data;
 
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
       const position = await getUniswapV3VaultPositionService().findByPositionHash(
         user.id,
         positionHash

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/close-orders/[closeOrderHash]/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/close-orders/[closeOrderHash]/route.ts
@@ -14,7 +14,6 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { z } from 'zod';
 import { withAuth } from '@/middleware/with-auth';
 import {
   createSuccessResponse,
@@ -22,8 +21,9 @@ import {
   ApiErrorCode,
   ErrorCodeToHttpStatus,
   CloseOrderHashSchema,
+  GetUniswapV3VaultPositionParamsSchema,
 } from '@midcurve/api-shared';
-import { normalizeAddress } from '@midcurve/shared';
+import { UniswapV3VaultPosition } from '@midcurve/shared';
 import { serializeCloseOrder } from '@/lib/serializers';
 import { apiLogger, apiLog } from '@/lib/logger';
 import {
@@ -36,22 +36,13 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 /**
- * Path params schema.
+ * The shared vault position path (which normalizes both addresses to EIP-55)
+ * plus the close order identifier.
  *
- * Addresses are normalized to EIP-55 so a lowercase address in the URL resolves
- * the same position as a checksummed one — the position hash is built from
- * checksummed addresses.
+ * This route introduced the normalization in #78 with its own copy of the
+ * schema; #80 moved it into the shared one, so the copy is gone.
  */
-const PathParamsSchema = z.object({
-  chainId: z.string().regex(/^\d+$/).transform(Number),
-  vaultAddress: z
-    .string()
-    .regex(/^0x[0-9a-fA-F]{40}$/)
-    .transform((value) => normalizeAddress(value)),
-  ownerAddress: z
-    .string()
-    .regex(/^0x[0-9a-fA-F]{40}$/)
-    .transform((value) => normalizeAddress(value)),
+const PathParamsSchema = GetUniswapV3VaultPositionParamsSchema.extend({
   closeOrderHash: CloseOrderHashSchema,
 });
 
@@ -114,7 +105,7 @@ export async function GET(
         paramsValidation.data;
 
       // 2. Find vault position by positionHash
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
       const position = await getUniswapV3VaultPositionService().findByPositionHash(
         user.id,
         positionHash

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/close-orders/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/close-orders/route.ts
@@ -14,7 +14,9 @@ import {
   createErrorResponse,
   ApiErrorCode,
   ErrorCodeToHttpStatus,
+  GetUniswapV3VaultPositionParamsSchema,
 } from '@midcurve/api-shared';
+import { UniswapV3VaultPosition } from '@midcurve/shared';
 import { serializeCloseOrder } from '@/lib/serializers';
 import { apiLogger, apiLog } from '@/lib/logger';
 import { getUniswapV3CloseOrderService, getUniswapV3VaultPositionService } from '@/lib/services';
@@ -22,15 +24,6 @@ import { createPreflightResponse } from '@/lib/cors';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
-
-/**
- * Path params schema
- */
-const PathParamsSchema = z.object({
-  chainId: z.string().regex(/^\d+$/).transform(Number),
-  vaultAddress: z.string().regex(/^0x[0-9a-fA-F]{40}$/),
-  ownerAddress: z.string().regex(/^0x[0-9a-fA-F]{40}$/),
-});
 
 /**
  * Query params schema for filtering
@@ -73,7 +66,8 @@ export async function GET(
     try {
       // 1. Parse and validate path parameters
       const resolvedParams = await params;
-      const paramsValidation = PathParamsSchema.safeParse(resolvedParams);
+      const paramsValidation =
+        GetUniswapV3VaultPositionParamsSchema.safeParse(resolvedParams);
 
       if (!paramsValidation.success) {
         apiLog.validationError(apiLogger, requestId, paramsValidation.error.errors);
@@ -120,7 +114,7 @@ export async function GET(
       const { automationState, type } = queryValidation.data;
 
       // 3. Find vault position by positionHash
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
       const position = await getUniswapV3VaultPositionService().findByPositionHash(
         user.id,
         positionHash

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/conversion/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/conversion/route.ts
@@ -26,6 +26,7 @@ import {
   adaptVaultEventsForConversion,
   type ConversionPositionInput,
   type VaultLedgerEventInput,
+  UniswapV3VaultPosition,
 } from '@midcurve/shared';
 import { serializeUniswapV3VaultPosition } from '@/lib/serializers';
 import { apiLogger, apiLog } from '@/lib/logger';
@@ -70,7 +71,7 @@ export async function GET(
       }
 
       const { chainId, vaultAddress, ownerAddress } = validation.data;
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
 
       const dbPosition = await getUniswapV3VaultPositionService().findByPositionHash(
         user.id,

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/ledger/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/ledger/route.ts
@@ -16,6 +16,7 @@ import {
   ErrorCodeToHttpStatus,
   GetUniswapV3VaultPositionParamsSchema,
 } from '@midcurve/api-shared';
+import { UniswapV3VaultPosition } from '@midcurve/shared';
 import type { LedgerEventsResponse, LedgerEventData } from '@midcurve/api-shared';
 import { apiLogger, apiLog } from '@/lib/logger';
 import { getUniswapV3VaultPositionService, getUniswapV3VaultLedgerService } from '@/lib/services';
@@ -46,7 +47,7 @@ export async function GET(
       }
 
       const { chainId, vaultAddress, ownerAddress } = validation.data;
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
 
       const dbPosition = await getUniswapV3VaultPositionService().findByPositionHash(user.id, positionHash);
 

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/pnl-curve/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/pnl-curve/route.ts
@@ -24,6 +24,7 @@ import {
   pricePerToken1InToken0,
   type Erc20Token,
   type UniswapV3Pool,
+  UniswapV3VaultPosition,
 } from '@midcurve/shared';
 import { apiLogger, apiLog } from '@/lib/logger';
 import { getUniswapV3VaultPositionService } from '@/lib/services';
@@ -80,7 +81,7 @@ export async function GET(
       }
 
       const { chainId, vaultAddress, ownerAddress } = pathValidation.data;
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
 
       const dbPosition = await getUniswapV3VaultPositionService().findByPositionHash(
         user.id,

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/refresh/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/refresh/route.ts
@@ -16,6 +16,7 @@ import {
   ErrorCodeToHttpStatus,
   GetUniswapV3VaultPositionParamsSchema,
 } from '@midcurve/api-shared';
+import { UniswapV3VaultPosition } from '@midcurve/shared';
 import { serializeUniswapV3VaultPosition } from '@/lib/serializers';
 import { apiLogger, apiLog } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
@@ -53,7 +54,7 @@ export async function POST(
       }
 
       const { chainId, vaultAddress, ownerAddress } = validation.data;
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
 
       const result = await prisma.$transaction(async (tx) => {
         const dbPosition = await getUniswapV3VaultPositionService().findByPositionHash(user.id, positionHash, tx);

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/reload-history/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/reload-history/route.ts
@@ -18,6 +18,7 @@ import {
   ErrorCodeToHttpStatus,
   GetUniswapV3VaultPositionParamsSchema,
 } from '@midcurve/api-shared';
+import { UniswapV3VaultPosition } from '@midcurve/shared';
 import type { UniswapV3VaultPositionResponse } from '@midcurve/api-shared';
 import { serializeUniswapV3VaultPosition } from '@/lib/serializers';
 import { apiLogger, apiLog } from '@/lib/logger';
@@ -50,7 +51,7 @@ export async function POST(
       }
 
       const { chainId, vaultAddress, ownerAddress } = validation.data;
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
 
       const dbPosition = await getUniswapV3VaultPositionService().findByPositionHash(user.id, positionHash);
 

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/route.ts
@@ -17,6 +17,7 @@ import {
   ErrorCodeToHttpStatus,
   GetUniswapV3VaultPositionParamsSchema,
 } from '@midcurve/api-shared';
+import { UniswapV3VaultPosition } from '@midcurve/shared';
 import { serializeUniswapV3VaultPosition } from '@/lib/serializers';
 import { apiLogger, apiLog } from '@/lib/logger';
 import { prisma } from '@/lib/prisma';
@@ -64,7 +65,7 @@ export async function GET(
       }
 
       const { chainId, vaultAddress, ownerAddress } = validation.data;
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
 
       apiLog.businessOperation(apiLogger, requestId, 'lookup', 'vault-position', positionHash, {
         chainId,
@@ -175,7 +176,7 @@ export async function DELETE(
       }
 
       const { chainId, vaultAddress, ownerAddress } = validation.data;
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
 
       const dbPosition = await getUniswapV3VaultPositionService().findByPositionHash(user.id, positionHash);
 

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/simulate/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/simulate/route.ts
@@ -25,6 +25,7 @@ import {
   priceToSqrtRatioX96,
   tickToSqrtRatioX96,
   type Erc20Token,
+  UniswapV3VaultPosition,
 } from '@midcurve/shared';
 import { apiLogger, apiLog } from '@/lib/logger';
 import { getUniswapV3VaultPositionService } from '@/lib/services';
@@ -79,7 +80,7 @@ export async function GET(
 
       const { chainId, vaultAddress, ownerAddress } = pathValidation.data;
       const price = BigInt(queryValidation.data.price);
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
 
       const dbPosition = await getUniswapV3VaultPositionService().findByPositionHash(
         user.id,

--- a/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/switch-quote-token/route.ts
+++ b/apps/midcurve-api/src/app/api/v1/positions/uniswapv3-vault/[chainId]/[vaultAddress]/[ownerAddress]/switch-quote-token/route.ts
@@ -18,6 +18,7 @@ import {
   ErrorCodeToHttpStatus,
   GetUniswapV3VaultPositionParamsSchema,
 } from '@midcurve/api-shared';
+import { UniswapV3VaultPosition } from '@midcurve/shared';
 import type { UniswapV3VaultPositionResponse } from '@midcurve/api-shared';
 import { serializeUniswapV3VaultPosition } from '@/lib/serializers';
 import { apiLogger, apiLog } from '@/lib/logger';
@@ -50,7 +51,7 @@ export async function POST(
       }
 
       const { chainId, vaultAddress, ownerAddress } = validation.data;
-      const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${ownerAddress}`;
+      const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
 
       const dbPosition = await getUniswapV3VaultPositionService().findByPositionHash(user.id, positionHash);
 

--- a/packages/midcurve-api-shared/src/types/positions/uniswapv3-vault/get.test.ts
+++ b/packages/midcurve-api-shared/src/types/positions/uniswapv3-vault/get.test.ts
@@ -1,0 +1,117 @@
+/**
+ * GetUniswapV3VaultPositionParamsSchema
+ *
+ * The path params for every vault route. Addresses must come out EIP-55
+ * checksummed whatever case they went in as — the stored positionHash is
+ * checksummed, so an un-normalized param resolves nothing and 404s (#80).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { GetUniswapV3VaultPositionParamsSchema } from './get.js';
+
+const VAULT_CHECKSUMMED = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const VAULT_LOWERCASE = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+const VAULT_UPPERCASE = '0xC02AAA39B223FE8D0A0E5C4F27EAD9083C756CC2';
+
+const OWNER_CHECKSUMMED = '0x1F98431c8aD98523631AE4a59f267346ea31F984';
+const OWNER_LOWERCASE = '0x1f98431c8ad98523631ae4a59f267346ea31f984';
+
+const parse = (params: Record<string, string>) =>
+  GetUniswapV3VaultPositionParamsSchema.safeParse(params);
+
+describe('GetUniswapV3VaultPositionParamsSchema', () => {
+  describe('address normalization', () => {
+    it('normalizes lowercase addresses to EIP-55', () => {
+      const result = parse({
+        chainId: '42161',
+        vaultAddress: VAULT_LOWERCASE,
+        ownerAddress: OWNER_LOWERCASE,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toEqual({
+        chainId: 42161,
+        vaultAddress: VAULT_CHECKSUMMED,
+        ownerAddress: OWNER_CHECKSUMMED,
+      });
+    });
+
+    it('normalizes uppercase-hex addresses to EIP-55', () => {
+      const result = parse({
+        chainId: '42161',
+        vaultAddress: VAULT_UPPERCASE,
+        ownerAddress: OWNER_LOWERCASE,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.vaultAddress).toBe(VAULT_CHECKSUMMED);
+    });
+
+    it('leaves already-checksummed addresses unchanged', () => {
+      const result = parse({
+        chainId: '42161',
+        vaultAddress: VAULT_CHECKSUMMED,
+        ownerAddress: OWNER_CHECKSUMMED,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.vaultAddress).toBe(VAULT_CHECKSUMMED);
+      expect(result.data?.ownerAddress).toBe(OWNER_CHECKSUMMED);
+    });
+
+    it('normalizes each address independently', () => {
+      const result = parse({
+        chainId: '42161',
+        vaultAddress: VAULT_LOWERCASE,
+        ownerAddress: OWNER_CHECKSUMMED,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.vaultAddress).toBe(VAULT_CHECKSUMMED);
+      expect(result.data?.ownerAddress).toBe(OWNER_CHECKSUMMED);
+    });
+
+    it('re-checksums a wrong-checksum address rather than rejecting it', () => {
+      // normalizeAddress() validates case-insensitively, so the EIP-55
+      // checksum is not used as an integrity check here. Documented, not
+      // accidental — nothing in this system treats it as one.
+      const wrongChecksum = '0xc02AAA39B223FE8D0a0E5c4f27EaD9083c756cC2';
+      const result = parse({
+        chainId: '42161',
+        vaultAddress: wrongChecksum,
+        ownerAddress: OWNER_LOWERCASE,
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.data?.vaultAddress).toBe(VAULT_CHECKSUMMED);
+    });
+  });
+
+  describe('rejects malformed input with a validation error, not a throw', () => {
+    it.each([
+      ['too short', '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc'],
+      ['too long', '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc22'],
+      ['non-hex characters', '0xzzzzzz39b223fe8d0a0e5c4f27ead9083c756cc2'],
+      ['missing 0x prefix', 'c02aaa39b223fe8d0a0e5c4f27ead9083c756cc2'],
+      ['empty', ''],
+    ])('vaultAddress %s', (_label, vaultAddress) => {
+      const result = parse({
+        chainId: '42161',
+        vaultAddress,
+        ownerAddress: OWNER_LOWERCASE,
+      });
+
+      expect(result.success).toBe(false);
+    });
+
+    it.each(['0', '-1', 'abc', ''])('chainId %s', (chainId) => {
+      const result = parse({
+        chainId,
+        vaultAddress: VAULT_LOWERCASE,
+        ownerAddress: OWNER_LOWERCASE,
+      });
+
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/packages/midcurve-api-shared/src/types/positions/uniswapv3-vault/get.ts
+++ b/packages/midcurve-api-shared/src/types/positions/uniswapv3-vault/get.ts
@@ -7,6 +7,7 @@
 
 import type { UniswapV3VaultPositionResponse } from './typed-response.js';
 import type { SerializedCloseOrder } from '../../automation/close-orders.js';
+import { normalizeAddress } from '@midcurve/shared';
 import { z } from 'zod';
 
 /**
@@ -36,7 +37,20 @@ export interface GetUniswapV3VaultPositionResponse extends UniswapV3VaultPositio
 // =============================================================================
 
 /**
- * Zod schema for validating path parameters
+ * Zod schema for validating path parameters.
+ *
+ * Addresses are normalized to EIP-55 so a lowercase address in the URL — a
+ * valid way to write an EVM address, and what most tooling produces —
+ * resolves the same position as a checksummed one.
+ *
+ * Ordering matters: `.regex()` runs before `.transform()`, and its pattern is
+ * strictly narrower than the one `normalizeAddress()` validates against. That
+ * is what keeps the throw inside the transform unreachable — a throw there
+ * would escape as a 500 rather than a 400.
+ *
+ * This is the outer guard. The inner one is
+ * `UniswapV3VaultPosition.createHash()`, which normalizes again for callers
+ * that never pass through a schema.
  */
 export const GetUniswapV3VaultPositionParamsSchema = z.object({
   chainId: z.string().transform((val, ctx) => {
@@ -53,11 +67,13 @@ export const GetUniswapV3VaultPositionParamsSchema = z.object({
 
   vaultAddress: z
     .string()
-    .regex(/^0x[0-9a-fA-F]{40}$/, 'vaultAddress must be a valid EVM address'),
+    .regex(/^0x[0-9a-fA-F]{40}$/, 'vaultAddress must be a valid EVM address')
+    .transform((value) => normalizeAddress(value)),
 
   ownerAddress: z
     .string()
-    .regex(/^0x[0-9a-fA-F]{40}$/, 'ownerAddress must be a valid EVM address'),
+    .regex(/^0x[0-9a-fA-F]{40}$/, 'ownerAddress must be a valid EVM address')
+    .transform((value) => normalizeAddress(value)),
 });
 
 export type GetUniswapV3VaultPositionParamsInput = z.input<

--- a/packages/midcurve-services/scripts/backfill-position-hash.ts
+++ b/packages/midcurve-services/scripts/backfill-position-hash.ts
@@ -9,6 +9,7 @@
  */
 
 import { PrismaClient } from '@prisma/client';
+import { UniswapV3VaultPosition } from '@midcurve/shared';
 
 const prisma = new PrismaClient();
 
@@ -47,7 +48,11 @@ async function backfillPositionHash() {
         positionHash = `uniswapv3/${config.chainId}/${config.nftId}`;
       } else if (position.protocol === 'uniswapv3-vault') {
         const config = position.config as { chainId: number; vaultAddress: string; ownerAddress: string };
-        positionHash = `uniswapv3-vault/${config.chainId}/${config.vaultAddress}/${config.ownerAddress}`;
+        positionHash = UniswapV3VaultPosition.createHash(
+          config.chainId,
+          config.vaultAddress,
+          config.ownerAddress
+        );
       } else {
         console.warn(`Unknown protocol: ${position.protocol}, skipping position ${position.id}`);
         continue;

--- a/packages/midcurve-services/src/services/position/uniswapv3-vault-position-service.ts
+++ b/packages/midcurve-services/src/services/position/uniswapv3-vault-position-service.ts
@@ -307,7 +307,7 @@ export class UniswapV3VaultPositionService {
         const vaultAddress = normalizeAddress(params.vaultAddress);
 
         // Check for existing position
-        const positionHash = `uniswapv3-vault/${chainId}/${vaultAddress}/${normalizeAddress(ownerAddress)}`;
+        const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddress, ownerAddress);
         const existing = await this.findByPositionHash(userId, positionHash, dbTx);
         if (existing) {
             return this.refresh(existing.id, 'latest', dbTx);
@@ -544,7 +544,7 @@ export class UniswapV3VaultPositionService {
             found += matchedVaults.size;
 
             for (const vaultAddr of matchedVaults) {
-                const positionHash = `uniswapv3-vault/${chainId}/${vaultAddr}/${normalizeAddress(walletAddress)}`;
+                const positionHash = UniswapV3VaultPosition.createHash(chainId, vaultAddr, walletAddress);
                 const existing = await this.findByPositionHash(userId, positionHash);
                 if (existing) {
                     skipped++;

--- a/packages/midcurve-shared/src/types/position/uniswapv3-vault/uniswapv3-vault-position.test.ts
+++ b/packages/midcurve-shared/src/types/position/uniswapv3-vault/uniswapv3-vault-position.test.ts
@@ -1,0 +1,86 @@
+/**
+ * UniswapV3VaultPosition.createHash
+ *
+ * The canonical positionHash builder. Normalizing inside the builder is the
+ * point: every construction is EIP-55 regardless of what the caller passes,
+ * including call sites no Zod schema protects (services, scripts).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { UniswapV3VaultPosition } from './uniswapv3-vault-position.js';
+
+const CHAIN_ID = 42161;
+
+// Same address in three notations. The checksummed form is the expected output.
+const VAULT_CHECKSUMMED = '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2';
+const VAULT_LOWERCASE = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+const VAULT_UPPERCASE = '0xC02AAA39B223FE8D0A0E5C4F27EAD9083C756CC2';
+
+const OWNER_CHECKSUMMED = '0x1F98431c8aD98523631AE4a59f267346ea31F984';
+const OWNER_LOWERCASE = '0x1f98431c8ad98523631ae4a59f267346ea31f984';
+
+const EXPECTED = `uniswapv3-vault/${CHAIN_ID}/${VAULT_CHECKSUMMED}/${OWNER_CHECKSUMMED}`;
+
+describe('UniswapV3VaultPosition.createHash', () => {
+  it('builds "uniswapv3-vault/{chainId}/{vault}/{owner}"', () => {
+    expect(
+      UniswapV3VaultPosition.createHash(CHAIN_ID, VAULT_CHECKSUMMED, OWNER_CHECKSUMMED)
+    ).toBe(EXPECTED);
+  });
+
+  it('normalizes lowercase addresses to EIP-55', () => {
+    expect(
+      UniswapV3VaultPosition.createHash(CHAIN_ID, VAULT_LOWERCASE, OWNER_LOWERCASE)
+    ).toBe(EXPECTED);
+  });
+
+  it('normalizes uppercase-hex addresses to EIP-55', () => {
+    expect(
+      UniswapV3VaultPosition.createHash(CHAIN_ID, VAULT_UPPERCASE, OWNER_LOWERCASE)
+    ).toBe(EXPECTED);
+  });
+
+  it('is idempotent on already-checksummed input', () => {
+    const once = UniswapV3VaultPosition.createHash(
+      CHAIN_ID,
+      VAULT_CHECKSUMMED,
+      OWNER_CHECKSUMMED
+    );
+    const twice = UniswapV3VaultPosition.createHash(
+      CHAIN_ID,
+      once.split('/')[2]!,
+      once.split('/')[3]!
+    );
+    expect(twice).toBe(once);
+  });
+
+  it('normalizes each address independently', () => {
+    expect(
+      UniswapV3VaultPosition.createHash(CHAIN_ID, VAULT_LOWERCASE, OWNER_CHECKSUMMED)
+    ).toBe(EXPECTED);
+    expect(
+      UniswapV3VaultPosition.createHash(CHAIN_ID, VAULT_CHECKSUMMED, OWNER_LOWERCASE)
+    ).toBe(EXPECTED);
+  });
+
+  it('keeps vault and owner in that order', () => {
+    const swapped = UniswapV3VaultPosition.createHash(
+      CHAIN_ID,
+      OWNER_CHECKSUMMED,
+      VAULT_CHECKSUMMED
+    );
+    expect(swapped).not.toBe(EXPECTED);
+    expect(swapped).toBe(
+      `uniswapv3-vault/${CHAIN_ID}/${OWNER_CHECKSUMMED}/${VAULT_CHECKSUMMED}`
+    );
+  });
+
+  it('throws on an invalid address rather than emitting a malformed hash', () => {
+    expect(() =>
+      UniswapV3VaultPosition.createHash(CHAIN_ID, '0xnope', OWNER_CHECKSUMMED)
+    ).toThrow(/Invalid Ethereum address/);
+    expect(() =>
+      UniswapV3VaultPosition.createHash(CHAIN_ID, VAULT_CHECKSUMMED, '')
+    ).toThrow(/Invalid Ethereum address/);
+  });
+});

--- a/packages/midcurve-shared/src/types/position/uniswapv3-vault/uniswapv3-vault-position.ts
+++ b/packages/midcurve-shared/src/types/position/uniswapv3-vault/uniswapv3-vault-position.ts
@@ -29,6 +29,7 @@ import {
 } from './uniswapv3-vault-position-state.js';
 import { calculatePositionValue } from '../../../utils/uniswapv3/liquidity.js';
 import { priceToSqrtRatioX96 } from '../../../utils/uniswapv3/price.js';
+import { normalizeAddress } from '../../../utils/evm/address.js';
 
 // ============================================================================
 // CONSTRUCTOR PARAMS
@@ -61,6 +62,31 @@ export class UniswapV3VaultPosition extends BasePosition {
     super(params);
     this._config = params.config;
     this._state = params.state;
+  }
+
+  // ============================================================================
+  // Hash builder
+  // ============================================================================
+
+  /**
+   * Canonical positionHash for vault positions.
+   *
+   * A vault holds shares for many owners, so vaultAddress alone does not
+   * disambiguate — the share holder is part of the identity.
+   *
+   * Both addresses are normalized to EIP-55 here rather than at the call
+   * sites, so a hash built from lowercase input matches one built from
+   * checksummed input. This is the single source of truth for the format;
+   * do not inline the template literal elsewhere.
+   *
+   * @throws if either address is not a valid EVM address
+   */
+  static createHash(
+    chainId: number,
+    vaultAddress: string,
+    ownerAddress: string
+  ): string {
+    return `uniswapv3-vault/${chainId}/${normalizeAddress(vaultAddress)}/${normalizeAddress(ownerAddress)}`;
   }
 
   // ============================================================================


### PR DESCRIPTION
Vault routes 404'd on a lowercase address in the path. The stored `positionHash` is EIP-55 checksummed; the routes built theirs straight from the raw path params, so a lowercase address — valid, and what most tooling emits — matched no row.

Closes #80

## Two layers, per the [decisions](https://github.com/0xNedAlbo/midcurve-finance/issues/80#issuecomment-5231005331)

**`UniswapV3VaultPosition.createHash()` (the real fix).** The format was a template literal at 17 sites — 14 routes, two service methods, one script. Only the service sites normalized, which is why the bug reproduced across a whole tree rather than in one file. The builder normalizes internally, so every construction is correct regardless of what the caller passes, including the call sites no Zod schema sits in front of. Fifteen copies of the format collapse to one — the change is a net reduction.

Modelled on `UniswapV3StakingPosition.createHash`, lifted from git history (`db9fe4b3^`) since #99 removed it, with normalization moved inside.

**The schema transform (second line of defence).** `GetUniswapV3VaultPositionParamsSchema` now normalizes both addresses. Every vault route parses through it, so all of them are fixed at the boundary too.

**Schema consolidation (Q1).** The three close-orders routes each had their own path schema — the copy #78 added, plus two that never normalized. All three now derive from the shared one. One definition of "a vault position path" instead of four.

## Verification

`pnpm typecheck` 14/14 · `pnpm build` 11/11 · all six CI suites green (shared 134, api-shared 22, mcp-server 13, services 153, business-logic 24, onchain-data 7). 21 of those tests are new.

Against the built artifacts, a lowercase, an uppercase-hex and a checksummed path all resolve to the same hash, and the builder normalizes unaided:

```
checksummed path -> uniswapv3-vault/42161/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/0x1F98431c8aD98523631AE4a59f267346ea31F984
lowercase   path -> uniswapv3-vault/42161/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/0x1F98431c8aD98523631AE4a59f267346ea31F984
uppercase   path -> uniswapv3-vault/42161/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2/0x1F98431c8aD98523631AE4a59f267346ea31F984

all three resolve to one hash: true
builder normalizes unaided: true
```

**Not run: a live HTTP request against Arbitrum.** The mechanism above is verified against the compiled packages, not through a running server with auth and a database. Flagging rather than claiming it.

## Things worth stating rather than leaving implicit

**The EIP-55 checksum is not an integrity check here.** `normalizeAddress()` validates case-insensitively, so a mixed-case address with a *wrong* checksum is silently re-checksummed rather than rejected. That is consistent with the rest of the repo, and nothing in this system treats the checksum as a guard — but it means these endpoints accept an address a checksum-validating client would reject. Pinned by a test so the behaviour is deliberate rather than incidental.

**A throw inside a Zod `.transform()` surfaces as a 500, not a 400.** `normalizeAddress()` throws on invalid input. What keeps that unreachable is ordering — `.regex()` runs first and its pattern is strictly narrower than what `normalizeAddress()` accepts. It is ordering, not belt-and-braces, so it is now a comment next to the code.

**No DB check was run**, per the decisions: the environment is frozen and will be replaced by a fresh deploy with an empty database, so a lowercase hash row could not survive even if one existed. Both writers normalize in any case, and after this change they normalize through the builder.

**`chainId` gets stricter on three routes.** The shared parser rejects `0` and negatives where the local regexes took any digit string. A 400 on nonsense input that previously became a 404.

## Deliberately not done

- **`accounting/route.ts` is untouched** — it normalizes by hand, so it is not affected by this bug, and #98 removes it. Editing a file about to be deleted buys nothing. It is the one remaining inline hash literal in the routes.
- **No route-level HTTP tests**, and no vitest bootstrap for `apps/midcurve-api` — recorded on #91 instead, as agreed.
- **`discover` routes untouched** (Q3) — safe before via the service, safe now via the builder.
- **No redirect** (Q4) — normalize silently.
- **UI and MCP URL construction untouched** — those build request paths, not position hashes.
- **No separate audit issue** for the other address-carrying schemas in `@midcurve/api-shared` — centralising hash construction covers the half that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
