### PR TITLE
DO NOT MERGE: prove the migration-chain check fails

### DIFF
--- a/.claude/commands/finish-issue.md
+++ b/.claude/commands/finish-issue.md
@@ -1,9 +1,17 @@
 The PR for issue #$ARGUMENTS has been merged into main.
 
 1. Switch to `main` and `git pull`.
-2. Delete the feature branch locally (`git branch -d <name>`) and
+2. If the pull brought new migrations —
+   `git diff --name-only ORIG_HEAD HEAD -- packages/midcurve-database/prisma/migrations/`
+   — apply them to the dev database:
+   `cd packages/midcurve-database && pnpm db:migrate:deploy`.
+   Merging a migration does not apply it anywhere. Dev drifts silently
+   after every schema change until someone runs `migrate dev` and
+   inherits the divergence. Say what was applied, or that there was
+   nothing to apply.
+3. Delete the feature branch locally (`git branch -d <name>`) and
    on the remote (`git push origin --delete <name>`).
-3. Close issue #$ARGUMENTS with a short comment: 2–3 lines
+4. Close issue #$ARGUMENTS with a short comment: 2–3 lines
    summarising what was actually delivered, plus a link to the
    merge commit or PR.
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -21,6 +21,23 @@ jobs:
       contents: read
       pull-requests: read
 
+    # Throwaway Postgres for the migration-chain verification below. Holds no
+    # data and is never seeded — the check creates and drops its own database.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -38,6 +55,15 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Does applying the checked-in migrations to an empty database produce the
+      # schema the client expects? Hand-written migrations are standing practice
+      # here, so this is the expected failure of the workflow rather than a rare
+      # one. Runs before the build for fast feedback; it needs only the schema.
+      - name: Verify migration chain
+        run: pnpm --filter @midcurve/database db:migrate:verify
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
 
       - name: Build
         run: pnpm build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,8 +41,8 @@ pnpm db:migrate:verify  # Does the chain reproduce schema.prisma from empty?
 pnpm db:studio          # Inspect database
 ```
 
-Run `db:migrate:verify` after creating a migration and before applying the chain
-to any empty database. `prisma migrate status` does not report database-only
+`db:migrate:verify` runs on every PR; run it locally after writing a migration
+to get the answer sooner. `prisma migrate status` does not report database-only
 migration rows, so a clean status is not evidence of a clean history — see
 [docs/architecture.md](docs/architecture.md), "Verifying the migration chain".
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,14 @@ cd apps/midcurve-contracts && forge build  # Solidity contracts
 ```bash
 cd packages/midcurve-database
 pnpm db:migrate:dev --name migration_name
-pnpm db:studio  # Inspect database
+pnpm db:migrate:verify  # Does the chain reproduce schema.prisma from empty?
+pnpm db:studio          # Inspect database
 ```
+
+Run `db:migrate:verify` after creating a migration and before applying the chain
+to any empty database. `prisma migrate status` does not report database-only
+migration rows, so a clean status is not evidence of a clean history — see
+[docs/architecture.md](docs/architecture.md), "Verifying the migration chain".
 
 ## Architecture Docs
 For detailed architecture, auth flows, and design decisions:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -768,12 +768,56 @@ cd packages/midcurve-database
 # Edit prisma/schema.prisma
 pnpm db:migrate:dev --name your_migration_name
 
+# Verify the chain still reproduces the schema from empty
+pnpm db:migrate:verify
+
 # Changes immediately available via workspace linking
 # All apps automatically use the updated client
 
 # Run Prisma Studio to inspect database
 pnpm db:studio
 ```
