### PR TITLE
fix: current position state from the exact pool price, and one read for both tabs

### DIFF
--- a/apps/midcurve-ui/src/components/positions/protocol/uniswapv3-vault/uniswapv3-vault-conversion-tab.tsx
+++ b/apps/midcurve-ui/src/components/positions/protocol/uniswapv3-vault/uniswapv3-vault-conversion-tab.tsx
@@ -1,7 +1,13 @@
 "use client";
 
+import { useMemo } from "react";
+import { applyCurrentPrice } from "@midcurve/shared";
 import type { UniswapV3VaultPositionData } from "@/hooks/positions/uniswapv3-vault/useUniswapV3VaultPosition";
-import type { UniswapV3VaultPositionConfigResponse } from "@midcurve/api-shared";
+import type {
+  UniswapV3VaultPositionConfigResponse,
+  UniswapV3VaultPositionStateResponse,
+  UniswapV3PoolStateResponse,
+} from "@midcurve/api-shared";
 import { ConversionSummary } from "../uniswapv3/conversion-summary";
 import { useUniswapV3VaultConversion } from "@/hooks/positions/uniswapv3-vault/useUniswapV3VaultConversion";
 
@@ -18,5 +24,32 @@ export function UniswapV3VaultConversionTab({ position }: UniswapV3VaultConversi
     config.ownerAddress,
   );
 
-  return <ConversionSummary summary={summary ?? null} isLoading={isLoading} />;
+  // Re-apply the pool price the rest of the page is rendering — see the NFT tab
+  // for why. The liquidity basis is the holder's proportional share, the same
+  // one the Overview tab uses; the route derives it from sharesBalance alone,
+  // which only agrees while totalSupply equals the vault's liquidity.
+  const pricedSummary = useMemo(() => {
+    if (!summary) return null;
+
+    const state = position.state as UniswapV3VaultPositionStateResponse;
+    const poolState = position.pool.state as UniswapV3PoolStateResponse;
+
+    const totalSupply = BigInt(state.totalSupply);
+    const userLiquidity =
+      totalSupply > 0n
+        ? (BigInt(state.liquidity) * BigInt(state.sharesBalance)) / totalSupply
+        : 0n;
+
+    return applyCurrentPrice(summary, {
+      isToken0Quote: position.isToken0Quote,
+      tickLower: config.tickLower,
+      tickUpper: config.tickUpper,
+      sqrtPriceX96: BigInt(poolState.sqrtPriceX96),
+      liquidity: userLiquidity,
+      unclaimedFees0: BigInt(state.unclaimedFees0),
+      unclaimedFees1: BigInt(state.unclaimedFees1),
+    });
+  }, [summary, position, config.tickLower, config.tickUpper]);
+
+  return <ConversionSummary summary={pricedSummary} isLoading={isLoading} />;
 }

--- a/apps/midcurve-ui/src/components/positions/protocol/uniswapv3/uniswapv3-conversion-tab.tsx
+++ b/apps/midcurve-ui/src/components/positions/protocol/uniswapv3/uniswapv3-conversion-tab.tsx
@@ -1,6 +1,13 @@
 "use client";
 
+import { useMemo } from "react";
+import { applyCurrentPrice } from "@midcurve/shared";
 import type { UniswapV3PositionData } from "@/hooks/positions/uniswapv3/useUniswapV3Position";
+import type {
+  UniswapV3PositionConfigResponse,
+  UniswapV3PositionStateResponse,
+  UniswapV3PoolStateResponse,
+} from "@midcurve/api-shared";
 import { ConversionSummary } from "./conversion-summary";
 import { useUniswapV3Conversion } from "@/hooks/positions/uniswapv3/useUniswapV3Conversion";
 
@@ -9,12 +16,34 @@ interface UniswapV3ConversionTabProps {
 }
 
 export function UniswapV3ConversionTab({ position }: UniswapV3ConversionTabProps) {
-  const config = position.config as { chainId: number; nftId: number };
+  const config = position.config as UniswapV3PositionConfigResponse;
 
   const { data: summary, isLoading } = useUniswapV3Conversion(
     config.chainId,
     config.nftId.toString(),
   );
 
-  return <ConversionSummary summary={summary ?? null} isLoading={isLoading} />;
+  // The server computed the summary against the pool price it read at request
+  // time; this tab's query holds that response for 60s while the page keeps
+  // watching the pool. Re-apply the price the rest of the page is rendering, so
+  // "Current Holdings" cannot disagree with the Overview tab's "Current State".
+  // Everything else in the summary is a replay of immutable history.
+  const pricedSummary = useMemo(() => {
+    if (!summary) return null;
+
+    const state = position.state as UniswapV3PositionStateResponse;
+    const poolState = position.pool.state as UniswapV3PoolStateResponse;
+
+    return applyCurrentPrice(summary, {
+      isToken0Quote: position.isToken0Quote,
+      tickLower: config.tickLower,
+      tickUpper: config.tickUpper,
+      sqrtPriceX96: BigInt(poolState.sqrtPriceX96),
+      liquidity: BigInt(state.liquidity),
+      unclaimedFees0: BigInt(state.unclaimedFees0),
+      unclaimedFees1: BigInt(state.unclaimedFees1),
+    });
+  }, [summary, position, config.tickLower, config.tickUpper]);
+
+  return <ConversionSummary summary={pricedSummary} isLoading={isLoading} />;
 }

--- a/apps/midcurve-ui/src/lib/position-states.ts
+++ b/apps/midcurve-ui/src/lib/position-states.ts
@@ -10,7 +10,7 @@ import {
   calculatePositionValue,
   tickToPrice,
   tickToSqrtRatioX96,
-  priceToTick,
+  priceToSqrtRatioX96,
   pricePerToken0InToken1,
   pricePerToken1InToken0,
   UniswapV3Pool,
@@ -19,7 +19,6 @@ import {
 } from "@midcurve/shared";
 import type { PoolJSON } from "@midcurve/shared";
 import type { SwapConfig, SerializedCloseOrder } from "@midcurve/api-shared";
-import { TickMath } from "@uniswap/v3-sdk";
 
 /**
  * Position state interface - represents position at a specific price point
@@ -73,9 +72,6 @@ interface BasicPosition {
     token1: {
       config: { address: string };
       decimals: number;
-    };
-    config: {
-      tickSpacing: number;
     };
     state: {
       currentTick: number;
@@ -542,7 +538,7 @@ export function calculateBreakEvenPrice(
   for (let i = 0; i < maxIterations; i++) {
     const midPrice = (lowPrice + highPrice) / 2n;
 
-    // Validate midPrice is valid before converting to tick
+    // Validate midPrice is valid before converting to a sqrt price
     if (midPrice <= 0n) {
       console.warn(
         "calculateBreakEvenPrice: Binary search reached invalid price"
@@ -550,17 +546,19 @@ export function calculateBreakEvenPrice(
       break;
     }
 
-    // Convert price to tick
-    const tick = priceToTick(
-      midPrice,
-      position.pool.config.tickSpacing,
-      baseTokenConfig.address,
-      quoteTokenConfig.address,
-      Number(baseToken.decimals)
+    // Convert price → sqrtPriceX96 DIRECTLY (continuous, no tick snapping).
+    // Going through priceToTick() would snap to tickSpacing, quantizing the
+    // search grid to 0.6% (spacing 60) or 0.1% (spacing 10): the bisection
+    // would then keep halving the interval while evaluating the same handful of
+    // distinct values. Same reasoning as UniswapV3Position.simulatePnLAtPrice().
+    const sqrtPriceX96 = BigInt(
+      priceToSqrtRatioX96(
+        baseTokenConfig.address,
+        quoteTokenConfig.address,
+        Number(baseToken.decimals),
+        midPrice
+      ).toString()
     );
-
-    // Calculate position value at this price
-    const sqrtPriceX96 = BigInt(TickMath.getSqrtRatioAtTick(tick).toString());
     const positionValue = calculatePositionValue(
       liquidity,
       sqrtPriceX96,

--- a/apps/midcurve-ui/src/lib/position-states.ts
+++ b/apps/midcurve-ui/src/lib/position-states.ts
@@ -11,6 +11,8 @@ import {
   tickToPrice,
   tickToSqrtRatioX96,
   priceToTick,
+  pricePerToken0InToken1,
+  pricePerToken1InToken0,
   UniswapV3Pool,
   UniswapV3Position,
   CloseOrderSimulationOverlay,
@@ -77,33 +79,37 @@ interface BasicPosition {
     };
     state: {
       currentTick: number;
+      sqrtPriceX96: string;
     };
   };
 }
 
 /**
- * Calculate position state at a specific tick
+ * Calculate position state at a given sqrt price.
+ *
+ * The sqrt price is the input rather than a tick because a tick only ever
+ * approximates a price: it is the floor of the tick implied by sqrtPriceX96, so
+ * converting one back into the other loses everything below the tick boundary.
+ * Callers that genuinely have a tick (the range boundaries) convert once, here.
+ *
  * @param position - Position data
  * @param pnlBreakdown - PnL breakdown data (optional)
- * @param tick - Tick to calculate state at
- * @returns Position state at the specified tick
+ * @param sqrtPriceX96 - Sqrt price to calculate state at (Q96.96)
+ * @param poolPrice - The same price in quote token units, for display
+ * @param includeUnclaimedFees - Whether unclaimed fees count towards PnL, which
+ *   is true only for the position's current state
+ * @returns Position state at the specified price
  */
-function calculatePositionStateAtTick(
+function calculatePositionStateAtSqrtPrice(
   position: BasicPosition,
   pnlBreakdown: PnlBreakdown | null | undefined,
-  tick: number
+  sqrtPriceX96: bigint,
+  poolPrice: bigint,
+  includeUnclaimedFees: boolean
 ): PositionState {
-  const { pool } = position;
-  const baseToken = position.isToken0Quote ? pool.token1 : pool.token0;
-  const quoteToken = position.isToken0Quote ? pool.token0 : pool.token1;
-
-  const baseTokenConfig = baseToken.config as { address: string };
-  const quoteTokenConfig = quoteToken.config as { address: string };
-
   const liquidity = BigInt(position.state.liquidity);
-  const sqrtPriceX96 = BigInt(TickMath.getSqrtRatioAtTick(tick).toString());
 
-  // Calculate token amounts at this tick
+  // Calculate token amounts at this price
   const { token0Amount, token1Amount } = getTokenAmountsFromLiquidity(
     liquidity,
     sqrtPriceX96,
@@ -115,15 +121,7 @@ function calculatePositionStateAtTick(
   const baseTokenAmount = position.isToken0Quote ? token1Amount : token0Amount;
   const quoteTokenAmount = position.isToken0Quote ? token0Amount : token1Amount;
 
-  // Calculate price at this tick
-  const poolPrice = tickToPrice(
-    tick,
-    baseTokenConfig.address,
-    quoteTokenConfig.address,
-    Number(baseToken.decimals)
-  );
-
-  // Calculate position value at this tick
+  // Calculate position value at this price
   const baseIsToken0 = !position.isToken0Quote;
   const positionValue = calculatePositionValue(
     liquidity,
@@ -143,14 +141,14 @@ function calculatePositionStateAtTick(
   // unrealizedPnL = positionValue - costBasis
   const unrealizedPnL = positionValue - currentCostBasis;
 
-  // For current tick, use unclaimed fees; for other ticks, fees would be 0
-  const unclaimedFeesAtTick =
-    tick === position.pool.state.currentTick ? unclaimedFees : 0n;
+  // Unclaimed fees are only earned at the current price; at a hypothetical
+  // range boundary they have not accrued.
+  const applicableUnclaimedFees = includeUnclaimedFees ? unclaimedFees : 0n;
 
   // PnL Including Fees = realizedPnL + unrealizedPnL + unclaimedFees
   // Note: realizedPnL already includes collectedFees (fees are added to pnlAfter in the ledger)
   const pnlIncludingFees =
-    realizedPnL + unrealizedPnL + unclaimedFeesAtTick;
+    realizedPnL + unrealizedPnL + applicableUnclaimedFees;
 
   // PnL Excluding Fees = capital gains only (subtract fee portion from realizedPnL)
   const pnlExcludingFees = realizedPnL - collectedFees + unrealizedPnL;
@@ -163,6 +161,82 @@ function calculatePositionStateAtTick(
     pnlIncludingFees,
     pnlExcludingFees,
   };
+}
+
+/**
+ * Calculate position state at a range boundary tick.
+ *
+ * A boundary is defined by its tick, so converting that tick to a sqrt price is
+ * exact by definition — unlike the current price, which only ever passes through
+ * a tick by losing precision.
+ *
+ * @param position - Position data
+ * @param pnlBreakdown - PnL breakdown data (optional)
+ * @param tick - Tick to calculate state at
+ * @returns Position state at the specified tick
+ */
+function calculatePositionStateAtTick(
+  position: BasicPosition,
+  pnlBreakdown: PnlBreakdown | null | undefined,
+  tick: number
+): PositionState {
+  const { pool } = position;
+  const baseToken = position.isToken0Quote ? pool.token1 : pool.token0;
+  const quoteToken = position.isToken0Quote ? pool.token0 : pool.token1;
+
+  const baseTokenConfig = baseToken.config as { address: string };
+  const quoteTokenConfig = quoteToken.config as { address: string };
+
+  const poolPrice = tickToPrice(
+    tick,
+    baseTokenConfig.address,
+    quoteTokenConfig.address,
+    Number(baseToken.decimals)
+  );
+
+  return calculatePositionStateAtSqrtPrice(
+    position,
+    pnlBreakdown,
+    BigInt(tickToSqrtRatioX96(tick).toString()),
+    poolPrice,
+    false
+  );
+}
+
+/**
+ * Calculate the position's current state from the pool's exact sqrt price.
+ *
+ * Uses pool.state.sqrtPriceX96 rather than pool.state.currentTick: the tick is
+ * the floor of the tick implied by that sqrt price, so routing the current price
+ * through it discards the sub-tick remainder. On a live position that is worth
+ * up to ~0.1% of each leg, and it is what made the "Position Value" row disagree
+ * with the "Current Value" card computed by the backend from the same price.
+ *
+ * @param position - Position data
+ * @param pnlBreakdown - PnL breakdown data (optional)
+ * @returns Position state at the current pool price
+ */
+function calculateCurrentPositionState(
+  position: BasicPosition,
+  pnlBreakdown: PnlBreakdown | null | undefined
+): PositionState {
+  const { pool } = position;
+  const baseToken = position.isToken0Quote ? pool.token1 : pool.token0;
+  const sqrtPriceX96 = BigInt(pool.state.sqrtPriceX96);
+
+  // Price of one base token in quote units, from the same sqrt price the
+  // amounts are computed at — so the displayed price and amounts agree.
+  const poolPrice = position.isToken0Quote
+    ? pricePerToken1InToken0(sqrtPriceX96, Number(baseToken.decimals))
+    : pricePerToken0InToken1(sqrtPriceX96, Number(baseToken.decimals));
+
+  return calculatePositionStateAtSqrtPrice(
+    position,
+    pnlBreakdown,
+    sqrtPriceX96,
+    poolPrice,
+    true
+  );
 }
 
 /**
@@ -262,8 +336,6 @@ export function calculatePositionStates(
   pnlBreakdown: PnlBreakdown | null | undefined,
   activeCloseOrders?: SerializedCloseOrder[]
 ): PositionStates {
-  const currentTick = position.pool.state.currentTick;
-
   // When isToken0Quote = true, tick-to-price relationship is inverted:
   // - tickLower gives HIGHER price (more quote per base)
   // - tickUpper gives LOWER price (fewer quote per base)
@@ -276,7 +348,7 @@ export function calculatePositionStates(
     : position.config.tickUpper;
 
   // Current state is always raw (triggers haven't fired at current price)
-  const current = calculatePositionStateAtTick(position, pnlBreakdown, currentTick);
+  const current = calculateCurrentPositionState(position, pnlBreakdown);
 
   // Without close orders, use raw calculations for all states
   if (!activeCloseOrders?.length || !pnlBreakdown) {

--- a/packages/midcurve-shared/src/conversion/uniswapv3-conversion.test.ts
+++ b/packages/midcurve-shared/src/conversion/uniswapv3-conversion.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyCurrentPrice,
+  type ConversionSummary,
+  type CurrentPriceParams,
+} from './uniswapv3-conversion.js';
+import { getTokenAmountsFromLiquidity } from '../utils/uniswapv3/index.js';
+
+/**
+ * applyCurrentPrice — the price-dependent tail of the conversion summary.
+ *
+ * Split out of computeUniswapV3ConversionSummary so a caller holding a fresher
+ * pool price than the one the summary was computed with can re-apply it, and
+ * render numbers consistent with everything else it draws from that price.
+ *
+ * Fixture is the live Arbitrum vault position 0x7eBA… (WETH/USDC, 0.05%):
+ * WETH is token0, USDC token1, so base = token0 and isToken0Quote = false.
+ */
+describe('applyCurrentPrice', () => {
+  const TICK_LOWER = -201070;
+  const TICK_UPPER = -197880;
+  const LIQUIDITY = 3094570764498n;
+
+  // Exact on-chain price, and the price of the tick it floors to.
+  const SQRT_PRICE_EXACT = 3476237843309497840453491n;
+  const SQRT_PRICE_AT_TICK = 3476196724740106474038315n;
+
+  const baseSummary: ConversionSummary = {
+    netDepositBase: 6578526936727586n,
+    netDepositQuote: 34749426n,
+    netDepositAvgPrice: 2318859504n,
+    withdrawnBase: 2652872785374859n,
+    withdrawnQuote: 21177382n,
+    ammBoughtBase: 7852300617581362n,
+    ammBoughtAvgPrice: 2164592369n,
+    ammBoughtPremium: 0n,
+    ammSoldBase: 2525176170272745n,
+    ammSoldAvgPrice: 2360978243n,
+    ammSoldPremium: 0n,
+    netRebalancingBase: 5327124447308617n,
+    netRebalancingQuote: -11035144n,
+    netRebalancingAvgPrice: 2071501071n,
+    totalPremium: 0n,
+    currentBase: 0n,
+    currentQuote: 0n,
+    currentSpotPrice: 0n,
+    isClosed: false,
+    closePriceX96: null,
+    daysActive: null,
+    segments: [
+      {
+        index: 0,
+        startTimestamp: '2026-04-15T08:06:13.000Z',
+        endTimestamp: '2026-04-22T12:51:33.000Z',
+        isTrailing: false,
+        deltaBase: -2525176170272745n,
+        deltaQuote: 5961886n,
+        avgPrice: 2360978243n,
+        feesEarned: 0n,
+      },
+      {
+        index: 1,
+        startTimestamp: '2026-08-09T15:37:22.000Z',
+        endTimestamp: null,
+        isTrailing: true,
+        deltaBase: 1123311208105n,
+        deltaQuote: -2163n,
+        avgPrice: 1925557213n,
+        feesEarned: 0n,
+      },
+    ],
+    baseTokenSymbol: 'WETH',
+    quoteTokenSymbol: 'USDC',
+    baseTokenDecimals: 18,
+    quoteTokenDecimals: 6,
+  };
+
+  const params: CurrentPriceParams = {
+    isToken0Quote: false,
+    tickLower: TICK_LOWER,
+    tickUpper: TICK_UPPER,
+    sqrtPriceX96: SQRT_PRICE_EXACT,
+    liquidity: LIQUIDITY,
+    unclaimedFees0: 0n,
+    unclaimedFees1: 0n,
+  };
+
+  it('computes current holdings from the exact sqrt price', () => {
+    const result = applyCurrentPrice(baseSummary, params);
+
+    // These are the values the /conversion endpoint served for this position.
+    expect(result.currentBase).toBe(9252778598661343n);
+    expect(result.currentQuote).toBe(2536899n);
+  });
+
+  it('does not route the current price through a tick', () => {
+    const exact = applyCurrentPrice(baseSummary, params);
+    const viaTick = applyCurrentPrice(baseSummary, {
+      ...params,
+      sqrtPriceX96: SQRT_PRICE_AT_TICK,
+    });
+
+    // The tick-derived price is a different price and must produce different
+    // holdings — the guard against anyone reintroducing a tick round trip.
+    expect(viaTick.currentBase).not.toBe(exact.currentBase);
+    expect(viaTick.currentQuote).not.toBe(exact.currentQuote);
+    expect(exact.currentBase).toBe(
+      getTokenAmountsFromLiquidity(LIQUIDITY, SQRT_PRICE_EXACT, TICK_LOWER, TICK_UPPER)
+        .token0Amount,
+    );
+  });
+
+  it('is idempotent — re-applying the same price changes nothing', () => {
+    const once = applyCurrentPrice(baseSummary, {
+      ...params,
+      unclaimedFees0: 1_000_000_000_000n,
+      unclaimedFees1: 250_000n,
+    });
+    const twice = applyCurrentPrice(once, {
+      ...params,
+      unclaimedFees0: 1_000_000_000_000n,
+      unclaimedFees1: 250_000n,
+    });
+
+    expect(twice).toEqual(once);
+  });
+
+  it('re-applying a different price does not accumulate fee attribution', () => {
+    const fees = { unclaimedFees0: 1_000_000_000_000n, unclaimedFees1: 250_000n };
+
+    // Applying to an already-priced summary must equal applying to the base one:
+    // the trailing segment's attribution is rebuilt, not added to.
+    const viaBase = applyCurrentPrice(baseSummary, {
+      ...params,
+      ...fees,
+      sqrtPriceX96: SQRT_PRICE_AT_TICK,
+    });
+    const viaApplied = applyCurrentPrice(applyCurrentPrice(baseSummary, { ...params, ...fees }), {
+      ...params,
+      ...fees,
+      sqrtPriceX96: SQRT_PRICE_AT_TICK,
+    });
+
+    expect(viaApplied).toEqual(viaBase);
+  });
+
+  it('assigns unclaimed fees to the trailing segment only', () => {
+    const result = applyCurrentPrice(baseSummary, {
+      ...params,
+      unclaimedFees1: 500_000n,
+    });
+
+    expect(result.totalPremium).toBe(500_000n);
+    expect(result.segments[0]!.feesEarned).toBe(0n);
+    expect(result.segments[1]!.feesEarned).toBe(500_000n);
+    // The trailing segment bought base, so fees make the effective price better.
+    expect(result.segments[1]!.avgPrice).not.toBe(baseSummary.segments[1]!.avgPrice);
+  });
+
+  it('leaves segment average prices at their raw ratio when there are no fees', () => {
+    const result = applyCurrentPrice(baseSummary, params);
+
+    expect(result.totalPremium).toBe(0n);
+    for (const segment of result.segments) {
+      expect(segment.feesEarned).toBe(0n);
+      const raw =
+        (segment.deltaQuote < 0n ? -segment.deltaQuote : segment.deltaQuote) *
+        10n ** 18n /
+        (segment.deltaBase < 0n ? -segment.deltaBase : segment.deltaBase);
+      expect(segment.avgPrice).toBe(raw);
+    }
+  });
+
+  it('prices a closed position at close, ignoring the current price', () => {
+    const closed: ConversionSummary = {
+      ...baseSummary,
+      isClosed: true,
+      closePriceX96: SQRT_PRICE_AT_TICK,
+    };
+
+    const result = applyCurrentPrice(closed, { ...params, liquidity: 0n });
+    const atOtherPrice = applyCurrentPrice(closed, {
+      ...params,
+      liquidity: 0n,
+      sqrtPriceX96: SQRT_PRICE_EXACT * 2n,
+    });
+
+    expect(result.currentBase).toBe(0n);
+    expect(result.currentQuote).toBe(0n);
+    expect(atOtherPrice.currentSpotPrice).toBe(result.currentSpotPrice);
+  });
+
+  it('holds no position value when liquidity is zero', () => {
+    const result = applyCurrentPrice(baseSummary, { ...params, liquidity: 0n });
+
+    expect(result.currentBase).toBe(0n);
+    expect(result.currentQuote).toBe(0n);
+    // The spot price is still the live one — the position is open, just empty.
+    expect(result.currentSpotPrice).toBeGreaterThan(0n);
+  });
+});

--- a/packages/midcurve-shared/src/conversion/uniswapv3-conversion.ts
+++ b/packages/midcurve-shared/src/conversion/uniswapv3-conversion.ts
@@ -107,6 +107,12 @@ export interface ConversionSummary {
   currentQuote: bigint;
   currentSpotPrice: bigint;
   isClosed: boolean;
+  /**
+   * Pool price at the moment the position was closed, null while it is open.
+   * Kept so that applyCurrentPrice() can tell "price this at close" from "price
+   * this now" without re-reading the ledger.
+   */
+  closePriceX96: bigint | null;
   /** Days position was active (for closed positions), null if still active */
   daysActive: number | null;
   segments: RebalancingSegment[];
@@ -238,7 +244,6 @@ export function computeUniswapV3ConversionSummary(
   let ammBoughtBase = 0n;
   let ammBoughtQuoteVolume = 0n;
   const ammBoughtPremium = 0n;
-  let totalPremium = 0n;
   let netRebalancingBase = 0n;
   let netRebalancingQuote = 0n;
 
@@ -384,68 +389,24 @@ export function computeUniswapV3ConversionSummary(
     }
   }
 
-  // Current holdings (or holdings at close for closed positions)
-  let currentHoldingsBase = 0n;
-  let currentHoldingsQuote = 0n;
-  let spotPriceX96 = currentSqrtPriceX96; // live price for active, overridden for closed
+  // For closed positions the reference price is the one at close, not the live
+  // pool price: holdings are 0 (already counted in withdrawnBase/Quote) and the
+  // comparison the UI draws is against the market as it was that day.
+  let closePriceX96: bigint | null = null;
   if (isClosed) {
-    // For closed positions: holdings are 0 (already counted in withdrawnBase/Quote).
-    // Use the price from the final DECREASE event as the reference spot price.
     for (let j = financialEvents.length - 1; j >= 0; j--) {
       const evt = financialEvents[j]!;
       if (evt.eventType === 'DECREASE_POSITION') {
         const closeCfg = parseConfig(evt);
         if (closeCfg.liquidityAfter === 0n) {
-          spotPriceX96 = closeCfg.sqrtPriceX96;
+          closePriceX96 = closeCfg.sqrtPriceX96;
           break;
         }
       }
     }
-  } else if (currentLiquidity > 0n) {
-    const currentAmounts = getTokenAmountsFromLiquidity(
-      currentLiquidity,
-      currentSqrtPriceX96,
-      tickLower,
-      tickUpper,
-    );
-    const mapped = toBaseQuote(
-      currentAmounts.token0Amount,
-      currentAmounts.token1Amount,
-      baseIsToken0,
-    );
-    currentHoldingsBase = mapped.base;
-    currentHoldingsQuote = mapped.quote;
   }
 
-  // Premium = unclaimed fees only.
-  // Fees are not compounded into liquidity. Once claimed, they leave the position
-  // and can go anywhere — they cannot count against the purchase or sale of assets
-  // inside the position. Only unclaimed fees are still inside the position.
-  totalPremium = feesToQuote(
-    BigInt(position.state.unclaimedFees0),
-    BigInt(position.state.unclaimedFees1),
-    currentSqrtPriceX96,
-    baseIsToken0,
-  );
-
-  // Assign all unclaimed fees to the last segment for execution price adjustment.
-  if (segments.length > 0) {
-    const attributedFees = segments.reduce((acc, s) => acc + s.feesEarned, 0n);
-    const unattributedFees = totalPremium - attributedFees;
-    if (unattributedFees > 0n) {
-      const last = segments[segments.length - 1]!;
-      last.feesEarned += unattributedFees;
-      if (last.deltaBase !== 0n) {
-        const effectiveQuote =
-          last.deltaBase < 0n
-            ? absBI(last.deltaQuote) + last.feesEarned
-            : absBI(last.deltaQuote) - last.feesEarned;
-        last.avgPrice = (effectiveQuote * scale) / absBI(last.deltaBase);
-      }
-    }
-  }
-
-  return {
+  const historySummary: ConversionSummary = {
     netDepositBase,
     netDepositQuote,
     netDepositAvgPrice:
@@ -465,19 +426,125 @@ export function computeUniswapV3ConversionSummary(
       netRebalancingBase !== 0n
         ? (absBI(netRebalancingQuote) * scale) / absBI(netRebalancingBase)
         : 0n,
-    totalPremium,
+    totalPremium: 0n,
     segments,
-    currentBase: currentHoldingsBase,
-    currentQuote: currentHoldingsQuote,
-    currentSpotPrice: baseIsToken0
-      ? pricePerToken0InToken1(spotPriceX96, baseTokenDecimals)
-      : pricePerToken1InToken0(spotPriceX96, baseTokenDecimals),
+    currentBase: 0n,
+    currentQuote: 0n,
+    currentSpotPrice: 0n,
     isClosed,
+    closePriceX96,
     daysActive,
     baseTokenSymbol: baseToken.symbol,
     quoteTokenSymbol: quoteToken.symbol,
     baseTokenDecimals,
     quoteTokenDecimals: quoteToken.decimals,
+  };
+
+  return applyCurrentPrice(historySummary, {
+    isToken0Quote: position.isToken0Quote,
+    tickLower,
+    tickUpper,
+    sqrtPriceX96: currentSqrtPriceX96,
+    liquidity: currentLiquidity,
+    unclaimedFees0: BigInt(position.state.unclaimedFees0),
+    unclaimedFees1: BigInt(position.state.unclaimedFees1),
+  });
+}
+
+// =============================================================================
+// Applying a current price
+//
+// Everything above is a replay of immutable history: each event carries the
+// sqrtPriceX96 it happened at. Only the handful of fields below depend on what
+// the pool costs *now*, which is why they are applied separately — a caller
+// holding a fresher price than the one the summary was computed with can
+// re-apply this and get numbers consistent with whatever else it renders from
+// that same price, instead of two views drifting apart on two reads.
+//
+// The transform is idempotent: it recomputes the price-dependent fields from
+// its inputs and rebuilds segment fee attribution from each segment's own
+// deltaBase/deltaQuote, so applying it twice is the same as applying it once.
+// =============================================================================
+
+export interface CurrentPriceParams {
+  isToken0Quote: boolean;
+  tickLower: number;
+  tickUpper: number;
+  /** Current pool price. Ignored for closed positions, which price at close. */
+  sqrtPriceX96: bigint;
+  /** Liquidity the holdings are computed from. For vaults, the holder's share. */
+  liquidity: bigint;
+  unclaimedFees0: bigint;
+  unclaimedFees1: bigint;
+}
+
+export function applyCurrentPrice(
+  summary: ConversionSummary,
+  params: CurrentPriceParams,
+): ConversionSummary {
+  const baseIsToken0 = !params.isToken0Quote;
+  const scale = 10n ** BigInt(summary.baseTokenDecimals);
+
+  // A closed position is priced at close, not now.
+  const spotPriceX96 = summary.isClosed
+    ? (summary.closePriceX96 ?? params.sqrtPriceX96)
+    : params.sqrtPriceX96;
+
+  let currentBase = 0n;
+  let currentQuote = 0n;
+  if (!summary.isClosed && params.liquidity > 0n) {
+    const amounts = getTokenAmountsFromLiquidity(
+      params.liquidity,
+      params.sqrtPriceX96,
+      params.tickLower,
+      params.tickUpper,
+    );
+    const mapped = toBaseQuote(amounts.token0Amount, amounts.token1Amount, baseIsToken0);
+    currentBase = mapped.base;
+    currentQuote = mapped.quote;
+  }
+
+  // Premium = unclaimed fees only.
+  // Fees are not compounded into liquidity. Once claimed, they leave the position
+  // and can go anywhere — they cannot count against the purchase or sale of assets
+  // inside the position. Only unclaimed fees are still inside the position.
+  const totalPremium = feesToQuote(
+    params.unclaimedFees0,
+    params.unclaimedFees1,
+    spotPriceX96,
+    baseIsToken0,
+  );
+
+  // Rebuild segments from their own deltas, then assign all unclaimed fees to
+  // the last one for execution price adjustment. Rebuilding rather than adding
+  // is what makes this safe to re-apply to an already-priced summary.
+  const segments = summary.segments.map((s) => ({
+    ...s,
+    feesEarned: 0n,
+    avgPrice: s.deltaBase !== 0n ? (absBI(s.deltaQuote) * scale) / absBI(s.deltaBase) : 0n,
+  }));
+
+  if (segments.length > 0 && totalPremium > 0n) {
+    const last = segments[segments.length - 1]!;
+    last.feesEarned = totalPremium;
+    if (last.deltaBase !== 0n) {
+      const effectiveQuote =
+        last.deltaBase < 0n
+          ? absBI(last.deltaQuote) + last.feesEarned
+          : absBI(last.deltaQuote) - last.feesEarned;
+      last.avgPrice = (effectiveQuote * scale) / absBI(last.deltaBase);
+    }
+  }
+
+  return {
+    ...summary,
+    totalPremium,
+    segments,
+    currentBase,
+    currentQuote,
+    currentSpotPrice: baseIsToken0
+      ? pricePerToken0InToken1(spotPriceX96, summary.baseTokenDecimals)
+      : pricePerToken1InToken0(spotPriceX96, summary.baseTokenDecimals),
   };
 }
 
@@ -519,6 +586,7 @@ export interface SerializedConversionSummary {
   currentQuote: string;
   currentSpotPrice: string;
   isClosed: boolean;
+  closePriceX96: string | null;
   daysActive: number | null;
   segments: SerializedRebalancingSegment[];
   baseTokenSymbol: string;
@@ -550,6 +618,7 @@ export function serializeConversionSummary(
     currentQuote: summary.currentQuote.toString(),
     currentSpotPrice: summary.currentSpotPrice.toString(),
     isClosed: summary.isClosed,
+    closePriceX96: summary.closePriceX96?.toString() ?? null,
     daysActive: summary.daysActive,
     segments: summary.segments.map((s) => ({
       index: s.index,
@@ -591,6 +660,7 @@ export function deserializeConversionSummary(
     currentQuote: BigInt(wire.currentQuote),
     currentSpotPrice: BigInt(wire.currentSpotPrice),
     isClosed: wire.isClosed,
+    closePriceX96: wire.closePriceX96 === null ? null : BigInt(wire.closePriceX96),
     daysActive: wire.daysActive,
     segments: wire.segments.map((s) => ({
       index: s.index,


### PR DESCRIPTION
Two independent defects made the Overview and Conversion tabs disagree about what a position currently holds. Only one of them is the defect #32 was filed under, and it is the smaller one.

Closes #32

## Three commits, described separately on purpose

**1. `fix(ui)` — the current state from the exact `sqrtPriceX96`.** `calculatePositionStateAtTick()` took a tick and converted it back to a sqrt price. For the range boundaries that is exact, since a boundary *is* a tick. For the current price it is not: `currentTick` is the floor of the tick implied by `sqrtPriceX96`, so the round trip discards the sub-tick remainder — worth 0.013–0.094 % of each leg across the six positions in the dev database.

Split into a sqrt-price core with two callers, and the displayed pool price now comes from the same sqrt price as the amounts. The tick-equality test that decided whether unclaimed fees count became an explicit flag, which also fixes a latent case: a position whose `tickLower` or `tickUpper` equalled `currentTick` added unclaimed fees to the range-boundary PnL.

**2. `fix(ui)` — break-even on a continuous price.** A second defect in the same file, [flagged while planning](https://github.com/0xNedAlbo/midcurve-finance/issues/32#issuecomment-5232406897) and [folded in per the decisions](https://github.com/0xNedAlbo/midcurve-finance/issues/32#issuecomment-5232433261) — not part of the first fix. `calculateBreakEvenPrice()` bisects on price but evaluated candidates through `priceToTick()`, which snaps to `tickSpacing`, sampling position value on a grid quantized to 0.6 % (spacing 60) or 0.1 % (spacing 10). Now converts price → sqrt directly, as `UniswapV3Position.simulatePnLAtPrice()` already does for the PnL curve.

**3. `fix` — one pool read feeds both tabs.** The defect that actually produces gaps of the reported size. The Conversion tab's query holds the server's response for 60 s with no refetch interval, and that response came from an independent read of the stored pool state.

The confirmation run turned up why that framing was wrong, and made the fix smaller: `uniswapv3-position-detail.tsx:43` and its vault twin already wrap the position in `useUniswapV3LiveMetrics`, which watches the pool over a WebSocket-backed subscription and patches the live `sqrtPriceX96` into `position.pool.state` before handing it to every tab. **The single read already existed; the Conversion tab was the one consumer discarding it.** So no new API parameter and no second poller — the price-dependent tail of `computeUniswapV3ConversionSummary()` is split into `applyCurrentPrice()`, and both conversion tabs re-apply it to the price they already hold. The replay over ledger history is price-independent; every event carries the `sqrtPriceX96` it happened at.

`computeUniswapV3ConversionSummary()` keeps its signature and calls the new function with the stored price, so the REST route and the MCP `get_position_conversion` tool are unchanged.

## Verification

`pnpm typecheck` 14/14 · `pnpm build` 11/11 · all six CI suites green (shared 142, api-shared 22, mcp-server 13, services 156, business-logic 24, onchain-data 7). Eight of those tests are new.

**Both defects were confirmed in a browser before the fix**, on the live Arbitrum vault position `0x7eBA…` with the dev stack running.

The precision defect was already user-visible, which I had not expected at 0.01 %. Before:

```
Current Value    20.35 USDC     ← backend, exact sqrtPriceX96 → 20.349689
Position Value   20.34 USDC     ← this file, tick-derived      → 20.349268
```

Same card, one cent apart, a 0.002 % difference straddling a rounding boundary. After the fix both read 20.34. Recomputing against the exact `sqrtPriceX96` the page was serving confirmed the conversion endpoint's `currentBase`/`currentQuote` match the exact branch to the wei, so the Overview was the odd one out. Break-even moved 2,023.37 → 2,024.29 USDC, about 0.045 % — the expected order for a half tick-spacing step on a spacing-10 pool.

The staleness mechanism was confirmed and its magnitude was not. Over ~70 s: 15 fetches of the position endpoint against **one** of the conversion endpoint, with the tab still rendering a 15:59:59 response after the pool state had been re-read at 16:00:23. The dev pool was quiet enough that both reads carried the same price, so nothing visibly diverged in that window. I did not reproduce the 34 % from the report, only the machinery that produces it when the pool moves.

## What is unverified by any suite

The new tests cover `applyCurrentPrice()` in `@midcurve/shared`, where a runner exists — per the [#100 precedent](https://github.com/0xNedAlbo/midcurve-finance/pull/100), and deliberately **not** by standing up UI test infrastructure, which belongs to #91. They pin the arithmetic, idempotence, closed-position pricing, fee attribution, and that the current price is not routed through a tick.

What no suite covers is the UI wiring itself — that the two conversion tabs and the overview actually pass the live price in. `apps/midcurve-ui` has no working unit test runner: `vitest.config.ts` includes only `src/app/api/**/*.e2e.test.ts`, `src/app/` no longer exists, there is no `vitest` devDependency and no `test` script, and CI runs none of it. The existing `src/lib/__tests__/update-position-in-list-cache.test.ts` has never executed. That wiring is browser-verified only. Flagging rather than claiming it.

## Things worth stating rather than leaving implicit

**Displayed numbers move for users**, by up to ~0.1 % on the Current State card and ~0.05 % on break-even. "Position Value" should now equal the "Current Value" card to the wei for NFT positions — same liquidity, same price, same function — which is the cleanest way to check the fix landed. For vaults it stays proportional by design.

**The vault conversion tab changes liquidity basis.** It now uses the holder's proportional liquidity (`liquidity × sharesBalance / totalSupply`), matching the Overview. The vault route feeds `sharesBalance` in directly, which agrees only while `totalSupply` equals the vault's liquidity — true for all three vaults in the dev database today, so this closes a latent divergence rather than a live one.

**`applyCurrentPrice()` is idempotent by construction**, because the UI applies it to a summary the server already priced. It rebuilds each segment's `avgPrice` from that segment's own `deltaBase`/`deltaQuote` and *sets* rather than adds the trailing segment's `feesEarned`. Pinned by two tests, including one that applies a second, different price.

**`ConversionSummary` gains `closePriceX96`.** A closed position prices at close, not at the live price, and that reference price used to be recovered by scanning the ledger inside the replay. Carrying it on the summary is what lets the price step be applied by a caller that never saw the events.

**The issue body was corrected before implementing**, following the #42 pattern: the reported example numbers cannot be produced by the defect the issue diagnosed, and a reproduction step credited tick rounding with the whole gap.

**Not fixed here:** the mini PnL curve, portfolio simulator and range status line still derive the current price from `currentTick`. Same defect class, but they position chart markers where a 0.01 % error is far below a pixel. Also untouched: the in-range badge's inclusive upper bound, which disagrees with the amounts math at exactly `currentTick === tickUpper`.

**Pre-existing and unrelated:** `pnpm lint` in `apps/midcurve-ui` fails to load its eslint config (circular structure in `plugins.react`). It reproduces on a clean tree without these changes, and CI does not run lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