+
+#### Verifying the migration chain
+
+`pnpm db:migrate:verify` applies every checked-in migration to a throwaway
+database and diffs the result against `schema.prisma`, exiting non-zero if they
+differ. It answers the only question that matters about the migration folder:
+**does applying it to an empty database produce the schema the client expects?**
+
+Run it:
+
+- after creating a migration, especially a hand-written one
+- before applying the chain to any empty database (a fresh deploy, a new dev
+  machine, CI)
+- after rebasing a branch onto a `main` that gained migrations
+
+It needs `psql` and a `DATABASE_URL` whose role may `CREATE DATABASE`. The
+throwaway database is created and dropped by the script; `DATABASE_URL` itself
+is only read.
+
+#### Two things `prisma migrate` will not tell you
+
+**`migrate status` does not report database-only migrations.** If
+`_prisma_migrations` holds a row with no corresponding folder, `migrate status`
+prints `Database schema is up to date!` and says nothing — *unless* a local
+migration also happens to be unapplied, at which point it reports both. A clean
+`migrate status` is therefore not evidence of a clean history. This reproduces
+on a freshly created, provably correct database, so it is a property of the
+tool, not a symptom of a damaged one. `db:migrate:verify` is the check that
+does not have this blind spot. (Found in #105.)
+
+**A database-only migration row cannot be removed with `migrate resolve`.**
+`--rolled-back` fails with `P3012` ("not in a failed state") because the row
+records a success, and `--applied` is for the opposite case — a folder with no
+row. Deleting the row directly is the supported route, not a workaround:
+
+```sql
+DELETE FROM _prisma_migrations WHERE migration_name = '<name>';
+```
+
+Verify with `db:migrate:verify` before doing this, so you know the chain still
+reproduces the schema without whatever the row claimed to have applied.
 
 **Docker Deployment:**
 ```bash
@@ -788,6 +832,10 @@ npx prisma migrate deploy --schema=./packages/midcurve-database/prisma/schema.pr
 - **Development:** `pnpm db:migrate:dev` in midcurve-database package
 - **Production/Docker:** `prisma migrate deploy` in Dockerfile or entrypoint
 - **Safety:** `prisma migrate deploy` is idempotent (safe to run on every deployment)
+- **After merging a migration:** run `pnpm db:migrate:deploy` against your dev
+  database. A merged migration is not applied anywhere by merging it, and dev
+  drifts silently until someone runs `migrate dev` and inherits the divergence.
+  This is a step in `.claude/commands/finish-issue.md`.
 
 ### 3. Workspace Protocol for Package Linking
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -785,16 +785,22 @@ database and diffs the result against `schema.prisma`, exiting non-zero if they
 differ. It answers the only question that matters about the migration folder:
 **does applying it to an empty database produce the schema the client expects?**
 
-Run it:
+**It runs on every PR** (`.github/workflows/pr-tests.yml`, against a Postgres
+service container), so the chain is verified without anyone remembering to. Run
+it locally when you want the answer before pushing — after creating a migration,
+especially a hand-written one, or after rebasing onto a `main` that gained
+migrations.
 
-- after creating a migration, especially a hand-written one
-- before applying the chain to any empty database (a fresh deploy, a new dev
-  machine, CI)
-- after rebasing a branch onto a `main` that gained migrations
+Hand-written migrations are standing practice here, which is why this is a CI
+check rather than a documented command: the drift it catches is the expected
+failure of the workflow, not a rare one, and a manual check is at its least
+likely to be run on the largest migration.
 
 It needs `psql` and a `DATABASE_URL` whose role may `CREATE DATABASE`. The
-throwaway database is created and dropped by the script; `DATABASE_URL` itself
-is only read.
+throwaway database is created and dropped by the script — including on the drift
+path and on an interrupted run — and `DATABASE_URL` itself is only read. A run
+killed outright leaves the database behind; the next run drops it before
+starting, so it self-heals rather than accumulating.
 
 #### Two things `prisma migrate` will not tell you
 

--- a/packages/midcurve-database/package.json
+++ b/packages/midcurve-database/package.json
@@ -16,6 +16,7 @@
     "db:generate": "prisma generate",
     "db:migrate:dev": "prisma migrate dev",
     "db:migrate:deploy": "prisma migrate deploy",
+    "db:migrate:verify": "sh ./scripts/verify-migration-chain.sh",
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
     "db:seed:accounts": "tsx prisma/seed-accounts.ts",

--- a/packages/midcurve-database/prisma/schema.prisma
+++ b/packages/midcurve-database/prisma/schema.prisma
@@ -409,6 +409,7 @@ model PositionAprPeriod {
 // Stores deployed shared contracts (e.g., UniswapV3PositionCloser) per chain/version
 // Uses JSON config field for platform-specific data (EVM: chainId + address)
 model SharedContract {
+  driftProbe String?
   id        String   @id @default(cuid())
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/packages/midcurve-database/scripts/verify-migration-chain.sh
+++ b/packages/midcurve-database/scripts/verify-migration-chain.sh
@@ -19,7 +19,10 @@ cd "$(dirname "$0")/.."
 # The package .env is a symlink to the repo root .env. Neither npm nor pnpm loads
 # it, and Prisma loads it too late to help — CLI flags are expanded by the shell
 # before Prisma runs. So it has to be sourced here.
-if [ -f .env ]; then
+#
+# Only when DATABASE_URL is not already set, so an explicit value wins over the
+# file. CI sets it directly and has no .env.
+if [ -z "${DATABASE_URL:-}" ] && [ -f .env ]; then
   set -a
   . ./.env
   set +a
@@ -35,11 +38,23 @@ if [ "$SHADOW_URL" = "$DATABASE_URL" ]; then
   exit 1
 fi
 
+# Cleanup runs on every exit path, including drift and an aborted run. It says so
+# out loud when it cannot drop the database rather than leaving a stray one to be
+# discovered later — the whole point of a throwaway is that nobody has to wonder
+# which database is real.
 drop_shadow() {
-  psql "$DATABASE_URL" -q -c "DROP DATABASE IF EXISTS \"$SHADOW_NAME\";" >/dev/null 2>&1
+  if ! psql "$DATABASE_URL" -q -c "DROP DATABASE IF EXISTS \"$SHADOW_NAME\";" >/dev/null 2>&1; then
+    echo "Warning: could not drop the throwaway database $SHADOW_NAME. Drop it by hand." >&2
+  fi
 }
 trap drop_shadow EXIT
+# A signal does not always run the EXIT trap, so handle the two that arrive in
+# practice — Ctrl-C and a CI cancellation — and exit with the conventional code.
+trap 'drop_shadow; exit 130' INT
+trap 'drop_shadow; exit 143' TERM
 
+# Also covers a database left behind by a run that was killed outright (SIGKILL,
+# a closed laptop), which no trap can catch.
 drop_shadow
 psql "$DATABASE_URL" -q -c "CREATE DATABASE \"$SHADOW_NAME\";" >/dev/null
 

--- a/packages/midcurve-database/scripts/verify-migration-chain.sh
+++ b/packages/midcurve-database/scripts/verify-migration-chain.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+#
+# Verify that the checked-in migration chain reproduces schema.prisma from empty.
+#
+# Applies every migration in prisma/migrations to a throwaway database, then
+# diffs the result against the datamodel. Exits 0 if they match, 2 if they have
+# drifted apart, 1 on error.
+#
+# Run it after creating a migration, and before applying the chain to an empty
+# database. See docs/architecture.md, "Verifying the migration chain".
+#
+# Requires psql and a DATABASE_URL whose role may CREATE DATABASE. The throwaway
+# database is created and dropped by this script; DATABASE_URL is only read.
+
+set -eu
+
+cd "$(dirname "$0")/.."
+
+# The package .env is a symlink to the repo root .env. Neither npm nor pnpm loads
+# it, and Prisma loads it too late to help — CLI flags are expanded by the shell
+# before Prisma runs. So it has to be sourced here.
+if [ -f .env ]; then
+  set -a
+  . ./.env
+  set +a
+fi
+
+: "${DATABASE_URL:?DATABASE_URL is not set — see .env.example}"
+
+SHADOW_NAME="${SHADOW_DATABASE_NAME:-midcurve_migration_check}"
+SHADOW_URL=$(printf '%s' "$DATABASE_URL" | sed -E "s|/[^/?]+(\?.*)?\$|/${SHADOW_NAME}\1|")
+
+if [ "$SHADOW_URL" = "$DATABASE_URL" ]; then
+  echo "Refusing to run: could not derive a throwaway database URL from DATABASE_URL." >&2
+  exit 1
+fi
+
+drop_shadow() {
+  psql "$DATABASE_URL" -q -c "DROP DATABASE IF EXISTS \"$SHADOW_NAME\";" >/dev/null 2>&1
+}
+trap drop_shadow EXIT
+
+drop_shadow
+psql "$DATABASE_URL" -q -c "CREATE DATABASE \"$SHADOW_NAME\";" >/dev/null
+
+echo "Applying the migration chain to a throwaway database ($SHADOW_NAME)…"
+
+# --exit-code makes Prisma report 0 for "no difference" and 2 for "differs".
+# Capture it directly: after a failed `if` with no `else`, $? is the status of
+# the `if` statement itself (0), not of the command that failed.
+set +e
+npx prisma migrate diff \
+  --from-migrations ./prisma/migrations \
+  --to-schema-datamodel ./prisma/schema.prisma \
+  --shadow-database-url "$SHADOW_URL" \
+  --exit-code
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+  echo "✓ The migration chain reproduces schema.prisma exactly."
+  exit 0
+fi
+
+if [ "$status" -eq 2 ]; then
+  echo ""
+  echo "✗ Drift: applying the migration chain to an empty database does not"
+  echo "  produce schema.prisma. A fresh deploy would land on the wrong schema."
+  echo ""
+  echo "  To see the difference, re-run the diff with --script:"
+  echo ""
+  echo "    npx prisma migrate diff \\"
+  echo "      --from-migrations ./prisma/migrations \\"
+  echo "      --to-schema-datamodel ./prisma/schema.prisma \\"
+  echo "      --shadow-database-url \"\$SHADOW_URL\" --script"
+  echo ""
+fi
+exit "$status"


### PR DESCRIPTION
Throwaway PR. Adds a field to schema.prisma that no migration creates, to confirm the CI check added in #106 actually goes red. Closing immediately after.